### PR TITLE
MINOR: Replace Scala style guide PDF link with scala-lang.org link

### DIFF
--- a/coding-guide.html
+++ b/coding-guide.html
@@ -19,7 +19,7 @@ These guidelines are meant to encourage consistency and best practices amongst p
 </ul>
 
 <h2>Scala</h2>
-We are following the style guide given <a href="http://docs.scala-lang.org/style/ ">here</a> (though not perfectly). Below are some specifics worth noting:
+We are following the style guide given <a href="http://docs.scala-lang.org/style/">here</a> (though not perfectly). Below are some specifics worth noting:
 <ul>
 <li>Scala is a very flexible language. Use restraint. Magic cryptic one-liners do not impress us, readability impresses us.</li>
 <li>Use <code>val</code>s when possible.</li>

--- a/coding-guide.html
+++ b/coding-guide.html
@@ -19,7 +19,7 @@ These guidelines are meant to encourage consistency and best practices amongst p
 </ul>
 
 <h2>Scala</h2>
-We are following the style guide given <a href="http://davetron5000.github.com/scala-style/ScalaStyleGuide.pdf ">here</a> (though not perfectly). Below are some specifics worth noting:
+We are following the style guide given <a href="http://docs.scala-lang.org/style/ ">here</a> (though not perfectly). Below are some specifics worth noting:
 <ul>
 <li>Scala is a very flexible language. Use restraint. Magic cryptic one-liners do not impress us, readability impresses us.</li>
 <li>Use <code>val</code>s when possible.</li>


### PR DESCRIPTION
The style guide PDF currently linked to is mostly empty with just "Moved to [scala-lang page]" links.
