### PR TITLE
Implementation: Clean-up invalid HTML

### DIFF
--- a/0100/implementation.html
+++ b/0100/implementation.html
@@ -146,7 +146,7 @@ The network layer is a fairly straight-forward NIO server, and will not be descr
 <p>
 Messages consist of a fixed-size header, a variable length opaque key byte array and a variable length opaque value byte array. The header contains the following fields:
 <ul>
-    <li> A CRC32 checksum to detect corruption or truncation. <li/>
+    <li> A CRC32 checksum to detect corruption or truncation. </li>
     <li> A format version. </li>
     <li> An attributes identifier </li>
     <li> A timestamp </li>


### PR DESCRIPTION
Small typo I found in `implementation.html`
