### PR TITLE
fix issue with rewrite rules blocking access to javadocs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,5 +4,6 @@ AddType text/html .html
 AddHandler server-parsed .html
 Redirect 301 /design.html /documentation#design
 
-RewriteRule ^/?(\d+)/documentation(\.html)? - [S=1]
+RewriteRule ^/?(\d+)/documentation(\.html)? - [S=2]
+RewriteRule ^/?(\d+)/javadoc - [S=1]
 RewriteRule ^/?(\d+)/([a-z]+)(\.html)? /$1/documentation#$2 [R=302,L,NE]

--- a/0100/api.html
+++ b/0100/api.html
@@ -30,7 +30,7 @@ Kafka exposes all its functionality over a language independent protocol which h
 The Producer API allows applications to send streams of data to topics in the Kafka cluster.
 <p>
 Examples showing how to use the producer are given in the
-<a href="http://kafka.apache.org/0100/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html" title="Kafka 0.10.0 Javadoc">javadocs</a>.
+<a href="/0100/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html" title="Kafka 0.10.0 Javadoc">javadocs</a>.
 <p>
 To use the producer, you can use the following maven dependency:
 
@@ -47,7 +47,7 @@ To use the producer, you can use the following maven dependency:
 The Consumer API allows applications to read streams of data from topics in the Kafka cluster.
 <p>
 Examples showing how to use the consumer are given in the
-<a href="http://kafka.apache.org/0100/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html" title="Kafka 0.9.0 Javadoc">javadocs</a>.
+<a href="/0100/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html" title="Kafka 0.10.0 Javadoc">javadocs</a>.
 <p>
 To use the consumer, you can use the following maven dependency:
 <pre>
@@ -63,7 +63,7 @@ To use the consumer, you can use the following maven dependency:
 The <a href="#streamsapi">Streams</a> API allows transforming streams of data from input topics to output topics.
 <p>
 Examples showing how to use this library are given in the
-<a href="http://kafka.apache.org/0100/javadoc/index.html?org/apache/kafka/streams/KafkaStreams.html" title="Kafka 0.10.0 Javadoc">javadocs</a>
+<a href="/0100/javadoc/index.html?org/apache/kafka/streams/KafkaStreams.html" title="Kafka 0.10.0 Javadoc">javadocs</a>
 <p>
 Additional documentation on using the Streams API is available <a href="/documentation.html#streams">here</a>.
 <p>
@@ -83,7 +83,7 @@ The Connect API allows implementing connectors that continually pull from some s
 <p>
 Many users of Connect won't need to use this API directly, though, they can use pre-built connectors without needing to write any code. Additional information on using Connect is available <a href="/documentation.html#connect">here</a>.
 <p>
-Those who want to implement custom connectors can see the <a href="http://kafka.apache.org/0100/javadoc/index.html?org/apache/kafka/connect">javadoc</a>.
+Those who want to implement custom connectors can see the <a href="/0100/javadoc/index.html?org/apache/kafka/connect" title="Kafka 0.10.0 Javadoc">javadoc</a>.
 <p>
 
 <h3><a id="legacyapis" href="#streamsapi">Legacy APIs</a></h3>

--- a/0100/design.html
+++ b/0100/design.html
@@ -114,7 +114,7 @@ The client controls which partition it publishes messages to. This can be done a
 <p>
 Batching is one of the big drivers of efficiency, and to enable batching the Kafka producer will attempt to accumulate data in memory and to send out larger batches in a single request. The batching can be configured to accumulate no more than a fixed number of messages and to wait no longer than some fixed latency bound (say 64k or 10 ms). This allows the accumulation of more bytes to send, and few larger I/O operations on the servers. This buffering is configurable and gives a mechanism to trade off a small amount of additional latency for better throughput.
 <p>
-Details on <a href="#producerconfigs">configuration</a> and the <a href="http://kafka.apache.org/082/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html">api</a> for the producer can be found elsewhere in the documentation.
+Details on <a href="#producerconfigs">configuration</a> and the <a href="/0100/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html" title="Kafka 0.10.0 Javadoc">api</a> for the producer can be found elsewhere in the documentation.
 
 <h3><a id="theconsumer" href="#theconsumer">4.5 The Consumer</a></h3>
 


### PR DESCRIPTION
fixes issue where rewrite rules were sending you back to the main documentation page when requesting our javadocs.
