### PR TITLE
Add new meetup link on events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -42,6 +42,7 @@
 				<h5 style="margin-bottom:0;">Asia</h5>
 				<ul>
 					<li><a href="https://www.meetup.com/Beijing-Kafka-Meetup/" target="_blank">Beijing, China</a></li>
+					<li><a href="https://kafka-apache-jp.connpass.com/" target="_blank">Tokyo, Japan</a></li>
 				</ul>
 
 				<h5 style="margin-bottom:0; margin-top:4rem">Australia</h5>


### PR DESCRIPTION
Added Japan meetup link.
If the event page should be meetup.com, I will consider migration to meetup.com.