### PR TITLE
Fix bad kafka stream link on use cases page

### DIFF
--- a/0102/uses.html
+++ b/0102/uses.html
@@ -63,7 +63,7 @@ For example, a processing pipeline for recommending news articles might crawl ar
 further processing might normalize or deduplicate this content and published the cleansed article content to a new topic;
 a final processing stage might attempt to recommend this content to users.
 Such processing pipelines create graphs of real-time data flows based on the individual topics.
-Starting in 0.10.0.0, a light-weight but powerful stream processing library called <a href="/{{version}}/documentation/streams">Kafka Streams</a>
+Starting in 0.10.0.0, a light-weight but powerful stream processing library called <a href="/documentation/streams">Kafka Streams</a>
 is available in Apache Kafka to perform such data processing as described above.
 Apart from Kafka Streams, alternative open source stream processing tools include <a href="https://storm.apache.org/">Apache Storm</a> and
 <a href="http://samza.apache.org/">Apache Samza</a>.


### PR DESCRIPTION
When clicking "Kafka Streams" link on [Use Cases](https://kafka.apache.org/uses#uses_streamprocessing) page, redirected to https://kafka.apache.org/%7B%7Bversion%7D%7D/documentation/streams) and got:

    404 Not Found: The requested URL /{{version}}/documentation/streams was not found on this server.