### PR TITLE
Add missing semicolon in JAAS config

### DIFF
--- a/0102/security.html
+++ b/0102/security.html
@@ -661,7 +661,10 @@
     </ol>
 
     <h3><a id="security_authz" href="#security_authz">7.4 Authorization and ACLs</a></h3>
-    Kafka ships with a pluggable Authorizer and an out-of-box authorizer implementation that uses zookeeper to store all the acls. Kafka acls are defined in the general format of "Principal P is [Allowed/Denied] Operation O From Host H On Resource R". You can read more about the acl structure on KIP-11. In order to add, remove or list acls you can use the Kafka authorizer CLI. By default, if a Resource R has no associated acls, no one other than super users is allowed to access R. If you want to change that behavior, you can include the following in broker.properties.
+    Kafka ships with a pluggable Authorizer and an out-of-box authorizer implementation that uses zookeeper to store all the acls. 
+    This must be enabled by adding the following to the broker configuration:
+    <pre>authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer</pre>
+    Kafka acls are defined in the general format of "Principal P is [Allowed/Denied] Operation O From Host H On Resource R". You can read more about the acl structure on KIP-11. In order to add, remove or list acls you can use the Kafka authorizer CLI. By default, if a Resource R has no associated acls, no one other than super users is allowed to access R. If you want to change that behavior, you can include the following in broker.properties.
     <pre>allow.everyone.if.no.acl.found=true</pre>
     One can also add super users in broker.properties like the following (note that the delimiter is semicolon since SSL user names may contain comma).
     <pre>super.users=User:Bob;User:Alice</pre>

--- a/0102/security.html
+++ b/0102/security.html
@@ -559,7 +559,7 @@
     KafkaServer {
         org.apache.kafka.common.security.scram.ScramLoginModule required
         username="admin"
-        password="admin-secret"
+        password="admin-secret";
     };</pre>
                 The properties <tt>username</tt> and <tt>password</tt> in the <tt>KafkaServer</tt> section are used by
                 the broker to initiate connections to other brokers. In this example, <i>admin</i> is the user for


### PR DESCRIPTION
For future googlers ref, this solves the following error:
```
[2017-03-22 11:19:59,516] FATAL Fatal error during KafkaServerStartable startup. Prepare to shutdown (kafka.server.KafkaServerStartable)
org.apache.kafka.common.KafkaException: Exception while loading Zookeeper JAAS login context 'Client'
	at org.apache.kafka.common.security.JaasUtils.isZkSecurityEnabled(JaasUtils.java:154)
	at kafka.server.KafkaServer.initZk(KafkaServer.scala:310)
	at kafka.server.KafkaServer.startup(KafkaServer.scala:187)
	at kafka.server.KafkaServerStartable.startup(KafkaServerStartable.scala:39)
	at kafka.Kafka$.main(Kafka.scala:67)
	at kafka.Kafka.main(Kafka.scala)
Caused by: java.lang.SecurityException: java.io.IOException: Configuration Error:
	Line 5: expected [option key]
	at sun.security.provider.ConfigFile$Spi.<init>(ConfigFile.java:137)
	at sun.security.provider.ConfigFile.<init>(ConfigFile.java:102)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at javax.security.auth.login.Configuration$2.run(Configuration.java:255)
	at javax.security.auth.login.Configuration$2.run(Configuration.java:247)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.login.Configuration.getConfiguration(Configuration.java:246)
	at org.apache.kafka.common.security.JaasUtils.isZkSecurityEnabled(JaasUtils.java:151)
	... 5 more
Caused by: java.io.IOException: Configuration Error:
	Line 5: expected [option key]
	at sun.security.provider.ConfigFile$Spi.ioException(ConfigFile.java:666)
	at sun.security.provider.ConfigFile$Spi.match(ConfigFile.java:562)
	at sun.security.provider.ConfigFile$Spi.parseLoginEntry(ConfigFile.java:477)
	at sun.security.provider.ConfigFile$Spi.readConfig(ConfigFile.java:427)
	at sun.security.provider.ConfigFile$Spi.init(ConfigFile.java:329)
	at sun.security.provider.ConfigFile$Spi.init(ConfigFile.java:271)
	at sun.security.provider.ConfigFile$Spi.<init>(ConfigFile.java:135)
	... 16 more
[2017-03-22 11:19:59,518] INFO shutting down (kafka.server.KafkaServer)
```