### PR TITLE
Provide link to ZooKeeper within Quickstart

### DIFF
--- a/0102/quickstart.html
+++ b/0102/quickstart.html
@@ -35,7 +35,7 @@ Since Kafka console scripts are different for Unix-based and Windows platforms, 
 <h4><a id="quickstart_startserver" href="#quickstart_startserver">Step 2: Start the server</a></h4>
 
 <p>
-Kafka uses ZooKeeper so you need to first start a ZooKeeper server if you don't already have one. You can use the convenience script packaged with kafka to get a quick-and-dirty single-node ZooKeeper instance.
+Kafka uses <a href="https://zookeeper.apache.org/">ZooKeeper</a> so you need to first start a ZooKeeper server if you don't already have one. You can use the convenience script packaged with kafka to get a quick-and-dirty single-node ZooKeeper instance.
 </p>
 
 <pre>


### PR DESCRIPTION
This adds a hyperlink to the ZooKeeper project within the quickstart tutorial for users who may be unfamiliar with ZooKeeper or who simply want a more-direct path to downloading the software.