### PR TITLE
Removed hyphens:auto. 

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -177,12 +177,6 @@ ol.toc > li {
 	word-break: break-all;
 	/* Instead use this non-standard one: */
 	word-break: break-word;
-
-	/* Adds a hyphen where the word breaks, if supported (No Blink) */
-	-ms-hyphens: auto;
-	-moz-hyphens: auto;
-	-webkit-hyphens: auto;
-	hyphens: auto;
 }
 
 /* helper classes */


### PR DESCRIPTION
This rule creates misleading setting names on the configuration tables.
For example with hyphens: auto we get
```
advertised.lis-teners
```
when the setting is really:

```
advertised.listeners
```