### PR TITLE
Do not use hyphens in wrapping property names in tables

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -184,6 +184,12 @@ ol.toc > li {
 	-webkit-hyphens: auto;
 	hyphens: auto;
 }
+.data-table tr td:first-of-type {
+	-ms-hyphens: none;
+	-moz-hyphens: none;
+	-webkit-hyphens: none;
+	hyphens: none;
+}
 
 /* helper classes */
 .centered {


### PR DESCRIPTION
Hyphenating long property names that wrap inside of tables cells is causing confusion. CSS to prevent this from happening. (mentioned in KAFKA-5460)