### PR TITLE
Rephrase mailing lists section to avoid incorrect subscribe emails

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -17,10 +17,10 @@
 				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto: dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-dev">here</a>.
 			</li>
 			<li>
-				<b>JIRA mailing list</b>: A list to track Kafka&reg; <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto: jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: jira@kafka.apache.org">jira@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-jira">here</a>.
+				<b>JIRA mailing list</b>: A list to track Kafka&reg; <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto: jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-jira">here</a>.
 			</li>
 			<li>
-				<b>Commit mailing list</b>: A list to track Kafka&reg; commits. To subscribe, send an email to <a href="mailto: commits-subscribe@kafka.apache.org">commits-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: commits@kafka.apache.org">commits@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-commits">here</a>.
+				<b>Commit mailing list</b>: A list to track Kafka&reg; commits. To subscribe, send an email to <a href="mailto: commits-subscribe@kafka.apache.org">commits-subscribe@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-commits">here</a>.
 			</li>
 		</ul>
 

--- a/contact.html
+++ b/contact.html
@@ -11,16 +11,16 @@
 		</p>
 		<ul>
 			<li>
-				<b>User maling list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto: users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, you can send your emails to <a href="mailto: users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-users">here</a>.
+				<b>User maling list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto: users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-users">here</a>.
 			</li>
 			<li>
-				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto: dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, you can send your emails to <a href="mailto: dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives available <a href="http://mail-archives.apache.org/mod_mbox/kafka-dev">here</a>.
+				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto: dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-dev">here</a>.
 			</li>
 			<li>
-				<b>JIRA mailing list</b>: A list to track Kafka&reg; <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto: jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Once subscribed, you can send your emails to <a href="mailto: jira@kafka.apache.org">jira@kafka.apache.org</a>. Archives available <a href="http://mail-archives.apache.org/mod_mbox/kafka-jira">here</a>.
+				<b>JIRA mailing list</b>: A list to track Kafka&reg; <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto: jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: jira@kafka.apache.org">jira@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-jira">here</a>.
 			</li>
 			<li>
-				<b>Commit mailing list</b>: A list to track Kafka&reg; commits. To subscribe, send an email to <a href="mailto: commits-subscribe@kafka.apache.org">commits-subscribe@kafka.apache.org</a>. Once subscribed, you can send your emails to <a href="mailto: commits@kafka.apache.org">commits@kafka.apache.org</a>. Archives available <a href="http://mail-archives.apache.org/mod_mbox/kafka-commits">here</a>.
+				<b>Commit mailing list</b>: A list to track Kafka&reg; commits. To subscribe, send an email to <a href="mailto: commits-subscribe@kafka.apache.org">commits-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: commits@kafka.apache.org">commits@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-commits">here</a>.
 			</li>
 		</ul>
 

--- a/contact.html
+++ b/contact.html
@@ -11,16 +11,16 @@
 		</p>
 		<ul>
 			<li>
-			  <a href="mailto: users@kafka.apache.org">users@kafka.apache.org</a>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto: users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-users">here</a>.
+				<b>User maling list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto: users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, you can send your emails to <a href="mailto: users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-users">here</a>.
 			</li>
 			<li>
-			  <a href="mailto: dev@kafka.apache.org">dev@kafka.apache.org</a>: A list for discussion on Kafka development. To subscribe, send an email to <a href="mailto: dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Archives available <a href="http://mail-archives.apache.org/mod_mbox/kafka-dev">here</a>.
+				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto: dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, you can send your emails to <a href="mailto: dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives available <a href="http://mail-archives.apache.org/mod_mbox/kafka-dev">here</a>.
 			</li>
 			<li>
-			  <a href="mailto: jira@kafka.apache.org">jira@kafka.apache.org</a>: A list to track Kafka <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto: jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Archives available <a href="http://mail-archives.apache.org/mod_mbox/kafka-jira">here</a>.
+				<b>JIRA mailing list</b>: A list to track Kafka&reg; <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto: jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Once subscribed, you can send your emails to <a href="mailto: jira@kafka.apache.org">jira@kafka.apache.org</a>. Archives available <a href="http://mail-archives.apache.org/mod_mbox/kafka-jira">here</a>.
 			</li>
 			<li>
-				<a href="mailto: commits@kafka.apache.org">commits@kafka.apache.org</a>: A list to track Kafka commits. To subscribe, send an email to <a href="mailto: commits-subscribe@kafka.apache.org">commits-subscribe@kafka.apache.org</a>. Archives available <a href="http://mail-archives.apache.org/mod_mbox/kafka-commits">here</a>.
+				<b>Commit mailing list</b>: A list to track Kafka&reg; commits. To subscribe, send an email to <a href="mailto: commits-subscribe@kafka.apache.org">commits-subscribe@kafka.apache.org</a>. Once subscribed, you can send your emails to <a href="mailto: commits@kafka.apache.org">commits@kafka.apache.org</a>. Archives available <a href="http://mail-archives.apache.org/mod_mbox/kafka-commits">here</a>.
 			</li>
 		</ul>
 
@@ -29,7 +29,7 @@
 		</p>
 
 		<p>
-		To unsubscribe from any of these you just change the word "subscribe" in the above to "unsubscribe".
+		To unsubscribe from any of these you just change the word "subscribe" to "unsubscribe" in the email adresses above.
 		</p>
 
 		<p>

--- a/contact.html
+++ b/contact.html
@@ -11,7 +11,7 @@
 		</p>
 		<ul>
 			<li>
-				<b>User maling list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto: users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-users">here</a>.
+				<b>User mailing list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto: users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-users">here</a>.
 			</li>
 			<li>
 				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto: dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-dev">here</a>.


### PR DESCRIPTION
The user@ and dev@ mailing lists seem to receive lot of emails from users who are not subscribed but are trying to subscribe. I wonder it is has something to do with the UX of the website and if the change in this PR can help to make it more clear to the users that they subscribe on a different email.