### PR TITLE
MINOR: Fix typo in checkstyle command

### DIFF
--- a/coding-guide.html
+++ b/coding-guide.html
@@ -139,7 +139,7 @@
 					<li>If reformatting is neccessary, do a minor PR (either upfront or as follow up).</li>
 				</ul>
 			</li>
-			<li>Run <code>./gradlew clean chechstyleMain checkstyleTest</code> before opening/updating a PR.</li>
+			<li>Run <code>./gradlew clean checkstyleMain checkstyleTest</code> before opening/updating a PR.</li>
 			<li>Help reviewing!
                             No need to be shy; if you can contribute code, you know enough to comment on the work of others.</li>
 		</ul>


### PR DESCRIPTION
Fix a typo in the [Coding Guidelines](http://kafka.apache.org/coding-guide.html) for Kafka Streams checkstyle commands