### PR TITLE
KAFKA-6312: Update website documentation for --reset-offsets option, …

### DIFF
--- a/10/ops.html
+++ b/10/ops.html
@@ -183,6 +183,15 @@
   test-foo                       0          1               3               2          consumer-1-a5d61779-4d04-4c50-a6d6-fb35d942642d   /127.0.0.1                     consumer-1
   </pre>
 
+  To reset offsets of a consumer group to latest offset, first make sure the instances are inactive, then:
+
+  <pre class="brush: bash;">
+  &gt; bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 --reset-offsets --group consumergroup1 --topic topic1 --to-latest
+
+  TOPIC                          PARTITION  NEW-OFFSET
+  topic1                         0          0
+  </pre>
+
   If you are using the old high-level consumer and storing the group metadata in ZooKeeper (i.e. <code>offsets.storage=zookeeper</code>), pass
   <code>--zookeeper</code> instead of <code>bootstrap-server</code>:
 


### PR DESCRIPTION
…for Kafka consumer groups, introduced in KIP-122

KIP-122 added the ability for kafka-consumer-groups.sh to reset/change consumer offsets, at a fine grained level.

There is documentation on it in the kafka-consumer-groups.sh usage text.

There was no such documentation on the kafka.apache.org website. This change updates the documentation on the website, so that users can read about the functionality without having the tools installed.