### PR TITLE
[KAFKA-6861] Missing parentheses in Kafka Streams documentation

### DIFF
--- a/10/tutorial.html
+++ b/10/tutorial.html
@@ -530,7 +530,7 @@
               .groupBy((key, value) -> value)
               .count(Materialized.&lt;String, Long, KeyValueStore&lt;Bytes, byte[]&gt;&gt;as("counts-store"))
               .toStream()
-              .to("streams-wordcount-output", Produced.with(Serdes.String(), Serdes.Long());
+              .to("streams-wordcount-output", Produced.with(Serdes.String(), Serdes.Long()));
     </pre>
 
     <p>


### PR DESCRIPTION
Adding missing parentheses in the code snippet for Streams Word Count tutorial