### PR TITLE
Fixed dead link to BookKeeper in Usecases

### DIFF
--- a/11/uses.html
+++ b/11/uses.html
@@ -78,4 +78,4 @@ time-ordered sequence of records. Kafka's support for very large stored log data
 Kafka can serve as a kind of external commit-log for a distributed system. The log helps replicate data between nodes and acts as a re-syncing
 mechanism for failed nodes to restore their data.
 The <a href="/documentation.html#compaction">log compaction</a> feature in Kafka helps support this usage.
-In this usage Kafka is similar to <a href="http://zookeeper.apache.org/bookkeeper/">Apache BookKeeper</a> project.
+In this usage Kafka is similar to <a href="https://bookkeeper.apache.org/">Apache BookKeeper</a> project.


### PR DESCRIPTION
The link forwarded to http://zookeeper.apache.org/bookkeeper what isn't available. BookKeeper is currently available at https://bookkeeper.apache.org.