### PR TITLE
MINOR: Fix link in num.standby.replicas section

### DIFF
--- a/11/streams/developer-guide/config-streams.html
+++ b/11/streams/developer-guide/config-streams.html
@@ -373,7 +373,7 @@
               Standby replicas are used to minimize the latency of task failover.  A task that was previously running on a failed instance is
               preferred to restart on an instance that has standby replicas so that the local state store restoration process from its
               changelog can be minimized.  Details about how Kafka Streams makes use of the standby replicas to minimize the cost of
-              resuming tasks on failover can be found in the <a class="reference internal" href="running-app.html#state_restoration_during_workload_rebalance"><span class="std std-ref">State restoration during workload rebalance</span></a> section.</div></blockquote>
+              resuming tasks on failover can be found in the <a class="reference internal" href="../architecture.html#streams_architecture_state"><span class="std std-ref">State</span></a> section.</div></blockquote>
         </div>
         <div class="section" id="num-stream-threads">
           <h4><a class="toc-backref" href="#id11">num.stream.threads</a><a class="headerlink" href="#num-stream-threads" title="Permalink to this headline"></a></h4>

--- a/11/streams/developer-guide/config-streams.html
+++ b/11/streams/developer-guide/config-streams.html
@@ -373,7 +373,7 @@
               Standby replicas are used to minimize the latency of task failover.  A task that was previously running on a failed instance is
               preferred to restart on an instance that has standby replicas so that the local state store restoration process from its
               changelog can be minimized.  Details about how Kafka Streams makes use of the standby replicas to minimize the cost of
-              resuming tasks on failover can be found in the <a class="reference internal" href="../architecture.html#streams-architecture-state"><span class="std std-ref">State</span></a> section.</div></blockquote>
+              resuming tasks on failover can be found in the <a class="reference internal" href="running-app.html#state_restoration_during_workload_rebalance"><span class="std std-ref">State restoration during workload rebalance</span></a> section.</div></blockquote>
         </div>
         <div class="section" id="num-stream-threads">
           <h4><a class="toc-backref" href="#id11">num.stream.threads</a><a class="headerlink" href="#num-stream-threads" title="Permalink to this headline"></a></h4>


### PR DESCRIPTION
Replace broken link with link to [State restoration during workload rebalance](https://docs.confluent.io/current/streams/developer-guide/running-app.html#state-restoration-during-workload-rebalance).