### PR TITLE
Make links recognizable

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -81,11 +81,7 @@ h3.bullet::after {
     width: 5rem;
 }
 a {
-    color: #0B6D88;
-    text-decoration: none;
-}
-a:hover {
-    color: #0C637B;
+    color: #0968DE;
 }
 img {
     max-width: 100%;
@@ -352,6 +348,9 @@ nav {
     float: left;
     text-transform: uppercase;
     width: 16rem;
+}
+nav a {
+    text-decoration: none;
 }
 .nav__item,
 .nav__item__with__subs {


### PR DESCRIPTION
Links are nearly impossible impossible to discern from regular black text (at least on my monitor).

I don't really care about how specifically they're made more visible, but issues are disabled on the repo so I had to submit something!

I added back standard link underlines, but removed them in the nav where they're unneccessary.
I chose a random decent-looking blue color for links, which passes WCAG AA: https://webaim.org/resources/contrastchecker/?fcolor=0968DE&bcolor=FFFFFF

Before:
![screen shot 2018-08-31 at 7 37 49 pm](https://user-images.githubusercontent.com/1588273/44940530-b977cc80-ad5d-11e8-8d17-82c5a8b96c75.png)

After:
![screen shot 2018-08-31 at 8 36 39 pm](https://user-images.githubusercontent.com/1588273/44940533-bed51700-ad5d-11e8-8225-36c4177721e2.png)
