### PR TITLE
fix for broken zero-copy URL

### DIFF
--- a/0100/design.html
+++ b/0100/design.html
@@ -92,7 +92,7 @@ We expect a common use case to be multiple consumers on a topic. Using the zero-
 <p>
 This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
 <p>
-For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
 <h4><a id="design_compression" href="#design_compression">End-to-end Batch Compression</a></h4>
 <p>

--- a/0101/design.html
+++ b/0101/design.html
@@ -125,7 +125,7 @@
     <p>
     This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
     <p>
-    For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+    For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
     <h4><a id="design_compression" href="#design_compression">End-to-end Batch Compression</a></h4>
     <p>

--- a/0102/design.html
+++ b/0102/design.html
@@ -125,7 +125,7 @@
     <p>
     This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
     <p>
-    For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+    For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
     <h4><a id="design_compression" href="#design_compression">End-to-end Batch Compression</a></h4>
     <p>

--- a/0110/design.html
+++ b/0110/design.html
@@ -125,7 +125,7 @@
     <p>
     This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
     <p>
-    For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+    For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
     <h4><a id="design_compression" href="#design_compression">End-to-end Batch Compression</a></h4>
     <p>

--- a/08/design.html
+++ b/08/design.html
@@ -75,7 +75,7 @@ We expect a common use case to be multiple consumers on a topic. Using the zero-
 <p>
 This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
 <p>
-For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
 <h4>End-to-end Batch Compression</h4>
 <p>

--- a/081/design.html
+++ b/081/design.html
@@ -75,7 +75,7 @@ We expect a common use case to be multiple consumers on a topic. Using the zero-
 <p>
 This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
 <p>
-For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
 <h4>End-to-end Batch Compression</h4>
 <p>

--- a/082/design.html
+++ b/082/design.html
@@ -75,7 +75,7 @@ We expect a common use case to be multiple consumers on a topic. Using the zero-
 <p>
 This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
 <p>
-For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
 <h4>End-to-end Batch Compression</h4>
 <p>

--- a/090/design.html
+++ b/090/design.html
@@ -92,7 +92,7 @@ We expect a common use case to be multiple consumers on a topic. Using the zero-
 <p>
 This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
 <p>
-For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
 <h4><a id="design_compression" href="#design_compression">End-to-end Batch Compression</a></h4>
 <p>

--- a/10/design.html
+++ b/10/design.html
@@ -125,7 +125,7 @@
     <p>
     This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
     <p>
-    For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+    For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
     <h4><a id="design_compression" href="#design_compression">End-to-end Batch Compression</a></h4>
     <p>

--- a/11/design.html
+++ b/11/design.html
@@ -125,7 +125,7 @@
     <p>
     This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
     <p>
-    For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+    For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
     <h4><a id="design_compression" href="#design_compression">End-to-end Batch Compression</a></h4>
     <p>

--- a/20/design.html
+++ b/20/design.html
@@ -125,7 +125,7 @@
     <p>
     This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
     <p>
-    For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+    For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
     <h4><a id="design_compression" href="#design_compression">End-to-end Batch Compression</a></h4>
     <p>

--- a/21/design.html
+++ b/21/design.html
@@ -125,7 +125,7 @@
     <p>
     This combination of pagecache and sendfile means that on a Kafka cluster where the consumers are mostly caught up you will see no read activity on the disks whatsoever as they will be serving data entirely from cache.
     <p>
-    For more background on the sendfile and zero-copy support in Java, see this <a href="http://www.ibm.com/developerworks/linux/library/j-zerocopy">article</a>.
+    For more background on the sendfile and zero-copy support in Java, see this <a href="https://developer.ibm.com/articles/j-zerocopy/">article</a>.
 
     <h4><a id="design_compression" href="#design_compression">End-to-end Batch Compression</a></h4>
     <p>


### PR DESCRIPTION
The old developerWorks URL has been moved to a `developer.ibm.com` domain.