### PR TITLE
MINOR: Use lists.apache.org for mailing list archives

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -11,13 +11,13 @@
 		</p>
 		<ul>
 			<li>
-				<b>User mailing list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto: users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-users">here</a>.
+				<b>User mailing list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto: users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?users@kafka.apache.org">here</a>.
 			</li>
 			<li>
-				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto: dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-dev">here</a>.
+				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto: dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto: dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?dev@kafka.apache.org">here</a>.
 			</li>
 			<li>
-				<b>JIRA mailing list</b>: A list to track Kafka&reg; <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto: jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-jira">here</a>.
+				<b>JIRA mailing list</b>: A list to track Kafka&reg; <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto: jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?jira@kafka.apache.org">here</a>.
 			</li>
 			<li>
 				<b>Commit mailing list</b>: A list to track Kafka&reg; commits. To subscribe, send an email to <a href="mailto: commits-subscribe@kafka.apache.org">commits-subscribe@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-commits">here</a>.


### PR DESCRIPTION
lists.apache.org has a much better UI for browsing than mail-archives.apache.org