### PR TITLE
Minor: Fix name of created directory in streams tutorial

### DIFF
--- a/10/streams/tutorial.html
+++ b/10/streams/tutorial.html
@@ -60,7 +60,7 @@
 
     <pre class="brush: bash;">
         &gt; tree streams.examples
-        streams-quickstart
+        streams.examples
         |-- pom.xml
         |-- src
             |-- main
@@ -80,7 +80,7 @@
     </p>
 
     <pre class="brush: bash;">
-        &gt; cd streams-quickstart
+        &gt; cd streams.examples
         &gt; rm src/main/java/myapps/*.java
     </pre>
 

--- a/11/streams/tutorial.html
+++ b/11/streams/tutorial.html
@@ -60,7 +60,7 @@
 
     <pre class="brush: bash;">
         &gt; tree streams.examples
-        streams-quickstart
+        streams.examples
         |-- pom.xml
         |-- src
             |-- main
@@ -80,7 +80,7 @@
     </p>
 
     <pre class="brush: bash;">
-        &gt; cd streams-quickstart
+        &gt; cd streams.examples
         &gt; rm src/main/java/myapps/*.java
     </pre>
 

--- a/20/streams/tutorial.html
+++ b/20/streams/tutorial.html
@@ -60,7 +60,7 @@
 
     <pre class="brush: bash;">
         &gt; tree streams.examples
-        streams-quickstart
+        streams.examples
         |-- pom.xml
         |-- src
             |-- main
@@ -80,7 +80,7 @@
     </p>
 
     <pre class="brush: bash;">
-        &gt; cd streams-quickstart
+        &gt; cd streams.examples
         &gt; rm src/main/java/myapps/*.java
     </pre>
 

--- a/21/streams/tutorial.html
+++ b/21/streams/tutorial.html
@@ -60,7 +60,7 @@
 
     <pre class="brush: bash;">
         &gt; tree streams.examples
-        streams-quickstart
+        streams.examples
         |-- pom.xml
         |-- src
             |-- main
@@ -80,7 +80,7 @@
     </p>
 
     <pre class="brush: bash;">
-        &gt; cd streams-quickstart
+        &gt; cd streams.examples
         &gt; rm src/main/java/myapps/*.java
     </pre>
 


### PR DESCRIPTION
In the streams tutorial, the code examples mixes `streams-quickstart` and `streams.examples`. I believe that they should all be `streams.examples`. 

Affected version: 2.1.*, 2.0.*, 1.1.*, 1.0.* 

Tested on mac os x v10.14.2, Java v1.8, Maven v3.5.4