### PR TITLE
MINOR: add config docs to manage-topics

### DIFF
--- a/10/streams/developer-guide/manage-topics.html
+++ b/10/streams/developer-guide/manage-topics.html
@@ -94,7 +94,9 @@
       <p>
         <pre class="brush: java;">
           Properties config = new Properties();
+          config.put(StreamsConfig.APPLICATION_ID_CONFIG, "myapp");
           config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
+          KafkaStreams streams = new KafkaStreams(topology, config);
         </pre>
       </p>
       <div class="admonition note">

--- a/10/streams/developer-guide/manage-topics.html
+++ b/10/streams/developer-guide/manage-topics.html
@@ -67,10 +67,36 @@
     </div>
     <div class="section" id="internal-topics">
       <span id="streams-developer-guide-topics-internal"></span><h2>Internal topics<a class="headerlink" href="#internal-topics" title="Permalink to this headline"></a></h2>
-      <p>Internal topics are used internally by the Kafka Streams application while executing, for example the
-        changelog topics for state stores. These topics are created by the application and are only used by that stream application.</p>
-      <p>If security is enabled on the Kafka brokers, you must grant the underlying clients admin permissions so that they can
-        create internal topics set. For more information, see <a class="reference internal" href="security.html#streams-developer-guide-security"><span class="std std-ref">Streams Security</span></a>.</p>
+      <p>
+        Internal topics are used internally by the Kafka Streams application
+        while executing, for example the changelog topics for state stores.
+        These topics are created by the application and are only used by that
+        stream application.
+      </p>
+      <p>
+        If security is enabled on the Kafka brokers, you must grant the
+        underlying clients admin permissions so that they can
+        create internal topics set. For more information, see
+        <a class="reference internal" href="security.html#streams-developer-guide-security">
+          <span class="std std-ref">Streams Security</span>
+        </a>.
+      </p>
+      <p>
+        Kafka Streams automatically creates internal repartitioning and changelog
+        topics, and does <em>not</em> use broker auto-topic creation.
+        Therefore, internal topics take on the default broker configurations for
+        new topics.
+        You can override the default configs used when creating these topics by
+        adding any configs from <code>TopicConfig</code> to your
+        <code>StreamsConfig</code> with the prefix
+        <code>StreamsConfig.topicPrefix()</code>.
+      </p>
+      <p>
+        <pre class="brush: java;">
+          Properties config = new Properties();
+          config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
+        </pre>
+      </p>
       <div class="admonition note">
         <p class="first admonition-title">Note</p>
         <p class="last">The internal topics follow the naming convention <code class="docutils literal"><span class="pre">&lt;application.id&gt;-&lt;operatorName&gt;-&lt;suffix&gt;</span></code>, but this convention

--- a/11/streams/developer-guide/manage-topics.html
+++ b/11/streams/developer-guide/manage-topics.html
@@ -94,7 +94,9 @@
       <p>
         <pre class="brush: java;">
           Properties config = new Properties();
+          config.put(StreamsConfig.APPLICATION_ID_CONFIG, "myapp");
           config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
+          KafkaStreams streams = new KafkaStreams(topology, config);
         </pre>
       </p>
       <div class="admonition note">

--- a/11/streams/developer-guide/manage-topics.html
+++ b/11/streams/developer-guide/manage-topics.html
@@ -67,10 +67,36 @@
     </div>
     <div class="section" id="internal-topics">
       <span id="streams-developer-guide-topics-internal"></span><h2>Internal topics<a class="headerlink" href="#internal-topics" title="Permalink to this headline"></a></h2>
-      <p>Internal topics are used internally by the Kafka Streams application while executing, for example the
-        changelog topics for state stores. These topics are created by the application and are only used by that stream application.</p>
-      <p>If security is enabled on the Kafka brokers, you must grant the underlying clients admin permissions so that they can
-        create internal topics set. For more information, see <a class="reference internal" href="security.html#streams-developer-guide-security"><span class="std std-ref">Streams Security</span></a>.</p>
+      <p>
+        Internal topics are used internally by the Kafka Streams application
+        while executing, for example the changelog topics for state stores.
+        These topics are created by the application and are only used by that
+        stream application.
+      </p>
+      <p>
+        If security is enabled on the Kafka brokers, you must grant the
+        underlying clients admin permissions so that they can
+        create internal topics set. For more information, see
+        <a class="reference internal" href="security.html#streams-developer-guide-security">
+          <span class="std std-ref">Streams Security</span>
+        </a>.
+      </p>
+      <p>
+        Kafka Streams automatically creates internal repartitioning and changelog
+        topics, and does <em>not</em> use broker auto-topic creation.
+        Therefore, internal topics take on the default broker configurations for
+        new topics.
+        You can override the default configs used when creating these topics by
+        adding any configs from <code>TopicConfig</code> to your
+        <code>StreamsConfig</code> with the prefix
+        <code>StreamsConfig.topicPrefix()</code>.
+      </p>
+      <p>
+        <pre class="brush: java;">
+          Properties config = new Properties();
+          config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
+        </pre>
+      </p>
       <div class="admonition note">
         <p class="first admonition-title">Note</p>
         <p class="last">The internal topics follow the naming convention <code class="docutils literal"><span class="pre">&lt;application.id&gt;-&lt;operatorName&gt;-&lt;suffix&gt;</span></code>, but this convention

--- a/20/streams/developer-guide/manage-topics.html
+++ b/20/streams/developer-guide/manage-topics.html
@@ -94,7 +94,9 @@
       <p>
         <pre class="brush: java;">
           Properties config = new Properties();
+          config.put(StreamsConfig.APPLICATION_ID_CONFIG, "myapp");
           config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
+          KafkaStreams streams = new KafkaStreams(topology, config);
         </pre>
       </p>
       <div class="admonition note">

--- a/20/streams/developer-guide/manage-topics.html
+++ b/20/streams/developer-guide/manage-topics.html
@@ -67,10 +67,36 @@
     </div>
     <div class="section" id="internal-topics">
       <span id="streams-developer-guide-topics-internal"></span><h2>Internal topics<a class="headerlink" href="#internal-topics" title="Permalink to this headline"></a></h2>
-      <p>Internal topics are used internally by the Kafka Streams application while executing, for example the
-        changelog topics for state stores. These topics are created by the application and are only used by that stream application.</p>
-      <p>If security is enabled on the Kafka brokers, you must grant the underlying clients admin permissions so that they can
-        create internal topics set. For more information, see <a class="reference internal" href="security.html#streams-developer-guide-security"><span class="std std-ref">Streams Security</span></a>.</p>
+      <p>
+        Internal topics are used internally by the Kafka Streams application
+        while executing, for example the changelog topics for state stores.
+        These topics are created by the application and are only used by that
+        stream application.
+      </p>
+      <p>
+        If security is enabled on the Kafka brokers, you must grant the
+        underlying clients admin permissions so that they can
+        create internal topics set. For more information, see
+        <a class="reference internal" href="security.html#streams-developer-guide-security">
+          <span class="std std-ref">Streams Security</span>
+        </a>.
+      </p>
+      <p>
+        Kafka Streams automatically creates internal repartitioning and changelog
+        topics, and does <em>not</em> use broker auto-topic creation.
+        Therefore, internal topics take on the default broker configurations for
+        new topics.
+        You can override the default configs used when creating these topics by
+        adding any configs from <code>TopicConfig</code> to your
+        <code>StreamsConfig</code> with the prefix
+        <code>StreamsConfig.topicPrefix()</code>.
+      </p>
+      <p>
+        <pre class="brush: java;">
+          Properties config = new Properties();
+          config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
+        </pre>
+      </p>
       <div class="admonition note">
         <p class="first admonition-title">Note</p>
         <p class="last">The internal topics follow the naming convention <code class="docutils literal"><span class="pre">&lt;application.id&gt;-&lt;operatorName&gt;-&lt;suffix&gt;</span></code>, but this convention

--- a/21/streams/developer-guide/manage-topics.html
+++ b/21/streams/developer-guide/manage-topics.html
@@ -68,34 +68,34 @@
     <div class="section" id="internal-topics">
       <span id="streams-developer-guide-topics-internal"></span><h2>Internal topics<a class="headerlink" href="#internal-topics" title="Permalink to this headline"></a></h2>
       <p>
-	Internal topics are used internally by the Kafka Streams application
-	while executing, for example the changelog topics for state stores.
-	These topics are created by the application and are only used by that
-	stream application.
+        Internal topics are used internally by the Kafka Streams application
+        while executing, for example the changelog topics for state stores.
+        These topics are created by the application and are only used by that
+        stream application.
       </p>
       <p>
-	If security is enabled on the Kafka brokers, you must grant the
-	underlying clients admin permissions so that they can
-	create internal topics set. For more information, see
-	<a class="reference internal" href="security.html#streams-developer-guide-security">
-	  <span class="std std-ref">Streams Security</span>
-	</a>.
+        If security is enabled on the Kafka brokers, you must grant the
+        underlying clients admin permissions so that they can
+        create internal topics set. For more information, see
+        <a class="reference internal" href="security.html#streams-developer-guide-security">
+          <span class="std std-ref">Streams Security</span>
+        </a>.
       </p>
       <p>
-	Kafka Streams automatically creates internal repartitioning and changelog
-	topics, and does <em>not</em> use broker auto-topic creation.
-	Therefore, internal topics take on the default broker configurations for
-	new topics.
-	You can override the default configs used when creating these topics by
-	adding any configs from <code>TopicConfig</code> to your
-	<code>StreamsConfig</code> with the prefix
-	<code>StreamsConfig.topicPrefix()</code>.
+        Kafka Streams automatically creates internal repartitioning and changelog
+        topics, and does <em>not</em> use broker auto-topic creation.
+        Therefore, internal topics take on the default broker configurations for
+        new topics.
+        You can override the default configs used when creating these topics by
+        adding any configs from <code>TopicConfig</code> to your
+        <code>StreamsConfig</code> with the prefix
+        <code>StreamsConfig.topicPrefix()</code>.
       </p>
       <p>
-	<pre class="brush: java;">
-	  Properties config = new Properties();
-	  config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
-	</pre>
+        <pre class="brush: java;">
+          Properties config = new Properties();
+          config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
+        </pre>
       </p>
       <div class="admonition note">
         <p class="first admonition-title">Note</p>

--- a/21/streams/developer-guide/manage-topics.html
+++ b/21/streams/developer-guide/manage-topics.html
@@ -94,7 +94,9 @@
       <p>
         <pre class="brush: java;">
           Properties config = new Properties();
+          config.put(StreamsConfig.APPLICATION_ID_CONFIG, "myapp");
           config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
+          KafkaStreams streams = new KafkaStreams(topology, config);
         </pre>
       </p>
       <div class="admonition note">

--- a/21/streams/developer-guide/manage-topics.html
+++ b/21/streams/developer-guide/manage-topics.html
@@ -67,10 +67,36 @@
     </div>
     <div class="section" id="internal-topics">
       <span id="streams-developer-guide-topics-internal"></span><h2>Internal topics<a class="headerlink" href="#internal-topics" title="Permalink to this headline"></a></h2>
-      <p>Internal topics are used internally by the Kafka Streams application while executing, for example the
-        changelog topics for state stores. These topics are created by the application and are only used by that stream application.</p>
-      <p>If security is enabled on the Kafka brokers, you must grant the underlying clients admin permissions so that they can
-        create internal topics set. For more information, see <a class="reference internal" href="security.html#streams-developer-guide-security"><span class="std std-ref">Streams Security</span></a>.</p>
+      <p>
+	Internal topics are used internally by the Kafka Streams application
+	while executing, for example the changelog topics for state stores.
+	These topics are created by the application and are only used by that
+	stream application.
+      </p>
+      <p>
+	If security is enabled on the Kafka brokers, you must grant the
+	underlying clients admin permissions so that they can
+	create internal topics set. For more information, see
+	<a class="reference internal" href="security.html#streams-developer-guide-security">
+	  <span class="std std-ref">Streams Security</span>
+	</a>.
+      </p>
+      <p>
+	Kafka Streams automatically creates internal repartitioning and changelog
+	topics, and does <em>not</em> use broker auto-topic creation.
+	Therefore, internal topics take on the default broker configurations for
+	new topics.
+	You can override the default configs used when creating these topics by
+	adding any configs from <code>TopicConfig</code> to your
+	<code>StreamsConfig</code> with the prefix
+	<code>StreamsConfig.topicPrefix()</code>.
+      </p>
+      <p>
+	<pre class="brush: java;">
+	  Properties config = new Properties();
+	  config.put(StreamsConfig.topicPrefix(TopicConfig.SEGMENT_MS_CONFIG), 100);
+	</pre>
+      </p>
       <div class="admonition note">
         <p class="first admonition-title">Note</p>
         <p class="last">The internal topics follow the naming convention <code class="docutils literal"><span class="pre">&lt;application.id&gt;-&lt;operatorName&gt;-&lt;suffix&gt;</span></code>, but this convention


### PR DESCRIPTION
The config documentation from https://github.com/apache/kafka/pull/3459/files#diff-8dfad184a2604987442db10d8bebf8bc got lost at some point. This PR adds it back.