### PR TITLE
Update download links

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -87,16 +87,16 @@
                 Released Nov 20, 2018
             </li>
             <li>
-                <a href="https://www.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html">Release Notes</a>
+                <a href="https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html">Release Notes</a>
             </li>
             <li>
-                Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.1.0/kafka-2.1.0-src.tgz">kafka-2.1.0-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz.sha512">sha512</a>)
+                Source download: <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz">kafka-2.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz.sha512">sha512</a>)
             </li>
             <li>
                 Binary downloads:
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.1.0/kafka_2.11-2.1.0.tgz">kafka_2.11-2.1.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.1.0/kafka_2.12-2.1.0.tgz">kafka_2.12-2.1.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz.sha512">sha512</a>)</li>
+                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz">kafka_2.11-2.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz.sha512">sha512</a>)</li>
+                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz">kafka_2.12-2.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz.sha512">sha512</a>)</li>
                 </ul>
                 We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
             </li>
@@ -118,7 +118,7 @@
           <li>DNS handling improvements (KIP-235, KIP-302)</li>
         </ul>
         <p>
-            For more information, please read the detailed <a href="https://www.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html">Release Notes</a>.
+            For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html">Release Notes</a>.
         </p>
 
     <span id="2.0.1"></span>
@@ -131,13 +131,13 @@
                 <a href="https://www.apache.org/dist/kafka/2.0.1/RELEASE_NOTES.html">Release Notes</a>
             </li>
             <li>
-                Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.0.1/kafka-2.0.1-src.tgz">kafka-2.0.1-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz.sha512">sha512</a>)
+                Source download: <a href="https://www.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz">kafka-2.0.1-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz.sha512">sha512</a>)
             </li>
             <li>
                 Binary downloads:
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.0.1/kafka_2.11-2.0.1.tgz">kafka_2.11-2.0.1.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.0.1/kafka_2.12-2.0.1.tgz">kafka_2.12-2.0.1.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz.sha512">sha512</a>)</li>
+                    <li>Scala 2.11 &nbsp;- <a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz">kafka_2.11-2.0.1.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz.sha512">sha512</a>)</li>
+                    <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz">kafka_2.12-2.0.1.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz.sha512">sha512</a>)</li>
                 </ul>
                 We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
             </li>
@@ -151,7 +151,7 @@
                 Released July 30, 2018
             </li>
             <li>
-                <a href="https://www.apache.org/dist/kafka/2.0.0/RELEASE_NOTES.html">Release Notes</a>
+                <a href="https://archive.apache.org/dist/kafka/2.0.0/RELEASE_NOTES.html">Release Notes</a>
             </li>
             <li>
                 Source download: <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka-2.0.0-src.tgz">kafka-2.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.0/kafka-2.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka-2.0.0-src.tgz.sha512">sha512</a>)
@@ -207,7 +207,7 @@
           <li>We have further improved unit testibility of Kafka Streams with the kafka-streams-testutil artifact.</li>
         </ul>
         <p>
-            For more information, please read the detailed <a href="https://www.apache.org/dist/kafka/2.0.0/RELEASE_NOTES.html">Release Notes</a>.
+            For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.0.0/RELEASE_NOTES.html">Release Notes</a>.
         </p>
 
     <span id="1.1.1"></span>
@@ -217,16 +217,16 @@
                 Released July 19, 2018
             </li>
             <li>
-                <a href="https://www.apache.org/dist/kafka/1.1.1/RELEASE_NOTES.html">Release Notes</a>
+                <a href="https://archive.apache.org/dist/kafka/1.1.1/RELEASE_NOTES.html">Release Notes</a>
             </li>
             <li>
-                Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/1.1.1/kafka-1.1.1-src.tgz">kafka-1.1.1-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz.sha512">sha512</a>)
+                Source download: <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz">kafka-1.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz.sha512">sha512</a>)
             </li>
             <li>
                 Binary downloads:
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/1.1.1/kafka_2.11-1.1.1.tgz">kafka_2.11-1.1.1.tgz</a> (<a href="https://www.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/1.1.1/kafka_2.12-1.1.1.tgz">kafka_2.12-1.1.1.tgz</a> (<a href="https://www.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz.sha512">sha512</a>)</li>
+                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz">kafka_2.11-1.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz.sha512">sha512</a>)</li>
+                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz">kafka_2.12-1.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz.sha512">sha512</a>)</li>
                 </ul>
                 We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
             </li>
@@ -240,7 +240,7 @@
                 Released March 28, 2018
             </li>
             <li>
-                <a href="https://www.apache.org/dist/kafka/1.1.0/RELEASE_NOTES.html">Release Notes</a>
+                <a href="https://archive.apache.org/dist/kafka/1.1.0/RELEASE_NOTES.html">Release Notes</a>
             </li>
             <li>
                 Source download: <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka-1.1.0-src.tgz">kafka-1.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.0/kafka-1.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka-1.1.0-src.tgz.sha512">sha512</a>)
@@ -269,7 +269,7 @@
             <li>Several improvements have been added to the Kafka Streams API, including reducing repartition topic partitions footprint, customizable error handling for produce failures and enhanced resilience to broker unavailability. See KIPs 205, 210, 220, 224 and 239 for details.</li>
         </ul>
         <p>
-            For more information, please read the detailed <a href="https://www.apache.org/dist/kafka/1.1.0/RELEASE_NOTES.html">Release Notes</a>.
+            For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/1.1.0/RELEASE_NOTES.html">Release Notes</a>.
         </p>
 
 
@@ -280,7 +280,7 @@
                 Released July 8th, 2018
             </li>
             <li>
-                <a href="https://www.apache.org/dist/kafka/1.0.2/RELEASE_NOTES.html">Release Notes</a>
+                <a href="https://archive.apache.org/dist/kafka/1.0.2/RELEASE_NOTES.html">Release Notes</a>
             </li>
             <li>
                 Source download: <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka-1.0.2-src.tgz">kafka-1.0.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.2/kafka-1.0.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka-1.0.2-src.tgz.sha512">sha512</a>)
@@ -364,7 +364,7 @@
         </ul>
 
         <p>
-            For more information, please read the detailed <a href="https://www.apache.org/dist/kafka/1.0.0/RELEASE_NOTES.html">Release Notes</a>.
+            For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/1.0.0/RELEASE_NOTES.html">Release Notes</a>.
         </p>
 
 
@@ -375,7 +375,7 @@
                 Released July 2ed, 2018
             </li>
             <li>
-                <a href="https://www.apache.org/dist/kafka/0.11.0.3/RELEASE_NOTES.html">Release Notes</a>
+                <a href="https://archive.apache.org/dist/kafka/0.11.0.3/RELEASE_NOTES.html">Release Notes</a>
             </li>
             <li>
                 Source download: <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka-0.11.0.3-src.tgz">kafka-0.11.0.3-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka-0.11.0.3-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka-0.11.0.3-src.tgz.sha512">sha512</a>)
@@ -466,19 +466,19 @@
                 Released July 2nd, 2018
             </li>
             <li>
-                <a href="https://www.apache.org/dist/kafka/0.10.2.2/RELEASE_NOTES.html">Release Notes</a>
+                <a href="https://archive.apache.org/dist/kafka/0.10.2.2/RELEASE_NOTES.html">Release Notes</a>
             </li>
             <li>
-                Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz">kafka-0.10.2.2-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz.md5">md5</a>)
+                Source download: <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz">kafka-0.10.2.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz.md5">md5</a>)
             </li>
             <li>
                 Binary downloads:
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz">kafka_2.10-0.10.2.2.tgz</a> (<a href="https://www.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz.md5">md5</a>)
+                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz">kafka_2.10-0.10.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz.md5">md5</a>)
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz">kafka_2.11-0.10.2.2.tgz</a> (<a href="https://www.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz.md5">md5</a>)
+                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz">kafka_2.11-0.10.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz.md5">md5</a>)
                     </li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz">kafka_2.12-0.10.2.2.tgz</a> (<a href="https://www.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz.md5">md5</a>)
+                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz">kafka_2.12-0.10.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz.md5">md5</a>)
                     </li>
                 </ul>
                 We add 2.12 to the supported Scala version. These different versions only matter if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
@@ -944,7 +944,7 @@
                 <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/RELEASE-NOTES.html">Release Notes</a>
             </li>
             <li>
-                Download: <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz">kafka-0.7.0-incubating-src.tar.gz</a> (<a href="	kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz.md5">md5</a>)
+                Download: <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz">kafka-0.7.0-incubating-src.tar.gz</a> (<a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz.md5">md5</a>)
             </li>
         </ul>
 


### PR DESCRIPTION
https://www.apache.org/dist/kafka/ only contains latest bug-fix per minor version

Update links to go to https://archive.apache.org/dist/kafka/ for other releases