### PR TITLE
KAFKA-8212 DOCS (kafka-site) - Fix Maven artifacts table from cutting off text

### DIFF
--- a/10/streams/developer-guide/write-streams.html
+++ b/10/streams/developer-guide/write-streams.html
@@ -52,7 +52,7 @@
           <span id="streams-developer-guide-maven"></span><h2>Libraries and Maven artifacts</h2>
           <p>This section lists the Kafka Streams related libraries that are available for writing your Kafka Streams applications.</p>
           <p>You can define dependencies on the following libraries for your Kafka Streams applications.</p>
-          <table border="1" class="non-scrolling-table docutils">
+          <table border="1" class="datatable">
               <colgroup>
                   <col width="14%" />
                   <col width="19%" />

--- a/11/streams/developer-guide/write-streams.html
+++ b/11/streams/developer-guide/write-streams.html
@@ -52,7 +52,7 @@
           <span id="streams-developer-guide-maven"></span><h2>Libraries and Maven artifacts</h2>
           <p>This section lists the Kafka Streams related libraries that are available for writing your Kafka Streams applications.</p>
           <p>You can define dependencies on the following libraries for your Kafka Streams applications.</p>
-          <table border="1" class="non-scrolling-table docutils">
+          <table border="1" class="datatable">
               <colgroup>
                   <col width="14%" />
                   <col width="19%" />

--- a/20/streams/developer-guide/write-streams.html
+++ b/20/streams/developer-guide/write-streams.html
@@ -53,7 +53,7 @@
           <span id="streams-developer-guide-maven"></span><h2>Libraries and Maven artifacts</h2>
           <p>This section lists the Kafka Streams related libraries that are available for writing your Kafka Streams applications.</p>
           <p>You can define dependencies on the following libraries for your Kafka Streams applications.</p>
-          <table border="1" class="non-scrolling-table docutils">
+          <table border="1" class="datatable">
               <colgroup>
                   <col width="14%" />
                   <col width="19%" />

--- a/21/streams/developer-guide/write-streams.html
+++ b/21/streams/developer-guide/write-streams.html
@@ -53,7 +53,7 @@
           <span id="streams-developer-guide-maven"></span><h2>Libraries and Maven artifacts</h2>
           <p>This section lists the Kafka Streams related libraries that are available for writing your Kafka Streams applications.</p>
           <p>You can define dependencies on the following libraries for your Kafka Streams applications.</p>
-          <table border="1" class="non-scrolling-table docutils">
+          <table border="1" class="datatable">
               <colgroup>
                   <col width="14%" />
                   <col width="19%" />

--- a/22/streams/developer-guide/write-streams.html
+++ b/22/streams/developer-guide/write-streams.html
@@ -53,7 +53,7 @@
           <span id="streams-developer-guide-maven"></span><h2>Libraries and Maven artifacts</h2>
           <p>This section lists the Kafka Streams related libraries that are available for writing your Kafka Streams applications.</p>
           <p>You can define dependencies on the following libraries for your Kafka Streams applications.</p>
-          <table border="1" class="non-scrolling-table docutils">
+          <table border="1" class="datatable">
               <colgroup>
                   <col width="14%" />
                   <col width="19%" />


### PR DESCRIPTION
## Description

**Jira ticket**: https://issues.apache.org/jira/browse/KAFKA-8212

- Fixed the table from cutting off the text by changing the table class to `datatable` (re-using a style that was already in the CSS and has an `overflow` property set).  

- This isn't the ideal fix. Given the current CSS, the `<pre>` items _should_ have a horizontal scroll, but they don't. If the entries in the first column of this table ever get too long, it will cut off the final column text. I tried several strategies, and nothing seemed to work. Can revisit if I have more time, this should work for now.

- Fixed these versions, where I found the problem: `22`, `21`, `11`, `10`

## Related

PR on `kafka`: https://github.com/apache/kafka/pull/6576

## Reviewers, cc:

@mjsax , @guozhangwang , @joel-hamill , @JimGalasyn

Signed-off-by: Victoria Bialas <vicky@confluent.io>