### PR TITLE
KAFKA-SITE DOCS 8227 - Add missing links Core Concepts duality of streams tables

### DIFF
--- a/10/streams/core-concepts.html
+++ b/10/streams/core-concepts.html
@@ -57,13 +57,14 @@
     <p>
         We first summarize the key concepts of Kafka Streams.
     </p>
+    <a id="streams_processor_node" href="#streams_processor_node"></a>
 
     <h3><a id="streams_topology" href="#streams_topology">Stream Processing Topology</a></h3>
 
     <ul>
         <li>A <b>stream</b> is the most important abstraction provided by Kafka Streams: it represents an unbounded, continuously updating data set. A stream is an ordered, replayable, and fault-tolerant sequence of immutable data records, where a <b>data record</b> is defined as a key-value pair.</li>
         <li>A <b>stream processing application</b> is any program that makes use of the Kafka Streams library. It defines its computational logic through one or more <b>processor topologies</b>, where a processor topology is a graph of stream processors (nodes) that are connected by streams (edges).</li>
-        <li>A <b><a href="#streams_processor_node">stream processor</a></b> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. </li>
+        <li>A <a id="defining-a-stream-processor" href="/{{version}}/documentation/streams/developer-guide/processor-api#defining-a-stream-processor"><b>stream processor</b></a> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. </li>
     </ul>
 
     There are two special processors in the topology:

--- a/10/streams/developer-guide/processor-api.html
+++ b/10/streams/developer-guide/processor-api.html
@@ -66,7 +66,7 @@
         </div>
         <div class="section" id="defining-a-stream-processor">
             <span id="streams-developer-guide-stream-processor"></span><h2><a class="toc-backref" href="#id2">Defining a Stream Processor</a><a class="headerlink" href="#defining-a-stream-processor" title="Permalink to this headline"></a></h2>
-            <p>A <a class="reference internal" href="../concepts.html#streams-concepts"><span class="std std-ref">stream processor</span></a> is a node in the processor topology that represents a single processing step.
+            <p>A <a class="reference internal" href="../core-concepts.html#streams_processor_node"><span class="std std-ref">stream processor</span></a> is a node in the processor topology that represents a single processing step.
                 With the Processor API, you can define arbitrary stream processors that processes one received record at a time, and connect
                 these processors with their associated state stores to compose the processor topology.</p>
             <p>You can define a customized stream processor by implementing the <code class="docutils literal"><span class="pre">Processor</span></code> interface, which provides the <code class="docutils literal"><span class="pre">process()</span></code> API method.

--- a/11/streams/core-concepts.html
+++ b/11/streams/core-concepts.html
@@ -57,13 +57,14 @@
     <p>
         We first summarize the key concepts of Kafka Streams.
     </p>
+    <a id="streams_processor_node" href="#streams_processor_node"></a>
 
     <h3><a id="streams_topology" href="#streams_topology">Stream Processing Topology</a></h3>
-
+    <a id="streams_processor_node" href="#streams_processor_node"></a>
     <ul>
         <li>A <b>stream</b> is the most important abstraction provided by Kafka Streams: it represents an unbounded, continuously updating data set. A stream is an ordered, replayable, and fault-tolerant sequence of immutable data records, where a <b>data record</b> is defined as a key-value pair.</li>
         <li>A <b>stream processing application</b> is any program that makes use of the Kafka Streams library. It defines its computational logic through one or more <b>processor topologies</b>, where a processor topology is a graph of stream processors (nodes) that are connected by streams (edges).</li>
-        <li>A <b><a id="#streams_processor_node" href="#streams_processor_node">stream processor</a></b> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. </li>
+        <li>A <a id="defining-a-stream-processor" href="/{{version}}/documentation/streams/developer-guide/processor-api#defining-a-stream-processor"><b>stream processor</b></a> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. </li>
     </ul>
 
     There are two special processors in the topology:

--- a/11/streams/developer-guide/processor-api.html
+++ b/11/streams/developer-guide/processor-api.html
@@ -66,7 +66,7 @@
         </div>
         <div class="section" id="defining-a-stream-processor">
             <span id="streams-developer-guide-stream-processor"></span><h2><a class="toc-backref" href="#id2">Defining a Stream Processor</a><a class="headerlink" href="#defining-a-stream-processor" title="Permalink to this headline"></a></h2>
-            <p>A <a class="reference internal" href="../concepts.html#streams-concepts"><span class="std std-ref">stream processor</span></a> is a node in the processor topology that represents a single processing step.
+            <p>A <a class="reference internal" href="../core-concepts.html#streams_processor_node"><span class="std std-ref">stream processor</span></a> is a node in the processor topology that represents a single processing step.
                 With the Processor API, you can define arbitrary stream processors that processes one received record at a time, and connect
                 these processors with their associated state stores to compose the processor topology.</p>
             <p>You can define a customized stream processor by implementing the <code class="docutils literal"><span class="pre">Processor</span></code> interface, which provides the <code class="docutils literal"><span class="pre">process()</span></code> API method.

--- a/20/streams/core-concepts.html
+++ b/20/streams/core-concepts.html
@@ -57,13 +57,14 @@
     <p>
         We first summarize the key concepts of Kafka Streams.
     </p>
+    <a id="streams_processor_node" href="#streams_processor_node"></a>
 
     <h3><a id="streams_topology" href="#streams_topology">Stream Processing Topology</a></h3>
 
     <ul>
         <li>A <b>stream</b> is the most important abstraction provided by Kafka Streams: it represents an unbounded, continuously updating data set. A stream is an ordered, replayable, and fault-tolerant sequence of immutable data records, where a <b>data record</b> is defined as a key-value pair.</li>
         <li>A <b>stream processing application</b> is any program that makes use of the Kafka Streams library. It defines its computational logic through one or more <b>processor topologies</b>, where a processor topology is a graph of stream processors (nodes) that are connected by streams (edges).</li>
-        <li>A <b><a id="streams_processor_node" href="#streams_processor_node">stream processor</a></b> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. </li>
+        <li>A <a id="defining-a-stream-processor" href="/{{version}}/documentation/streams/developer-guide/processor-api#defining-a-stream-processor"><b>stream processor</b></a> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. </li>
     </ul>
 
     There are two special processors in the topology:
@@ -160,21 +161,26 @@
 
     <p>
         Any stream processing technology must therefore provide <strong>first-class support for streams and tables</strong>.
-        Kafka's Streams API provides such functionality through its core abstractions for
-        <code class="interpreted-text" data-role="ref">streams &lt;streams_concepts_kstream&gt;</code> and
-        <code class="interpreted-text" data-role="ref">tables &lt;streams_concepts_ktable&gt;</code>, which we will talk about in a minute.
-        Now, an interesting observation is that there is actually a <strong>close relationship between streams and tables</strong>,
-        the so-called stream-table duality.
-        And Kafka exploits this duality in many ways: for example, to make your applications
+        Kafka's Streams API provides such functionality through its core abstractions for 
+        <a id="streams_concepts_kstream" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_kstream">streams</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>
+        and <a id="streams_concepts_ktable" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_ktable">tables</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>,
+        which we will talk about in a minute. Now, an interesting observation is that there is actually a <strong>close relationship between streams and tables</strong>,
+        the so-called stream-table duality. And Kafka exploits this duality in many ways: for example, to make your applications
+        <a id="streams-developer-guide-execution-scaling" href="/{{version}}/documentation/streams/developer-guide/running-app#elastic-scaling-of-your-application">elastic</a>
         <code class="interpreted-text" data-role="ref">elastic &lt;streams_developer-guide_execution-scaling&gt;</code>,
-        to support <code class="interpreted-text" data-role="ref">fault-tolerant stateful processing &lt;streams_developer-guide_state-store_fault-tolerance&gt;</code>,
-        or to run <code class="interpreted-text" data-role="ref">interactive queries &lt;streams_concepts_interactive-queries&gt;</code>
+        to support <a id="streams_architecture_recovery" href="/{{version}}/documentation/streams/architecture#streams_architecture_recovery">fault-tolerant stateful processing</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_developer-guide_state-store_fault-tolerance&gt;</code>,
+        or to run <a id="streams-developer-guide-interactive-queries" href="/{{version}}/documentation/streams/developer-guide/interactive-queries#interactive-queries">interactive queries</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_interactive-queries&gt;</code>
         against your application's latest processing results. And, beyond its internal usage, the Kafka Streams API
         also allows developers to exploit this duality in their own applications.
     </p>
 
     <p>
-        Before we discuss concepts such as <code class="interpreted-text" data-role="ref">aggregations &lt;streams_concepts_aggregations&gt;</code>
+        Before we discuss concepts such as <a id="streams-developer-guide-dsl-aggregating" href="/{{version}}/documentation/streams/developer-guide/dsl-api#aggregating">aggregations</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_aggregations&gt;</code>,
         in Kafka Streams we must first introduce <strong>tables</strong> in more detail, and talk about the aforementioned stream-table duality.
         Essentially, this duality means that a stream can be viewed as a table, and a table can be viewed as a stream.
     </p>

--- a/21/streams/core-concepts.html
+++ b/21/streams/core-concepts.html
@@ -162,25 +162,19 @@
         Any stream processing technology must therefore provide <strong>first-class support for streams and tables</strong>.
         Kafka's Streams API provides such functionality through its core abstractions for 
         <a id="streams_concepts_kstream" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_kstream">streams</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>
-        and <a id="streams_concepts_ktable" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_ktable">tables</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>,
+        and <a id="streams_concepts_ktable" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_ktable">tables</a>,
         which we will talk about in a minute. Now, an interesting observation is that there is actually a <strong>close relationship between streams and tables</strong>,
         the so-called stream-table duality. And Kafka exploits this duality in many ways: for example, to make your applications
-        <a id="streams-developer-guide-execution-scaling" href="/{{version}}/documentation/streams/developer-guide/running-app#elastic-scaling-of-your-application">elastic</a>
-        <code class="interpreted-text" data-role="ref">elastic &lt;streams_developer-guide_execution-scaling&gt;</code>,
-        to support <a id="streams_architecture_recovery" href="/{{version}}/documentation/streams/architecture#streams_architecture_recovery">fault-tolerant stateful processing</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_developer-guide_state-store_fault-tolerance&gt;</code>,
+        <a id="streams-developer-guide-execution-scaling" href="/{{version}}/documentation/streams/developer-guide/running-app#elastic-scaling-of-your-application">elastic</a>,
+        to support <a id="streams_architecture_recovery" href="/{{version}}/documentation/streams/architecture#streams_architecture_recovery">fault-tolerant stateful processing</a>,
         or to run <a id="streams-developer-guide-interactive-queries" href="/{{version}}/documentation/streams/developer-guide/interactive-queries#interactive-queries">interactive queries</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_interactive-queries&gt;</code>
         against your application's latest processing results. And, beyond its internal usage, the Kafka Streams API
         also allows developers to exploit this duality in their own applications.
     </p>
 
     <p>
         Before we discuss concepts such as <a id="streams-developer-guide-dsl-aggregating" href="/{{version}}/documentation/streams/developer-guide/dsl-api#aggregating">aggregations</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_aggregations&gt;</code>,
-        in Kafka Streams we must first introduce <strong>tables</strong> in more detail, and talk about the aforementioned stream-table duality.
+        in Kafka Streams, we must first introduce <strong>tables</strong> in more detail, and talk about the aforementioned stream-table duality.
         Essentially, this duality means that a stream can be viewed as a table, and a table can be viewed as a stream.
     </p>
 

--- a/21/streams/core-concepts.html
+++ b/21/streams/core-concepts.html
@@ -57,13 +57,13 @@
     <p>
         We first summarize the key concepts of Kafka Streams.
     </p>
-
+    <a id="streams_processor_node" href="#streams_processor_node"></a>
     <h3><a id="streams_topology" href="#streams_topology">Stream Processing Topology</a></h3>
 
     <ul>
         <li>A <b>stream</b> is the most important abstraction provided by Kafka Streams: it represents an unbounded, continuously updating data set. A stream is an ordered, replayable, and fault-tolerant sequence of immutable data records, where a <b>data record</b> is defined as a key-value pair.</li>
         <li>A <b>stream processing application</b> is any program that makes use of the Kafka Streams library. It defines its computational logic through one or more <b>processor topologies</b>, where a processor topology is a graph of stream processors (nodes) that are connected by streams (edges).</li>
-        <li>A <b><a id="streams_processor_node" href="#streams_processor_node">stream processor</a></b> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. </li>
+        <li>A <a id="defining-a-stream-processor" href="/{{version}}/documentation/streams/developer-guide/processor-api#defining-a-stream-processor"><b>stream processor</b></a> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. </li>
     </ul>
 
     There are two special processors in the topology:
@@ -160,21 +160,26 @@
 
     <p>
         Any stream processing technology must therefore provide <strong>first-class support for streams and tables</strong>.
-        Kafka's Streams API provides such functionality through its core abstractions for
-        <code class="interpreted-text" data-role="ref">streams &lt;streams_concepts_kstream&gt;</code> and
-        <code class="interpreted-text" data-role="ref">tables &lt;streams_concepts_ktable&gt;</code>, which we will talk about in a minute.
-        Now, an interesting observation is that there is actually a <strong>close relationship between streams and tables</strong>,
-        the so-called stream-table duality.
-        And Kafka exploits this duality in many ways: for example, to make your applications
+        Kafka's Streams API provides such functionality through its core abstractions for 
+        <a id="streams_concepts_kstream" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_kstream">streams</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>
+        and <a id="streams_concepts_ktable" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_ktable">tables</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>,
+        which we will talk about in a minute. Now, an interesting observation is that there is actually a <strong>close relationship between streams and tables</strong>,
+        the so-called stream-table duality. And Kafka exploits this duality in many ways: for example, to make your applications
+        <a id="streams-developer-guide-execution-scaling" href="/{{version}}/documentation/streams/developer-guide/running-app#elastic-scaling-of-your-application">elastic</a>
         <code class="interpreted-text" data-role="ref">elastic &lt;streams_developer-guide_execution-scaling&gt;</code>,
-        to support <code class="interpreted-text" data-role="ref">fault-tolerant stateful processing &lt;streams_developer-guide_state-store_fault-tolerance&gt;</code>,
-        or to run <code class="interpreted-text" data-role="ref">interactive queries &lt;streams_concepts_interactive-queries&gt;</code>
+        to support <a id="streams_architecture_recovery" href="/{{version}}/documentation/streams/architecture#streams_architecture_recovery">fault-tolerant stateful processing</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_developer-guide_state-store_fault-tolerance&gt;</code>,
+        or to run <a id="streams-developer-guide-interactive-queries" href="/{{version}}/documentation/streams/developer-guide/interactive-queries#interactive-queries">interactive queries</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_interactive-queries&gt;</code>
         against your application's latest processing results. And, beyond its internal usage, the Kafka Streams API
         also allows developers to exploit this duality in their own applications.
     </p>
 
     <p>
-        Before we discuss concepts such as <code class="interpreted-text" data-role="ref">aggregations &lt;streams_concepts_aggregations&gt;</code>
+        Before we discuss concepts such as <a id="streams-developer-guide-dsl-aggregating" href="/{{version}}/documentation/streams/developer-guide/dsl-api#aggregating">aggregations</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_aggregations&gt;</code>,
         in Kafka Streams we must first introduce <strong>tables</strong> in more detail, and talk about the aforementioned stream-table duality.
         Essentially, this duality means that a stream can be viewed as a table, and a table can be viewed as a stream.
     </p>

--- a/22/streams/core-concepts.html
+++ b/22/streams/core-concepts.html
@@ -63,7 +63,9 @@
     <ul>
         <li>A <b>stream</b> is the most important abstraction provided by Kafka Streams: it represents an unbounded, continuously updating data set. A stream is an ordered, replayable, and fault-tolerant sequence of immutable data records, where a <b>data record</b> is defined as a key-value pair.</li>
         <li>A <b>stream processing application</b> is any program that makes use of the Kafka Streams library. It defines its computational logic through one or more <b>processor topologies</b>, where a processor topology is a graph of stream processors (nodes) that are connected by streams (edges).</li>
-        <li>A <b><a id="streams_processor_node" href="#streams_processor_node">stream processor</a></b> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. </li>
+        <li>A <b><a id="streams_processor_node" href="#streams_processor_node">stream processor</a></b> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. 
+        (See <a id="defining-a-stream-processor" href="/{{version}}/documentation/streams/developer-guide/processor-api#defining-a-stream-processor">Defining a Stream Processor</a>.)
+        </li>
     </ul>
 
     There are two special processors in the topology:

--- a/22/streams/core-concepts.html
+++ b/22/streams/core-concepts.html
@@ -157,10 +157,6 @@
         An example use case that is very common in practice is an e-commerce application that enriches an incoming <em>stream</em> of customer
         transactions with the latest customer information from a <em>database table</em>. In other words, streams are everywhere, but databases are everywhere, too.
     </p>
-    
-    EXAMPLEs REMOVE WHEN DONE: 
-    <a href="/{{version}}/documentation/#quickstart_kafkastreams">quickstart</a>
-    <a id="quickstart_kafkastreams" href="#quickstart_kafkastreams">Step 8: Use Kafka Streams to process data</a>
 
     <p>
         Any stream processing technology must therefore provide <strong>first-class support for streams and tables</strong>.

--- a/22/streams/core-concepts.html
+++ b/22/streams/core-concepts.html
@@ -57,14 +57,12 @@
     <p>
         We first summarize the key concepts of Kafka Streams.
     </p>
-
+    <a id="streams_processor_node" href="#streams_processor_node"></a>
     <h3><a id="streams_topology" href="#streams_topology">Stream Processing Topology</a></h3>
-
     <ul>
         <li>A <b>stream</b> is the most important abstraction provided by Kafka Streams: it represents an unbounded, continuously updating data set. A stream is an ordered, replayable, and fault-tolerant sequence of immutable data records, where a <b>data record</b> is defined as a key-value pair.</li>
         <li>A <b>stream processing application</b> is any program that makes use of the Kafka Streams library. It defines its computational logic through one or more <b>processor topologies</b>, where a processor topology is a graph of stream processors (nodes) that are connected by streams (edges).</li>
-        <li>A <b><a id="streams_processor_node" href="#streams_processor_node">stream processor</a></b> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. 
-        (See <a id="defining-a-stream-processor" href="/{{version}}/documentation/streams/developer-guide/processor-api#defining-a-stream-processor">Defining a Stream Processor</a>.)
+        <li>A <a id="defining-a-stream-processor" href="/{{version}}/documentation/streams/developer-guide/processor-api#defining-a-stream-processor"><b>stream processor</b></a> is a node in the processor topology; it represents a processing step to transform data in streams by receiving one input record at a time from its upstream processors in the topology, applying its operation to it, and may subsequently produce one or more output records to its downstream processors. 
         </li>
     </ul>
 

--- a/22/streams/core-concepts.html
+++ b/22/streams/core-concepts.html
@@ -157,24 +157,33 @@
         An example use case that is very common in practice is an e-commerce application that enriches an incoming <em>stream</em> of customer
         transactions with the latest customer information from a <em>database table</em>. In other words, streams are everywhere, but databases are everywhere, too.
     </p>
+    
+    EXAMPLEs REMOVE WHEN DONE: 
+    <a href="/{{version}}/documentation/#quickstart_kafkastreams">quickstart</a>
+    <a id="quickstart_kafkastreams" href="#quickstart_kafkastreams">Step 8: Use Kafka Streams to process data</a>
 
     <p>
         Any stream processing technology must therefore provide <strong>first-class support for streams and tables</strong>.
-        Kafka's Streams API provides such functionality through its core abstractions for
-        <code class="interpreted-text" data-role="ref">streams &lt;streams_concepts_kstream&gt;</code> and
-        <code class="interpreted-text" data-role="ref">tables &lt;streams_concepts_ktable&gt;</code>, which we will talk about in a minute.
-        Now, an interesting observation is that there is actually a <strong>close relationship between streams and tables</strong>,
-        the so-called stream-table duality.
-        And Kafka exploits this duality in many ways: for example, to make your applications
+        Kafka's Streams API provides such functionality through its core abstractions for 
+        <a id="streams_concepts_kstream" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_kstream">streams</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>
+        and <a id="streams_concepts_ktable" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_ktable">tables</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>,
+        which we will talk about in a minute. Now, an interesting observation is that there is actually a <strong>close relationship between streams and tables</strong>,
+        the so-called stream-table duality. And Kafka exploits this duality in many ways: for example, to make your applications
+        <a id="streams-developer-guide-execution-scaling" href="/{{version}}/documentation/streams/developer-guide/running-app#elastic-scaling-of-your-application">elastic</a>
         <code class="interpreted-text" data-role="ref">elastic &lt;streams_developer-guide_execution-scaling&gt;</code>,
-        to support <code class="interpreted-text" data-role="ref">fault-tolerant stateful processing &lt;streams_developer-guide_state-store_fault-tolerance&gt;</code>,
-        or to run <code class="interpreted-text" data-role="ref">interactive queries &lt;streams_concepts_interactive-queries&gt;</code>
+        to support <a id="streams_architecture_recovery" href="/{{version}}/documentation/streams/architecture#streams_architecture_recovery">fault-tolerant stateful processing</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_developer-guide_state-store_fault-tolerance&gt;</code>,
+        or to run <a id="streams-developer-guide-interactive-queries" href="/{{version}}/documentation/streams/developer-guide/interactive-queries#interactive-queries">interactive queries</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_interactive-queries&gt;</code>
         against your application's latest processing results. And, beyond its internal usage, the Kafka Streams API
         also allows developers to exploit this duality in their own applications.
     </p>
 
     <p>
-        Before we discuss concepts such as <code class="interpreted-text" data-role="ref">aggregations &lt;streams_concepts_aggregations&gt;</code>
+        Before we discuss concepts such as <a id="streams-developer-guide-dsl-aggregating" href="/{{version}}/documentation/streams/developer-guide/dsl-api#aggregating">aggregations</a>
+        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_aggregations&gt;</code>,
         in Kafka Streams we must first introduce <strong>tables</strong> in more detail, and talk about the aforementioned stream-table duality.
         Essentially, this duality means that a stream can be viewed as a table, and a table can be viewed as a stream.
     </p>

--- a/22/streams/core-concepts.html
+++ b/22/streams/core-concepts.html
@@ -162,25 +162,19 @@
         Any stream processing technology must therefore provide <strong>first-class support for streams and tables</strong>.
         Kafka's Streams API provides such functionality through its core abstractions for 
         <a id="streams_concepts_kstream" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_kstream">streams</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>
-        and <a id="streams_concepts_ktable" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_ktable">tables</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_kstreams&gt;</code>,
+        and <a id="streams_concepts_ktable" href="/{{version}}/documentation/streams/developer-guide/dsl-api#streams_concepts_ktable">tables</a>,
         which we will talk about in a minute. Now, an interesting observation is that there is actually a <strong>close relationship between streams and tables</strong>,
         the so-called stream-table duality. And Kafka exploits this duality in many ways: for example, to make your applications
-        <a id="streams-developer-guide-execution-scaling" href="/{{version}}/documentation/streams/developer-guide/running-app#elastic-scaling-of-your-application">elastic</a>
-        <code class="interpreted-text" data-role="ref">elastic &lt;streams_developer-guide_execution-scaling&gt;</code>,
-        to support <a id="streams_architecture_recovery" href="/{{version}}/documentation/streams/architecture#streams_architecture_recovery">fault-tolerant stateful processing</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_developer-guide_state-store_fault-tolerance&gt;</code>,
+        <a id="streams-developer-guide-execution-scaling" href="/{{version}}/documentation/streams/developer-guide/running-app#elastic-scaling-of-your-application">elastic</a>,
+        to support <a id="streams_architecture_recovery" href="/{{version}}/documentation/streams/architecture#streams_architecture_recovery">fault-tolerant stateful processing</a>,
         or to run <a id="streams-developer-guide-interactive-queries" href="/{{version}}/documentation/streams/developer-guide/interactive-queries#interactive-queries">interactive queries</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_interactive-queries&gt;</code>
         against your application's latest processing results. And, beyond its internal usage, the Kafka Streams API
         also allows developers to exploit this duality in their own applications.
     </p>
 
     <p>
         Before we discuss concepts such as <a id="streams-developer-guide-dsl-aggregating" href="/{{version}}/documentation/streams/developer-guide/dsl-api#aggregating">aggregations</a>
-        <code class="interpreted-text" data-role="ref">&lt;streams_concepts_aggregations&gt;</code>,
-        in Kafka Streams we must first introduce <strong>tables</strong> in more detail, and talk about the aforementioned stream-table duality.
+        in Kafka Streams, we must first introduce <strong>tables</strong> in more detail, and talk about the aforementioned stream-table duality.
         Essentially, this duality means that a stream can be viewed as a table, and a table can be viewed as a stream.
     </p>
 

--- a/22/streams/developer-guide/running-app.html
+++ b/22/streams/developer-guide/running-app.html
@@ -83,7 +83,8 @@ $ java -cp path-to-app-fatjar.jar com.example.MyStreamsApp
                   more information, see the  <a class="reference internal" href="#streams-developer-guide-execution-scaling-state-restoration"><span class="std std-ref">State restoration during workload rebalance</span></a> section).</p>
           </div>
           <div class="section" id="elastic-scaling-of-your-application">
-              <span id="streams-developer-guide-execution-scaling"></span><h2><a class="toc-backref" href="#id4">Elastic scaling of your application</a><a class="headerlink" href="#elastic-scaling-of-your-application" title="Permalink to this headline"></a></h2>
+              <span id="streams-developer-guide-execution-scaling"></span>
+              <h2><a class="toc-backref" href="#id4">Elastic scaling of your application</a><a class="headerlink" href="#elastic-scaling-of-your-application" title="Permalink to this headline"></a></h2>
               <p>Kafka Streams makes your stream processing applications elastic and scalable.  You can add and remove processing capacity
                   dynamically during application runtime without any downtime or data loss.  This makes your applications
                   resilient in the face of failures and for allows you to perform maintenance as needed (e.g. rolling upgrades).</p>


### PR DESCRIPTION
## Description

- Jira ticket: https://issues.apache.org/jira/browse/KAFKA-8227
- Related PR: https://github.com/apache/kafka/pull/6625
- add links from Core Concepts to relevant sections in Streams architecture and developer guides

## Review Requests
@bbejeck , @mjsax , @JimGalasyn , @joel-hamill 

Signed-off-by: Victoria Bialas <vicky@confluent.io>