### PR TITLE
Fixes #8198 KStreams testing docs use non-existent method pipe

### DIFF
--- a/22/streams/developer-guide/testing.html
+++ b/22/streams/developer-guide/testing.html
@@ -99,7 +99,7 @@ TopologyTestDriver testDriver = new TopologyTestDriver(topology, props);
             </p>
             <pre>
 ConsumerRecordFactory&lt;String, Integer&gt; factory = new ConsumerRecordFactory&lt;&gt;("input-topic", new StringSerializer(), new IntegerSerializer());
-testDriver.pipe(factory.create("key", 42L));
+testDriver.pipeInput(factory.create("key", 42L));
         </pre>
             <p>
                 To verify the output, the test driver produces <code>ProducerRecord</code>s with key and value type


### PR DESCRIPTION
Minor fix of #8198 
linked to https://github.com/apache/kafka/pull/6678