### PR TITLE
KAFKA-7315 update TOC internal links serdes all versions

### DIFF
--- a/10/streams/developer-guide/datatypes.html
+++ b/10/streams/developer-guide/datatypes.html
@@ -47,7 +47,7 @@
           <li><a class="reference internal" href="#available-serdes" id="id3">Available SerDes</a><ul>
               <li><a class="reference internal" href="#primitive-and-basic-types" id="id4">Primitive and basic types</a></li>
               <li><a class="reference internal" href="#json" id="id6">JSON</a></li>
-              <li><a class="reference internal" href="#further-serdes" id="id7">Further serdes</a></li>
+              <li><a class="reference internal" href="#implementing-custom-serdes" id="id5">Implementing custom serdes</a></li>
           </ul>
     <div class="section" id="configuring-serdes">
       <h2>Configuring SerDes<a class="headerlink" href="#configuring-serdes" title="Permalink to this headline"></a></h2>

--- a/11/streams/developer-guide/datatypes.html
+++ b/11/streams/developer-guide/datatypes.html
@@ -47,7 +47,7 @@
           <li><a class="reference internal" href="#available-serdes" id="id3">Available SerDes</a><ul>
               <li><a class="reference internal" href="#primitive-and-basic-types" id="id4">Primitive and basic types</a></li>
               <li><a class="reference internal" href="#json" id="id6">JSON</a></li>
-              <li><a class="reference internal" href="#further-serdes" id="id7">Further serdes</a></li>
+              <li><a class="reference internal" href="#implementing-custom-serdes" id="id5">Implementing custom serdes</a></li>
           </ul>
     <div class="section" id="configuring-serdes">
       <h2>Configuring SerDes<a class="headerlink" href="#configuring-serdes" title="Permalink to this headline"></a></h2>

--- a/20/streams/developer-guide/datatypes.html
+++ b/20/streams/developer-guide/datatypes.html
@@ -48,7 +48,7 @@
           <ul>
               <li><a class="reference internal" href="#primitive-and-basic-types" id="id4">Primitive and basic types</a></li>
               <li><a class="reference internal" href="#json" id="id6">JSON</a></li>
-              <li><a class="reference internal" href="#further-serdes" id="id7">Further serdes</a></li>
+              <li><a class="reference internal" href="#implementing-custom-serdes" id="id5">Implementing custom serdes</a></li>
           </ul>
           <li><a class="reference internal" href="#scala-dsl-serdes" id="id8">Kafka Streams DSL for Scala Implicit SerDes</a></li>
       </ul>

--- a/22/streams/developer-guide/datatypes.html
+++ b/22/streams/developer-guide/datatypes.html
@@ -48,7 +48,7 @@
           <ul>
               <li><a class="reference internal" href="#primitive-and-basic-types" id="id4">Primitive and basic types</a></li>
               <li><a class="reference internal" href="#json" id="id6">JSON</a></li>
-              <li><a class="reference internal" href="#further-serdes" id="id7">Further serdes</a></li>
+              <li><a class="reference internal" href="#implementing-custom-serdes" id="id5">Implementing custom serdes</a></li>
           </ul>
           <li><a class="reference internal" href="#scala-dsl-serdes" id="id8">Kafka Streams DSL for Scala Implicit SerDes</a></li>
       </ul>


### PR DESCRIPTION
- **apache/kafka-site** docs update per https://issues.apache.org/jira/browse/KAFKA-7315
- follow up to PR #177 to update same links in other version folders
- associated PR for kafka repo is https://github.com/apache/kafka/pull/6875

Reviewers: @mjsax , @JimGalasyn , @joel-hamill 


Signed-off-by: Victoria Bialas <vicky@confluent.io>