### PR TITLE
Remove streams default override for producer retries.

### DIFF
--- a/21/streams/developer-guide/config-streams.html
+++ b/21/streams/developer-guide/config-streams.html
@@ -658,11 +658,7 @@
               <td>Consumer</td>
               <td>1000</td>
             </tr>
-            <tr class="row-odd"><td>retries</td>
-              <td>Producer</td>
-              <td>10</td>
-            </tr>
-            <tr class="row-even"><td>rocksdb.config.setter</td>
+            <tr class="row-odd"><td>rocksdb.config.setter</td>
               <td>Consumer</td>
               <td>&nbsp;</td>
             </tr>

--- a/22/streams/developer-guide/config-streams.html
+++ b/22/streams/developer-guide/config-streams.html
@@ -658,11 +658,7 @@
               <td>Consumer</td>
               <td>1000</td>
             </tr>
-            <tr class="row-odd"><td>retries</td>
-              <td>Producer</td>
-              <td>10</td>
-            </tr>
-            <tr class="row-even"><td>rocksdb.config.setter</td>
+            <tr class="row-odd"><td>rocksdb.config.setter</td>
               <td>Consumer</td>
               <td>&nbsp;</td>
             </tr>

--- a/23/streams/developer-guide/config-streams.html
+++ b/23/streams/developer-guide/config-streams.html
@@ -658,11 +658,7 @@
               <td>Consumer</td>
               <td>1000</td>
             </tr>
-            <tr class="row-odd"><td>retries</td>
-              <td>Producer</td>
-              <td>10</td>
-            </tr>
-            <tr class="row-even"><td>rocksdb.config.setter</td>
+            <tr class="row-odd"><td>rocksdb.config.setter</td>
               <td>Consumer</td>
               <td>&nbsp;</td>
             </tr>


### PR DESCRIPTION
These default overrides are no longer applied, see: https://github.com/apache/kafka/pull/6844.
CC: @mjsax Updated for 2.2 and 2.1