### PR TITLE
highlight 2.3 inter.broker.protocol breaking change

### DIFF
--- a/23/upgrade.html
+++ b/23/upgrade.html
@@ -21,8 +21,8 @@
 
 <h4><a id="upgrade_2_3_0" href="#upgrade_2_3_0">Upgrading from 0.8.x, 0.9.x, 0.10.0.x, 0.10.1.x, 0.10.2.x, 0.11.0.x, 1.0.x, 1.1.x, 2.0.x or 2.1.x or 2.2.x to 2.3.0</a></h4>
 
-<p><b>If you are upgrading from a version prior to 2.1.x, please see the note below about the change to the schema used to store consumer offsets.
-    Once you have changed the inter.broker.protocol.version to the latest version, it will not be possible to downgrade to a version prior to 2.1.</b></p>
+<p><b>Note that 2.3.x contains a change to the internal schema used to store consumer offsets. Once you have changed the inter.broker.protocol.version to the latest version, it will not be possible to downgrade to a version prior to 2.3.
+    See the rolling upgrade notes below for more detail.</b></p>
 
 <p><b>For a rolling upgrade:</b></p>
 


### PR DESCRIPTION
it's misleading that the 2.3 upgrade guide still references the 2.1 changes whereas it introduces it's own set of not downgradeable changes. especially as the changes already become effective with the inter.broker.protocol upgrade.