### PR TITLE
KAFKA-8360: Docs do not mention RequestQueueSize JMX metric 

### DIFF
--- a/23/ops.html
+++ b/23/ops.html
@@ -846,6 +846,11 @@
         <td>Time in milliseconds spent on message format conversions.</td>
       </tr>
       <tr>
+        <td>Request Queue Size</td>
+        <td>kafka.network:type=RequestChannel,name=RequestQueueSize</td>
+        <td></td>
+      </tr>
+      <tr>
         <td>Message conversion rate</td>
         <td>kafka.server:type=BrokerTopicMetrics,name={Produce|Fetch}MessageConversionsPerSec,topic=([-.\w]+)</td>
         <td>Number of records which required message format conversion.</td>


### PR DESCRIPTION
What? :: Mentioning "Request Queue Size" under [Monitoring](https://kafka.apache.org/documentation/#monitoring) tab. RequestQueueSize is an important metric to monitor the number of requests in the queue. As a crowded queue might face issue processing incoming or outgoing requests

Can you please review this?

Thanks!!