### PR TITLE
MINOR fix description about whether internal topics respect broker defaults

### DIFF
--- a/10/streams/developer-guide/manage-topics.html
+++ b/10/streams/developer-guide/manage-topics.html
@@ -84,8 +84,10 @@
       <p>
         Kafka Streams automatically creates internal repartitioning and changelog
         topics, and does <em>not</em> use broker auto-topic creation.
-        Therefore, internal topics do not take on the default broker configurations for
-        new topics.
+        Therefore, internal topics do not take on all the default broker configurations for
+        new topics. In particular, <code>replication.factor</code> (which defaults to <code>1</code>),
+        <code>num.partitions</code>, and <code>cleanup.policy</code> do not respect broker configurations
+        fot automatically created topics.
         You can override the default configs used when creating these topics by
         adding any configs from <code>TopicConfig</code> to your
         <code>StreamsConfig</code> with the prefix

--- a/10/streams/developer-guide/manage-topics.html
+++ b/10/streams/developer-guide/manage-topics.html
@@ -84,7 +84,7 @@
       <p>
         Kafka Streams automatically creates internal repartitioning and changelog
         topics, and does <em>not</em> use broker auto-topic creation.
-        Therefore, internal topics take on the default broker configurations for
+        Therefore, internal topics do not take on the default broker configurations for
         new topics.
         You can override the default configs used when creating these topics by
         adding any configs from <code>TopicConfig</code> to your

--- a/11/streams/developer-guide/manage-topics.html
+++ b/11/streams/developer-guide/manage-topics.html
@@ -84,8 +84,10 @@
       <p>
         Kafka Streams automatically creates internal repartitioning and changelog
         topics, and does <em>not</em> use broker auto-topic creation.
-        Therefore, internal topics do not take on the default broker configurations for
-        new topics.
+        Therefore, internal topics do not take on all the default broker configurations for
+        new topics. In particular, <code>replication.factor</code> (which defaults to <code>1</code>),
+        <code>num.partitions</code>, and <code>cleanup.policy</code> do not respect broker configurations
+        fot automatically created topics.
         You can override the default configs used when creating these topics by
         adding any configs from <code>TopicConfig</code> to your
         <code>StreamsConfig</code> with the prefix

--- a/11/streams/developer-guide/manage-topics.html
+++ b/11/streams/developer-guide/manage-topics.html
@@ -84,7 +84,7 @@
       <p>
         Kafka Streams automatically creates internal repartitioning and changelog
         topics, and does <em>not</em> use broker auto-topic creation.
-        Therefore, internal topics take on the default broker configurations for
+        Therefore, internal topics do not take on the default broker configurations for
         new topics.
         You can override the default configs used when creating these topics by
         adding any configs from <code>TopicConfig</code> to your

--- a/20/streams/developer-guide/manage-topics.html
+++ b/20/streams/developer-guide/manage-topics.html
@@ -84,8 +84,10 @@
       <p>
         Kafka Streams automatically creates internal repartitioning and changelog
         topics, and does <em>not</em> use broker auto-topic creation.
-        Therefore, internal topics do not take on the default broker configurations for
-        new topics.
+        Therefore, internal topics do not take on all the default broker configurations for
+        new topics. In particular, <code>replication.factor</code> (which defaults to <code>1</code>),
+        <code>num.partitions</code>, and <code>cleanup.policy</code> do not respect broker configurations
+        fot automatically created topics.
         You can override the default configs used when creating these topics by
         adding any configs from <code>TopicConfig</code> to your
         <code>StreamsConfig</code> with the prefix

--- a/20/streams/developer-guide/manage-topics.html
+++ b/20/streams/developer-guide/manage-topics.html
@@ -84,7 +84,7 @@
       <p>
         Kafka Streams automatically creates internal repartitioning and changelog
         topics, and does <em>not</em> use broker auto-topic creation.
-        Therefore, internal topics take on the default broker configurations for
+        Therefore, internal topics do not take on the default broker configurations for
         new topics.
         You can override the default configs used when creating these topics by
         adding any configs from <code>TopicConfig</code> to your

--- a/21/streams/developer-guide/manage-topics.html
+++ b/21/streams/developer-guide/manage-topics.html
@@ -84,8 +84,10 @@
       <p>
         Kafka Streams automatically creates internal repartitioning and changelog
         topics, and does <em>not</em> use broker auto-topic creation.
-        Therefore, internal topics do not take on the default broker configurations for
-        new topics.
+        Therefore, internal topics do not take on all the default broker configurations for
+        new topics. In particular, <code>replication.factor</code> (which defaults to <code>1</code>),
+        <code>num.partitions</code>, and <code>cleanup.policy</code> do not respect broker configurations
+        fot automatically created topics.
         You can override the default configs used when creating these topics by
         adding any configs from <code>TopicConfig</code> to your
         <code>StreamsConfig</code> with the prefix

--- a/21/streams/developer-guide/manage-topics.html
+++ b/21/streams/developer-guide/manage-topics.html
@@ -84,7 +84,7 @@
       <p>
         Kafka Streams automatically creates internal repartitioning and changelog
         topics, and does <em>not</em> use broker auto-topic creation.
-        Therefore, internal topics take on the default broker configurations for
+        Therefore, internal topics do not take on the default broker configurations for
         new topics.
         You can override the default configs used when creating these topics by
         adding any configs from <code>TopicConfig</code> to your


### PR DESCRIPTION
Previous description says `Kafka Streams automatically creates internal repartitioning and changelog topics, and does not use broker auto-topic creation. Therefore, internal topics take on the default broker configurations for new topics.`
This is incorrect and self-conflicting. Because internal topics actually do not respect broker defaults for newly created topics.