### PR TITLE
Update site for 2.2.2 release

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -80,6 +80,28 @@
         For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.3.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
+    <span id="2.2.2"></span>
+    <h3 class="download-version">2.2.2<a href="#2.2.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+    <ul>
+        <li>
+            Released Dec 1, 2019
+        </li>
+        <li>
+            <a href="https://www.apache.org/dist/kafka/2.2.2/RELEASE_NOTES.html">Release Notes</a>
+        </li>
+        <li>
+            Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.2.2/kafka-2.2.2-src.tgz">kafka-2.2.2-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.2.2/kafka-2.2.2-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.2.2/kafka-2.2.2-src.tgz.sha512">sha512</a>)
+        </li>
+        <li>
+            Binary downloads:
+            <ul>
+                <li>Scala 2.11 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.2.2/kafka_2.11-2.2.2.tgz">kafka_2.11-2.2.2.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.2.2/kafka_2.11-2.2.2.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.2.2/kafka_2.11-2.2.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.2.2/kafka_2.12-2.2.2.tgz">kafka_2.12-2.2.2.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.2.2/kafka_2.12-2.2.2.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.2.2/kafka_2.12-2.2.2.tgz.sha512">sha512</a>)</li>
+            </ul>
+            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+        </li>
+    </ul>
+
     <span id="2.2.1"></span>
     <h3 class="download-version">2.2.1<a href="#2.2.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
     <ul>

--- a/downloads.html
+++ b/downloads.html
@@ -131,16 +131,16 @@
                 Released Mar 22, 2019
             </li>
             <li>
-                <a href="https://www.apache.org/dist/kafka/2.2.0/RELEASE_NOTES.html">Release Notes</a>
+                <a href="https://archive.apache.org/dist/kafka/2.2.0/RELEASE_NOTES.html">Release Notes</a>
             </li>
             <li>
-                Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.2.0/kafka-2.2.0-src.tgz">kafka-2.2.0-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz.sha512">sha512</a>)
+                Source download: <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz">kafka-2.2.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz.sha512">sha512</a>)
             </li>
             <li>
                 Binary downloads:
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.2.0/kafka_2.11-2.2.0.tgz">kafka_2.11-2.2.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.2.0/kafka_2.12-2.2.0.tgz">kafka_2.12-2.2.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz.sha512">sha512</a>)</li>
+                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz">kafka_2.11-2.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz.sha512">sha512</a>)</li>
+                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz">kafka_2.12-2.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz.sha512">sha512</a>)</li>
                 </ul>
                 We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
             </li>

--- a/index.html
+++ b/index.html
@@ -26,12 +26,12 @@
 					<time>Apr 27 - Apr 28, 2020</time>
 				</article>
 				<article>
-					<h3><a href="https://kafka.apache.org/downloads#2.3.1">AK Release 2.3.1</a></h3>
-					<time>October 24, 2019</time>
+					<h3><a href="https://kafka.apache.org/downloads#2.2.2">AK Release 2.2.2</a></h3>
+					<time>December 1, 2019</time>
 				</article>
 				<article>
-					<h3><a href="https://kafka.apache.org/downloads#2.2.1">AK Release 2.2.1</a></h3>
-					<time>June 1, 2019</time>
+					<h3><a href="https://kafka.apache.org/downloads#2.3.1">AK Release 2.3.1</a></h3>
+					<time>October 24, 2019</time>
 				</article>
 			</div>
 		</div>


### PR DESCRIPTION
Added the 2.2.2 release to the `downloads.html` page, updated the "Latest News" section on the `index.html` page to mention 2.2.2 rather than 2.2.1.

Also changed the 2.2.0 release links on the `downloads.html` page to use the archive links rather than the mirror links.