### PR TITLE
MINOR: Add fixes for adding new dsl naming page

### DIFF
--- a/24/documentation/streams/developer-guide/dsl-topology-naming.html
+++ b/24/documentation/streams/developer-guide/dsl-topology-naming.html
@@ -1,0 +1,19 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- should always link the latest release's documentation -->
+<!--#include virtual="../../../streams/developer-guide/dsl-topology-naming.html" -->

--- a/24/streams/developer-guide/index.html
+++ b/24/streams/developer-guide/index.html
@@ -43,6 +43,7 @@
 <li class="toctree-l1"><a class="reference internal" href="config-streams.html">Configuring a Streams Application</a></li>
 <li class="toctree-l1"><a class="reference internal" href="dsl-api.html">Streams DSL</a></li>
 <li class="toctree-l1"><a class="reference internal" href="processor-api.html">Processor API</a></li>
+<li class="toctree-l1"><a class="reference internal" href="dsl-topology-naming.html">Naming Operators in a Streams DSL application</a></li>
 <li class="toctree-l1"><a class="reference internal" href="datatypes.html">Data Types and Serialization</a></li>
 <li class="toctree-l1"><a class="reference internal" href="testing.html">Testing a Streams Application</a></li>
 <li class="toctree-l1"><a class="reference internal" href="interactive-queries.html">Interactive Queries</a></li>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../24/documentation.html" -->

--- a/documentation/streams/architecture.html
+++ b/documentation/streams/architecture.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../24/streams/architecture.html" -->

--- a/documentation/streams/core-concepts.html
+++ b/documentation/streams/core-concepts.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../24/streams/core-concepts.html" -->

--- a/documentation/streams/developer-guide/app-reset-tool.html
+++ b/documentation/streams/developer-guide/app-reset-tool.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/app-reset-tool.html" -->

--- a/documentation/streams/developer-guide/config-streams.html
+++ b/documentation/streams/developer-guide/config-streams.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/config-streams.html" -->

--- a/documentation/streams/developer-guide/datatypes.html
+++ b/documentation/streams/developer-guide/datatypes.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/datatypes.html" -->

--- a/documentation/streams/developer-guide/dsl-api.html
+++ b/documentation/streams/developer-guide/dsl-api.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/dsl-api.html" -->

--- a/documentation/streams/developer-guide/dsl-topology-naming.html
+++ b/documentation/streams/developer-guide/dsl-topology-naming.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/dsl-topology-naming.html" -->

--- a/documentation/streams/developer-guide/dsl-topology-naming.html
+++ b/documentation/streams/developer-guide/dsl-topology-naming.html
@@ -1,0 +1,2 @@
+<!-- should always link the the latest release's documentation -->
+<!--#include virtual="../../../24/streams/developer-guide/dsl-topology-naming.html" -->

--- a/documentation/streams/developer-guide/index.html
+++ b/documentation/streams/developer-guide/index.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/index.html" -->

--- a/documentation/streams/developer-guide/interactive-queries.html
+++ b/documentation/streams/developer-guide/interactive-queries.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/interactive-queries.html" -->

--- a/documentation/streams/developer-guide/manage-topics.html
+++ b/documentation/streams/developer-guide/manage-topics.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/manage-topics.html" -->

--- a/documentation/streams/developer-guide/memory-mgmt.html
+++ b/documentation/streams/developer-guide/memory-mgmt.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/memory-mgmt.html" -->

--- a/documentation/streams/developer-guide/processor-api.html
+++ b/documentation/streams/developer-guide/processor-api.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/processor-api.html" -->

--- a/documentation/streams/developer-guide/running-app.html
+++ b/documentation/streams/developer-guide/running-app.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/running-app.html" -->

--- a/documentation/streams/developer-guide/security.html
+++ b/documentation/streams/developer-guide/security.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/security.html" -->

--- a/documentation/streams/developer-guide/testing.html
+++ b/documentation/streams/developer-guide/testing.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/testing.html" -->

--- a/documentation/streams/developer-guide/write-streams.html
+++ b/documentation/streams/developer-guide/write-streams.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../../24/streams/developer-guide/write-streams.html" -->

--- a/documentation/streams/index.html
+++ b/documentation/streams/index.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../24/streams/index.html" -->

--- a/documentation/streams/quickstart.html
+++ b/documentation/streams/quickstart.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../24/streams/quickstart.html" -->

--- a/documentation/streams/upgrade-guide.html
+++ b/documentation/streams/upgrade-guide.html
@@ -1,2 +1,2 @@
-<!-- should always link the the latest release's documentation -->
+<!-- should always link the latest release's documentation -->
 <!--#include virtual="../../24/streams/upgrade-guide.html" -->


### PR DESCRIPTION
We needed to add the appropriate re-directs for the new topology naming page.  I've tested the links by rendering the site locally.