### PR TITLE
KAFKA-9574: Remove paragraph about searchable archive of the mailing lists

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -25,10 +25,6 @@
 		</ul>
 
 		<p>
-		A searchable archive of the mailing lists is available at <a href="http://search-hadoop.com/?project=Kafka">search-hadoop.com</a>.
-		</p>
-
-		<p>
 		To unsubscribe from any of these you just change the word "subscribe" to "unsubscribe" in the email adresses above.
 		</p>
 


### PR DESCRIPTION
See [KAFKA-9574](https://issues.apache.org/jira/browse/KAFKA-9574).