### PR TITLE
MINOR: update download links to point to ASF archive servers

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -86,17 +86,17 @@
             Released December 16, 2019
         </li>
         <li>
-            <a href="https://www.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.4.0/kafka-2.4.0-src.tgz">kafka-2.4.0-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz">kafka-2.4.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.11 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.4.0/kafka_2.11-2.4.0.tgz">kafka_2.11-2.4.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.4.0/kafka_2.12-2.4.0.tgz">kafka_2.12-2.4.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.4.0/kafka_2.13-2.4.0.tgz">kafka_2.13-2.4.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz">kafka_2.11-2.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz">kafka_2.12-2.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz">kafka_2.13-2.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
@@ -116,7 +116,7 @@
         <li>Administrative API for replica reassignment.</li>
     </ul>
     <p>
-        For more information, please read the detailed <a href="https://www.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html">Release Notes</a>.
+        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="2.3.1"></span>
@@ -152,16 +152,16 @@
             Released Jun 25, 2019
         </li>
         <li>
-            <a href="https://www.apache.org/dist/kafka/2.3.0/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/2.3.0/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.3.0/kafka-2.3.0-src.tgz">kafka-2.3.0-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz">kafka-2.3.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.11 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.3.0/kafka_2.11-2.3.0.tgz">kafka_2.11-2.3.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.3.0/kafka_2.12-2.3.0.tgz">kafka_2.12-2.3.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz">kafka_2.11-2.3.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz">kafka_2.12-2.3.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
         </li>


### PR DESCRIPTION
Call for review @mumrah 

There is 2.4.1 and 2.3.1, hence, 2.4.0 and 2.3.1 should point to the archive.