### PR TITLE
MINOR: Reorder the documentation sub-title to sync with the TOC

### DIFF
--- a/includes/_nav.htm
+++ b/includes/_nav.htm
@@ -10,13 +10,13 @@
         <a class="b-nav__docs nav__item nav__sub__anchor" href="/documentation">documentation</a>
         <a class="nav__item nav__sub__item" href="/documentation#gettingStarted">getting started</a>
         <a class="nav__item nav__sub__item" href="/documentation#api">APIs</a>
-        <a class="b-nav__streams nav__item nav__sub__item" href="/documentation/streams">kafka streams</a>
-        <a class="nav__item nav__sub__item" href="/documentation#connect">kafka connect</a>
         <a class="nav__item nav__sub__item" href="/documentation#configuration">configuration</a>
         <a class="nav__item nav__sub__item" href="/documentation#design">design</a>
         <a class="nav__item nav__sub__item" href="/documentation#implementation">implementation</a>
         <a class="nav__item nav__sub__item" href="/documentation#operations">operations</a>
         <a class="nav__item nav__sub__item" href="/documentation#security">security</a>
+        <a class="nav__item nav__sub__item" href="/documentation#connect">kafka connect</a>
+        <a class="b-nav__streams nav__item nav__sub__item" href="/documentation/streams">kafka streams</a>
       </div>
 
       <a class="b-nav__performance nav__item" href="/performance">performance</a>


### PR DESCRIPTION
current Table of Content(TOC) in navigation sidebar:
![image](https://user-images.githubusercontent.com/43372967/80948079-fabe5a80-8e23-11ea-9cc5-758fffcc63fa.png)

**TOC in the content:**
1. Getting Started
2. APIs
3. Configuration
4. Design
5. Implementation
6. Operations
7. Security
8. Kafka Connect
9. Kafka Streams

This change will sync them up.