### PR TITLE
MINOR: Add more info in the "adding to contributor list" section

### DIFF
--- a/contributing.html
+++ b/contributing.html
@@ -43,7 +43,7 @@
 
 		The easiest way to get started working with the code base is to pick up a really easy JIRA and work on that. This will help you get familiar with the code base, build system, review process, etc. We flag these kind of starter bugs <a href="https://issues.apache.org/jira/issues/?jql=project%20%3D%20KAFKA%20AND%20labels%20%3D%20newbie%20AND%20status%20%3D%20Open">here</a>.
 		<p>
-		Please contact us to be added the contributor list. After that you can assign yourself to the JIRA ticket you have started working on so others will notice.
+		Please contact us to be added the contributor list with your JIRA account username provided in the email. After that you can assign yourself to the JIRA ticket you have started working on so others will notice.
 		</p>
                 <p>
                 If your work is considered a "major change" then you would need to initiate a Kafka Improvement Proposal (KIP) along with the JIRA ticket (more details can be found <a href="https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Improvement+Proposals">here</a>). Please ask us to grant you the permission on wiki space in order to create a KIP wiki page.


### PR DESCRIPTION
We usually got this kind of email to request to be added into contributor list, but without JIRA username provided. That wasted the committer's or the existing contributor's time to do more explanation.  I found it's because we didn't provide enough information in the [How to contribute](https://kafka.apache.org/contributing) page. I added the info explicitly: **with your JIRA account username provided in the email** .

**example 1**
![image](https://user-images.githubusercontent.com/43372967/82968507-0c001e80-a000-11ea-89f2-99e1ce5650eb.png)

**example 2**
![image](https://user-images.githubusercontent.com/43372967/82968534-1cb09480-a000-11ea-9fc4-25638a1a05ed.png)
