### PR TITLE
MINOR: Make contact.html more clear

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -11,10 +11,10 @@
 		</p>
 		<ul>
 			<li>
-				<b>User mailing list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto:users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto:users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?users@kafka.apache.org">here</a>.
+				<b>User mailing list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto:users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, you can ask general user questions by mailing to <a href="mailto:users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?users@kafka.apache.org">here</a>.
 			</li>
 			<li>
-				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto:dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, send your emails to <a href="mailto:dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?dev@kafka.apache.org">here</a>.
+				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto:dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, you can have discussion on Kafka&reg; development by mailing to <a href="mailto:dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?dev@kafka.apache.org">here</a>.
 			</li>
 			<li>
 				<b>JIRA mailing list</b>: A list to track Kafka&reg; <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto:jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?jira@kafka.apache.org">here</a>.


### PR DESCRIPTION
In our `contact us` page, we said:
> To subscribe, send an email to users-subscribe@kafka.apache.org. Once subscribed, send your emails to users@kafka.apache.org.

which will confuse users to let them send their **email address** to users@kafka.apache.org, as below mailing thread showed.

![image](https://user-images.githubusercontent.com/43372967/84001508-59ce3c80-a999-11ea-8703-3afee40a9310.png)

Rephrase this sentence to make it more clear:
![image](https://user-images.githubusercontent.com/43372967/84001869-16280280-a99a-11ea-9c32-054ed745bc8a.png)

