### PR TITLE
MINOR: Fix table of contents in protocol page

### DIFF
--- a/24/protocol.html
+++ b/24/protocol.html
@@ -44,11 +44,6 @@
             <li><a href="#protocol_recordbatch">Record Batch</a>
         </ul>
     </li>
-    <li><a href="#protocol_evolution">Evolving the Protocol</a>
-        <ul>
-            <li><a href="#protocol_versioning">The Request Header</a>
-            <li><a href="#protocol_versioning">Versioning</a>
-        </ul>
     <li><a href="#protocol_constants">Constants</a>
         <ul>
             <li><a href="#protocol_error_codes">Error Codes</a>

--- a/25/protocol.html
+++ b/25/protocol.html
@@ -44,11 +44,6 @@
             <li><a href="#protocol_recordbatch">Record Batch</a>
         </ul>
     </li>
-    <li><a href="#protocol_evolution">Evolving the Protocol</a>
-        <ul>
-            <li><a href="#protocol_versioning">The Request Header</a>
-            <li><a href="#protocol_versioning">Versioning</a>
-        </ul>
     <li><a href="#protocol_constants">Constants</a>
         <ul>
             <li><a href="#protocol_error_codes">Error Codes</a>


### PR DESCRIPTION
I deleted a part of the table of contents in protocol.html because this page doesn't seem to contain "Evolving the Protocol" section.
https://kafka.apache.org/protocol.html#protocol_evolution

![スクリーンショット 2020-07-05 17 24 09](https://user-images.githubusercontent.com/3250247/86528591-7c923900-bee4-11ea-907b-0a24f9afcea5.png)