### PR TITLE
KAFKA-10222:Incorrect methods show up in 0.10 Kafka Streams docs

### DIFF
--- a/0100/javadoc/org/apache/kafka/streams/KafkaStreams.html
+++ b/0100/javadoc/org/apache/kafka/streams/KafkaStreams.html
@@ -130,7 +130,7 @@ extends <a href="http://docs.oracle.com/javase/7/docs/api/java/lang/Object.html?
     StreamsConfig config = new StreamsConfig(props);
 
     KStreamBuilder builder = new KStreamBuilder();
-    builder.from("my-input-topic").mapValue(value -&gt; value.length().toString()).to("my-output-topic");
+    builder.stream("my-input-topic").mapValues(value -&gt; value.length().toString()).to("my-output-topic");
 
     KafkaStreams streams = new KafkaStreams(builder, config);
     streams.start();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-10222

Non-existent methods show up in the doc:
_builder.from("my-input-topic").mapValue(value -> value.length().toString()).to("my-output-topic");_

There is no method named `from` or `mapValues`. They should be `stream` and `mapValues` respectively.