### PR TITLE
MINOR: Change the arrow direction based on the view state is expanded or not

### DIFF
--- a/includes/_footer.htm
+++ b/includes/_footer.htm
@@ -329,7 +329,13 @@
 				var docsHandle = document.querySelector('.toc-handle');
 
 				function toggleDocsWidth() {
-					docsContainer.classList.toggle('expanded');
+					let isExpanded = docsContainer.classList.toggle('expanded');
+					// change the arrow direction based on the view state is expanded or not
+					if (isExpanded) {
+						docsHandle.textContent = ">";
+					} else {
+						docsHandle.textContent = "<";
+					}
 				}
 
 				docsHandle.addEventListener('click', toggleDocsWidth);


### PR DESCRIPTION
Change the arrow direction based on the view state is expanded or not. We can identify it's in expanded mode or not by checking the return value of toggle method. Reference: https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/toggle

![image](https://user-images.githubusercontent.com/43372967/89490258-00d72500-d7df-11ea-8582-8bae5005a21e.png)



![image](https://user-images.githubusercontent.com/43372967/89490628-dcc81380-d7df-11ea-8335-8c4551253790.png)


**after my fix when expanded**
![image](https://user-images.githubusercontent.com/43372967/89490949-ab9c1300-d7e0-11ea-8d68-528d59b7359d.png)


