### PR TITLE
MINOR: Fix the wrong doc path and missing zk/docker button in quickstart page

### DIFF
--- a/quickstart.html
+++ b/quickstart.html
@@ -16,10 +16,18 @@
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
         </iframe>
       </div>
-      
+
+      <ul class="page-header-nav">
+        <li class="page-header-nav-item">
+          <a href="/quickstart" class="page-header-nav-item-anchor current">Zookeeper</a>
+        </li>
+        <li class="page-header-nav-item">
+          <a href="/quickstart-docker" class="page-header-nav-item-anchor">Docker</a>
+        </li>
+      </ul>
     </div>
 <!-- should always link the the latest release's documentation -->
-    <!--#include virtual="26/quickstart-zookeeper.html" -->
+    <!--#include virtual="25/quickstart-zookeeper.html" -->
 <!--#include virtual="includes/_footer.htm" -->
 <script>
 // Show selected style on nav item


### PR DESCRIPTION
1. In quickstart page, we should see the zookeeper and docker button for user to select, just like the `quickstart-docker` page showed: https://kafka.apache.org/quickstart-docker

<img width="885" alt="image" src="https://user-images.githubusercontent.com/43372967/89634859-a621f400-d8d8-11ea-86b8-061274530ce2.png">

2. In quickstart page, we'll see the following error message displayed. After investigation, I found it's because we point to the wrong document `26/quickstart-zookeeper.html`. Change to the correct name `25/quickstart-zookeeper.html` to fix it.

<img width="871" alt="image" src="https://user-images.githubusercontent.com/43372967/89632898-905eff80-d8d5-11ea-9849-e70095ad5d4b.png">
