### PR TITLE
MINOR: Fix the broken past-events link

### DIFF
--- a/25/quickstart-zookeeper.html
+++ b/25/quickstart-zookeeper.html
@@ -267,7 +267,7 @@ wordCounts.toStream().to("output-topic"), Produced.with(Serdes.String(), Serdes.
         -->
         <li>
             Join a <a href="/events">local Kafka meetup group</a> and
-            <a href="/past-events">watch talks from Kafka Summit</a>,
+            <a href="https://kafka-summit.org/past-events/">watch talks from Kafka Summit</a>,
             the main conference of the Kafka community.
         </li>
     </ul>

--- a/26/quickstart-zookeeper.html
+++ b/26/quickstart-zookeeper.html
@@ -267,7 +267,7 @@ wordCounts.toStream().to("output-topic"), Produced.with(Serdes.String(), Serdes.
         -->
         <li>
             Join a <a href="/events">local Kafka meetup group</a> and
-            <a href="/past-events">watch talks from Kafka Summit</a>,
+            <a href="https://kafka-summit.org/past-events/">watch talks from Kafka Summit</a>,
             the main conference of the Kafka community.
         </li>
     </ul>


### PR DESCRIPTION
Fix the broken past-events link. It should be in the `kafka-summit.org` domain, not under `kafka.apache.org`.