### PR TITLE
MINOR: Fix the corrupted html content

### DIFF
--- a/26/design.html
+++ b/26/design.html
@@ -515,7 +515,10 @@
     <p>
     <img class="centered" src="/{{version}}/images/log_compaction.png">
     <p>
-    $1 class="anchor-heading"><a id="$4" class="anchor-link"></a><a href="#$4">$8$9$10
+    <h4 class="anchor-heading">
+        <a class="anchor-link" id="design_compactionguarantees" href="#design_compactionguarantees"></a>
+        <a href="#design_compactionguarantees">What guarantees does log compaction provide</a>?
+    </h4>
 
     Log compaction guarantees the following:
     <ol>
@@ -578,7 +581,10 @@
     </ol>
     </p>
 
-    $1 class="anchor-heading"><a id="$4" class="anchor-link"></a><a href="#$4">$8$9$10
+    <h4 class="anchor-heading">
+        <a class="anchor-link" id="design_quotasnecessary" href="#design_quotasnecessary"></a>
+        <a href="#design_quotasnecessary">Why are quotas necessary</a>?
+    </h4>
     <p>
     It is possible for producers and consumers to produce/consume very high volumes of data or generate requests at a very high
     rate and thus monopolize broker resources, cause network saturation and generally DOS other clients and the brokers themselves.


### PR DESCRIPTION
Fix the corrupted html content by referring to the `25/design.html` html content.


![image](https://user-images.githubusercontent.com/43372967/89982013-83f8ef00-dca7-11ea-9bce-527a2bc0847d.png)


![image](https://user-images.githubusercontent.com/43372967/89982122-b276ca00-dca7-11ea-89f1-30f596de09e7.png)
