### PR TITLE
MINOR: remove unreleased versions from CVE page

### DIFF
--- a/cve-list.html
+++ b/cve-list.html
@@ -19,7 +19,7 @@ connector configuration property value (the externalized secret variable is not 
 whole configuration property value), then any client can issue a request to 
 the same Connect cluster to obtain the connector's task configurations and 
 the response will contain the plaintext secret rather than the externalized secrets variable.
-Users should upgrade to 2.0.2 or higher, 2.1.2 or higher, 2.2.2 or higher, or 2.3.1 or higher
+Users should upgrade to 2.2.2 or higher, or 2.3.1 or higher
 where this vulnerability has been fixed.</p>
 
 <table class="data-table">
@@ -30,7 +30,7 @@ where this vulnerability has been fixed.</p>
   </tr>
   <tr>
     <td>Fixed versions</td>
-    <td>2.0.2, 2.1.2, 2.2.2, 2.3.1 and later</td>
+    <td>2.2.2, 2.3.1 and later</td>
   </tr>
   <tr>
     <td>Impact</td>


### PR DESCRIPTION
As reported on the mailing list: https://lists.apache.org/list.html?dev@kafka.apache.org:lte=1M:cve%202.0.2%202.1.2

Call for review @ijuma 