### PR TITLE
Add the best talks from Kafka Summit 2020

### DIFF
--- a/videos.html
+++ b/videos.html
@@ -14,6 +14,18 @@
         conferences from 2018 onwards. Thanks to all the speakers for their hard work!
       </p>
 
+      <hr />
+      <p>
+      <strong>TABLE OF CONTENTS</strong>
+      <ul>
+        <li><a href="#kafka_internals_fundamentals">Kafka Internals and Fundamentals</a></li>
+        <li><a href="#applications_use_cases">Applications and Use Cases</a></li>
+        <li><a href="#architecture_patterns">Architecture and Patterns</a></li>
+        <li><a href="#data_pipelines">Data Pipelines</a></li>
+        <li><a href="#kafka_operations">Kafka Operations</a></li>
+      </ul>
+      </p>
+      <hr />
 
       <h4 class="anchor-heading">
         <a class="anchor-link" id="kafka_internals_fundamentals" href="#kafka_internals_fundamentals"></a>

--- a/videos.html
+++ b/videos.html
@@ -5,1788 +5,560 @@
   <div class="content content-home">
     <!--#include virtual="includes/_nav.htm" -->
     <section>
+
       <h1>Best Kafka Summit Videos</h1>
+
       <p>
-        The following talks, with video recordings and slides available,
-        achieved the best ratings by the community at the
-        <a href="https://kafka-summit.org/" rel="noopener noreferrer nofollow" target="_blank">
-          Kafka Summit
-        </a>
-        conferences from 2018 onwards. Thanks to all the speakers for their hard
-        work!
+        The following talks, with video recordings and slides available, achieved the best ratings by the community at
+        the <a href="https://kafka-summit.org/" rel="noopener noreferrer nofollow" target="_blank">Kafka Summit</a>
+        conferences from 2018 onwards. Thanks to all the speakers for their hard work!
       </p>
-      <h4 class="c9" id="h.28sj93j7rek1">
-        <span>Kafka Internals and Fundamentals</span>
-      </h4>
-      <ul class="c8 lst-kix_leuhnadg5dfu-0 start">
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-needs-no-keeper/"
-              >Kafka Needs no (Zoo)Keeper</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-needs-no-keeper/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Jason Gustafson & Colin McCabe (Confluent), SFO 2019</span
-          >
+
+
+      <h4 id="h.28sj93j7rek1">Kafka Internals and Fundamentals</h4>
+
+      <ul>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-needs-no-keeper/">Kafka Needs no (Zoo)Keeper</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-needs-no-keeper/">abstract</a>),
+          Jason Gustafson &amp; Colin McCabe (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/stop-world-can-change-design-implementation-incremental-cooperative-rebalancing/"
-              >Why Stop the World When you Can Change it? Design and
-              Implementation of Incremental Cooperative Rebalancing</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/stop-world-can-change-design-implementation-incremental-cooperative-rebalancing/"
-              >abstract</a
-            ></span
-          ><span class="c2">),</span
-          ><span class="c4 c2"
-            >&nbsp;Konstantine Karantasis (Confluent), SFO 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://kafka-summit.org/sessions/stop-world-can-change-design-implementation-incremental-cooperative-rebalancing/">Why Stop the World When you Can Change it? Design and Implementation of Incremental Cooperative Rebalancing</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/stop-world-can-change-design-implementation-incremental-cooperative-rebalancing/" >abstract</a>),
+          Konstantine Karantasis (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-102-streams-and-tables-all-the-way-down/"
-              >Kafka 102: Streams and Tables All the Way Down</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-102-streams-tables-way/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2">, Michael G. Noll (Confluent), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-102-streams-and-tables-all-the-way-down/">Kafka 102: Streams and Tables All the Way Down</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-102-streams-tables-way/">abstract</a>),
+          Michael G. Noll (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/whats-the-time-and-why"
-              >What&rsquo;s the time? &hellip;and why?</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/whats-the-time-and-why/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Matthias J. Sax (Confluent), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/whats-the-time-and-why">What&rsquo;s the time? &hellip;and why?</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/whats-the-time-and-why/">abstract</a>),
+          Matthias J. Sax (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/zen-and-the-art-of-streaming-joins/"
-              >Zen and the Art of Streaming Joins: The What, When and Why</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/zen-art-streaming-joins/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Nick Dearden (Confluent), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/zen-and-the-art-of-streaming-joins/">Zen and the Art of Streaming Joins: The What, When and Why</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/zen-art-streaming-joins/">abstract</a>),
+          Nick Dearden (Confluent), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/exactly-once-semantics-revisted"
-              >Exactly Once Semantics Revisited</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/exactly-semantics-revisited/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Jason Gustafson (Confluent), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/exactly-once-semantics-revisted">Exactly Once Semantics Revisited</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/exactly-semantics-revisited/">abstract</a>),
+          Jason Gustafson (Confluent), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/performance-analysis-optimizations-kafka-streams-applications/"
-              >Performance Analysis and Optimizations for Kafka Streams
-              Applications</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/performance-analysis-optimizations-kafka-streams-applications/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Guozhang Wang (Confluent), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/performance-analysis-optimizations-kafka-streams-applications/">Performance Analysis and Optimizations for Kafka Streams Applications</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/performance-analysis-optimizations-kafka-streams-applications/">abstract</a>),
+          Guozhang Wang (Confluent), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/everything-you-wanted-to-know-kafka-afraid/"
-              >Everything You Always Wanted to Know About Kafka&rsquo;s
-              Rebalance Protocol but Were Afraid to Ask</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/everything-know-kafkas-rebalance-protocol-afraid-ask/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Matthias J. Sax (Confluent), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/everything-you-wanted-to-know-kafka-afraid/">Everything You Always Wanted to Know About Kafka&rsquo;s Rebalance Protocol but Were Afraid to Ask</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/everything-know-kafkas-rebalance-protocol-afraid-ask/">abstract</a>),
+          Matthias J. Sax (Confluent), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/reliable-message-delivery-with-apache-kafka/"
-              >Reliable Message Delivery with Apache Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/reliable-message-delivery-apache-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Ying Zheng & Xiaobing Li (Uber), SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/reliable-message-delivery-with-apache-kafka/">Reliable Message Delivery with Apache Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/reliable-message-delivery-apache-kafka/">abstract</a>),
+          Ying Zheng &amp; Xiaobing Li (Uber), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/hardening-kafka-replication/"
-              >Hardening Kafka Replication</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/hardening-kafka-replication/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Jason Gustafson (Confluent), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/hardening-kafka-replication/">Hardening Kafka Replication</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/hardening-kafka-replication/">abstract</a>),
+          Jason Gustafson (Confluent), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-london18/dont-repeat-yourself-introducing-exactly-once-semantics-in-apache-kafka/"
-              >Don&rsquo;t Repeat Yourself: Introducing Exactly-Once Semantics
-              in Apache Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/dont-repeat-introducing-exactly-semantics-apache-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Matthias J. Sax (Confluent), LON 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-london18/dont-repeat-yourself-introducing-exactly-once-semantics-in-apache-kafka/">Don&rsquo;t Repeat Yourself: Introducing Exactly-Once Semantics in Apache Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/dont-repeat-introducing-exactly-semantics-apache-kafka/">abstract</a>),
+          Matthias J. Sax (Confluent), LON 2018
         </li>
       </ul>
-      <h4 class="c9" id="h.e1o0run8si2r">
-        <span class="c14 c6">Applications & Use Cases</span>
-      </h4>
-      <ul class="c8 lst-kix_blvf9kd9te8i-0 start">
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/0-60-teslas-streaming-data-platform/"
-              >0-60: Tesla&rsquo;s Streaming Data Platform</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/0-60-teslas-streaming-data-platform/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Jesse Yates (Tesla), SFO 2019</span>
+
+
+      <h4 id="h.e1o0run8si2r">Applications and Use Cases</h4>
+      <ul>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/0-60-teslas-streaming-data-platform/">0-60: Tesla&rsquo;s Streaming Data Platform</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/0-60-teslas-streaming-data-platform/">abstract</a>),
+          Jesse Yates (Tesla), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/eventing-things-a-netflix-original/"
-              >Eventing Things &ndash; A Netflix Original!</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/eventing-things-netflix-original/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Nitin Sharma (Netflix), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/eventing-things-a-netflix-original/">Eventing Things &ndash; A Netflix Original!</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/eventing-things-netflix-original/">abstract</a>),
+          Nitin Sharma (Netflix), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/mission-critical-real-time-fault-detection-for-nasas-deep-space-network-using-apache-kafka/"
-              >Mission-Critical, Real-Time Fault-Detection for NASA&rsquo;s Deep
-              Space Network using Apache Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/mission-critical-real-time-fault-detection-nasas-deep-space-network-using-apache-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2"
-            >, Rishi Verma (NASA Jet Propulsion Laboratory), SFO 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/mission-critical-real-time-fault-detection-for-nasas-deep-space-network-using-apache-kafka/">Mission-Critical, Real-Time Fault-Detection for NASA&rsquo;s Deep Space Network using Apache Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/mission-critical-real-time-fault-detection-nasas-deep-space-network-using-apache-kafka/">abstract</a>),
+          Rishi Verma (NASA Jet Propulsion Laboratory), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/using-kafka-to-discover-events-hidden-in-your-database/"
-              >Using Kafka to Discover Events Hidden in your Database</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/using-kafka-discover-events-hidden-database/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2">, Anna McDonald (SAS Institute), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/using-kafka-to-discover-events-hidden-in-your-database/">Using Kafka to Discover Events Hidden in your Database</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/using-kafka-discover-events-hidden-database/">abstract</a>),
+          Anna McDonald (SAS Institute), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/building-an-enterprise-eventing-framework/"
-              >Building an Enterprise Eventing Framework</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/building-enterprise-eventing-framework/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2"
-            >, Bryan Zelle (Centene) & Neil Buesing (Object Partners, Inc), SFO
-            2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/building-an-enterprise-eventing-framework/">Building an Enterprise Eventing Framework</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/building-enterprise-eventing-framework/">abstract</a>),
+          Bryan Zelle (Centene) &amp; Neil Buesing (Object Partners, Inc), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/ksql-performance-tuning-for-fun-and-profit/"
-              >ksqlDB Performance Tuning for Fun and Profit</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/ksql-performance-tuning-fun-profit/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2">, Nick Dearden (Confluent), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/ksql-performance-tuning-for-fun-and-profit/">ksqlDB Performance Tuning for Fun and Profit</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/ksql-performance-tuning-fun-profit/">abstract</a>),
+          Nick Dearden (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/discovering-drugs-with-kafka-streams/"
-              >Discovering Drugs with Kafka Streams</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/discovering-drugs-kafka-streams/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Ben Mabey & Scott Nielsen (Recursion Pharmaceutical), SFO
-            2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/discovering-drugs-with-kafka-streams/">Discovering Drugs with Kafka Streams</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/discovering-drugs-kafka-streams/">abstract</a>),
+          Ben Mabey & Scott Nielsen (Recursion Pharmaceutical), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/being-an-apache-kafka-developer-hero-in-the-world-of-cloud/"
-              >Being an Apache Kafka Developer Hero in the World of Cloud</a
-            ></span
-          ><span class="c4 c2">, Ricardo Ferreira (Confluent), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/being-an-apache-kafka-developer-hero-in-the-world-of-cloud/">Being an Apache Kafka Developer Hero in the World of Cloud</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/developer-hero-cloud/">abstract</a>),
+          Ricardo Ferreira (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/streaming-apps-and-poison-pills-handle-the-unexpected-with-kafka-streams/"
-              >Streaming Apps and Poison Pills: handle the unexpected with Kafka
-              Streams</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/streaming-apps-poison-pills-handle-unexpected-kafka-streams/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Loic Divad (Xebia France), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/streaming-apps-and-poison-pills-handle-the-unexpected-with-kafka-streams/">Streaming Apps and Poison Pills: handle the unexpected with Kafka Streams</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/streaming-apps-poison-pills-handle-unexpected-kafka-streams/">abstract</a>),
+          Loic Divad (Xebia France), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/scaling-for-indias-cricket-hungry-population/"
-              >Scaling for India&#39;s Cricket Hungry Population</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/scaling-indias-cricket-hungry-population/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Bhavesh Raheja & Namit Mahuvakar (Hotstar), SFO 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/scaling-for-indias-cricket-hungry-population/">Scaling for India&#39;s Cricket Hungry Population</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/scaling-indias-cricket-hungry-population/">abstract</a>),
+          Bhavesh Raheja &amp; Namit Mahuvakar (Hotstar), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/leveraging-services-in-stream-processor-apps-at-ticketmaster/"
-              >Leveraging Services in Stream Processor Apps at Ticketmaster</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/leveraging-services-stream-processor-apps-ticketmaster/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Derek Cline (Ticketmaster), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/leveraging-services-in-stream-processor-apps-at-ticketmaster/">Leveraging Services in Stream Processor Apps at Ticketmaster</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/leveraging-services-stream-processor-apps-ticketmaster/">abstract</a>),
+          Derek Cline (Ticketmaster), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/stream-processing-with-the-spring-framework/"
-              >Stream Processing with the Spring Framework (Like You&rsquo;ve
-              Never Seen It Before)</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/stream-processing-spring-framework-like-youve-never-seen/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Josh Long (Pivotal), Tim Berglund (Confluent), NYC 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/stream-processing-with-the-spring-framework/">Stream Processing with the Spring Framework (Like You&rsquo;ve Never Seen It Before)</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/stream-processing-spring-framework-like-youve-never-seen/">abstract</a>),
+          Josh Long (Pivotal), Tim Berglund (Confluent), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/use-kafka-and-druid-to-tame-router-data"
-              >How To Use Apache Kafka and Druid to Tame Your Router Data</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/use-kafka-druid-tame-router-data/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Rachel Pedreschi (Imply Data), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/use-kafka-and-druid-to-tame-router-data">How To Use Apache Kafka and Druid to Tame Your Router Data</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/use-kafka-druid-tame-router-data/">abstract</a>),
+          Rachel Pedreschi (Imply Data), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/using-tools-migrating-kafka-streams/"
-              >Kafka Connect and ksqlDB: Useful Tools in Migrating from a Legacy
-              System to Kafka Streams</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-connect-ksql-useful-weapons-migrating-heterogeneous-legacy-system-kafka-streams/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Alex Leung & Danica Fine (Bloomberg L.P.), NYC 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/using-tools-migrating-kafka-streams/">Kafka Connect and ksqlDB: Useful Tools in Migrating from a Legacy System to Kafka Streams</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-connect-ksql-useful-weapons-migrating-heterogeneous-legacy-system-kafka-streams/">abstract</a>),
+          Alex Leung &amp; Danica Fine (Bloomberg L.P.), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/building-serverless-apps-with-kafka/"
-              >Building Serverless Apps with Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/building-serverless-apps-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Dale Lane (IBM), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/building-serverless-apps-with-kafka/">Building Serverless Apps with Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/building-serverless-apps-kafka/">abstract</a>),
+          Dale Lane (IBM), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/introducing-events-stream-processing-nationwide-building-society/"
-              >Introducing Events and Stream Processing into Nationwide Building
-              Society</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/introducing-events-stream-processing-nationwide-building-society/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Robert Jackson & Pete Cracknell (Nationwide Building Society),
-            LON 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/introducing-events-stream-processing-nationwide-building-society/">Introducing Events and Stream Processing into Nationwide Building Society</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/introducing-events-stream-processing-nationwide-building-society/">abstract</a>),
+          Robert Jackson &amp; Pete Cracknell (Nationwide Building Society), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/exciting-frontier-custom-ksql-functions/"
-              >The Exciting Frontier of Custom ksqlDB Functions</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/exciting-frontier-custom-ksql-functions/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Mitch Seymour (Mailchimp), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/exciting-frontier-custom-ksql-functions/">The Exciting Frontier of Custom ksqlDB Functions</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/exciting-frontier-custom-ksql-functions/">abstract</a>),
+          Mitch Seymour (Mailchimp), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/using-location-data-showcase-keys-windows-joins/"
-              >Using Location Data to Showcase Keys, Windows, and Joins in Kafka
-              Streams DSL and ksqlDB</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/using-location-data-showcase-keys-windows-joins-kafka-streams-dsl-ksql/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Neil Buesing (Object Partners, Inc), LON 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/using-location-data-showcase-keys-windows-joins/">Using Location Data to Showcase Keys, Windows, and Joins in Kafka Streams DSL and ksqlDB</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/using-location-data-showcase-keys-windows-joins-kafka-streams-dsl-ksql/">abstract</a>),
+          Neil Buesing (Object Partners, Inc), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/ksql-in-practice/"
-              >ksqlDB in Practice</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/ksql-in-practice/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Almog Gavra (Confluent), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/ksql-in-practice/">ksqlDB in Practice</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/ksql-in-practice/">abstract</a>),
+          Almog Gavra (Confluent), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/industry-ready-nlp-service-framework-kafka/"
-              >Industry-ready NLP Service Framework Based on Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/industry-ready-nlp-service-framework-based-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Bernhard Waltl & Georg Bonczek (BMW Group), LON 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/industry-ready-nlp-service-framework-kafka/">Industry-ready NLP Service Framework Based on Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/industry-ready-nlp-service-framework-based-kafka/">abstract</a>),
+          Bernhard Waltl &amp; Georg Bonczek (BMW Group), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/data-streaming-ecosystem-management/"
-              >Data Streaming Ecosystem Management at Booking.com</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/data-streaming-ecosystem-management-booking-com/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Alex Mironov (Booking.com), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/data-streaming-ecosystem-management/">Data Streaming Ecosystem Management at Booking.com</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/data-streaming-ecosystem-management-booking-com/">abstract</a>),
+          Alex Mironov (Booking.com), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/kafka-in-the-enterprise/"
-              >Kafka in the Enterprise&mdash;A Two-Year Journey to Build a Data
-              Streaming Platform from Scratch</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-enterprise-two-year-journey-build-data-streaming-platform-scratch/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Benny Lee & Christopher Arthur (Commonwealth Bank of Australia),
-            SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/kafka-in-the-enterprise/">Kafka in the Enterprise&mdash;A Two-Year Journey to Build a Data Streaming Platform from Scratch</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-enterprise-two-year-journey-build-data-streaming-platform-scratch/">abstract</a>),
+          Benny Lee &amp; Christopher Arthur (Commonwealth Bank of Australia), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/life-is-a-stream-of-events/"
-              >Life is a Stream of Events</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/life-stream-events/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Bj&oslash;rn Kvernstuen & Tommy Jocumsen (Norwegian Directorate
-            for Work and Welfare), SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/life-is-a-stream-of-events/">Life is a Stream of Events</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/life-stream-events/">abstract</a>),
+          Bj&oslash;rn Kvernstuen &amp; Tommy Jocumsen (Norwegian Directorate for Work and Welfare), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/kafka-multi-tenancy/"
-              >Kafka Multi-Tenancy&mdash;160 Billion Daily Messages on One
-              Shared Cluster at LINE</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-multi-tenancy-160-billion-daily-messages-one-shared-cluster-line/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Yuto Kawamura (LINE Corporation, SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/kafka-multi-tenancy/">Kafka Multi-Tenancy&mdash;160 Billion Daily Messages on One Shared Cluster at LINE</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-multi-tenancy-160-billion-daily-messages-one-shared-cluster-line/">abstract</a>),
+          Yuto Kawamura (LINE Corporation), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/matching-the-scale-at-tinder-with-kafka/"
-              >Matching the Scale at Tinder with Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/matching-scale-tinder-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Krunal Vora (Tinder), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/matching-the-scale-at-tinder-with-kafka/">Matching the Scale at Tinder with Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/matching-scale-tinder-kafka/">abstract</a>),
+          Krunal Vora (Tinder), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-SF18/building-an-enterprise-streaming-platform-capital-one/"
-              >Building an Enterprise Streaming Platform at Capital One</a
-            ></span
-          ><span class="c4 c2"
-            >, Chris D&#39;Agostino (Capital One), SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-SF18/building-an-enterprise-streaming-platform-capital-one/">Building an Enterprise Streaming Platform at Capital One</a>,
+          Chris D&#39;Agostino (Capital One), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/more_data_more_problems/"
-              >More Data, More Problems: Scaling Kafka-Mirroring Pipelines at
-              LinkedIn</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/data-problems-scaling-kafka-mirroring-pipelines-linkedin/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2">, Celia Kung (LinkedIn), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/more_data_more_problems/">More Data, More Problems: Scaling Kafka-Mirroring Pipelines at LinkedIn</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/data-problems-scaling-kafka-mirroring-pipelines-linkedin/">abstract</a>),
+          Celia Kung (LinkedIn), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/from-propeller-to-jet/"
-              >From Propeller to Jet: Upgrading Your Engines Mid-Flight</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/propeller-jet-upgrading-engines-mid-flight/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Christopher Morris (PagerDuty), SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/from-propeller-to-jet/">From Propeller to Jet: Upgrading Your Engines Mid-Flight</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/propeller-jet-upgrading-engines-mid-flight/">abstract</a>),
+          Christopher Morris (PagerDuty), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/a-visual-approach-to-understanding-streaming-sql/"
-              >A Visual Approach to Understanding Streaming SQL</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/visual-approach-understanding-streaming-sql/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2">, Shant Hovespian (Arcadia Data), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/a-visual-approach-to-understanding-streaming-sql/">A Visual Approach to Understanding Streaming SQL</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/visual-approach-understanding-streaming-sql/">abstract</a>),
+          Shant Hovespian (Arcadia Data), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/digital-transformation-in-healthcare-with-kakfa/"
-              >Digital Transformation in Healthcare with Kafka&mdash;Building a
-              Low Latency Data Pipeline</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/digital-transformation-healthcare-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2"
-            >, Dmitry Milman & Ankur Kaneria (Express Scripts), SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/digital-transformation-in-healthcare-with-kakfa/">Digital Transformation in Healthcare with Kafka&mdash;Building a Low Latency Data Pipeline</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/digital-transformation-healthcare-kafka/">abstract</a>),
+          Dmitry Milman &amp; Ankur Kaneria (Express Scripts), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/building-pinterest-real-time-ads-platform-using-kafka-streams/"
-              >Building Pinterest Real-Time Ads Platform Using Kafka Streams</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/building-pinterest-realtime-ads-platform-using-kafka-streams/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2"
-            >, Liquan Pei & Boyang Chen (Pinterest), SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/building-pinterest-real-time-ads-platform-using-kafka-streams/">Building Pinterest Real-Time Ads Platform Using Kafka Streams</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/building-pinterest-realtime-ads-platform-using-kafka-streams/">abstract</a>),
+          Liquan Pei &amp; Boyang Chen (Pinterest), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-london18/taking-stateful-stream-processing-to-the-next-level-with-kafka-and-flink/"
-              >Taking Stateful Stream Processing to the Next Level with Kafka
-              and Flink</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/taking-stateful-stream-processing-to-next-level/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Stephan Ewen (Ververica), LON 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-london18/taking-stateful-stream-processing-to-the-next-level-with-kafka-and-flink/">Taking Stateful Stream Processing to the Next Level with Kafka and Flink</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/taking-stateful-stream-processing-to-next-level/">abstract</a>),
+          Stephan Ewen (Ververica), LON 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-london18/taming-billions-of-metrics-and-logs-at-scale-two-years-with-kafka-as-a-central-data-hub-for-monitoring-at-cern/"
-              >Taming Billions of Metrics and Logs at Scale: Two Years with
-              Kafka as a Central Data Hub for Monitoring at CERN</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/taming-billions-metrics-logs-scale-two-years-kafka-central-data-hub-monitoring-cern/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Luca Magnoni (CERN), LON 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-london18/taming-billions-of-metrics-and-logs-at-scale-two-years-with-kafka-as-a-central-data-hub-for-monitoring-at-cern/">Taming Billions of Metrics and Logs at Scale: Two Years with Kafka as a Central Data Hub for Monitoring at CERN</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/taming-billions-metrics-logs-scale-two-years-kafka-central-data-hub-monitoring-cern/">abstract</a>),
+          Luca Magnoni (CERN), LON 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-london18/ksql-201-a-deep-dive-into-query-processing/"
-              >ksqlDB 201: A Deep Dive into Query Processing</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/ksql-201-a-deep-dive-into-query-processing/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Hojjat Jafarpour (Confluent), LON 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-london18/ksql-201-a-deep-dive-into-query-processing/">ksqlDB 201: A Deep Dive into Query Processing</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/ksql-201-a-deep-dive-into-query-processing/">abstract</a>),
+          Hojjat Jafarpour (Confluent), LON 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-london18/the-evolution-of-kafka-at-ing-bank/"
-              >The Evolution of Kafka at ING Bank</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/the-evolution-of-kafka-at-ing-bank/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Timor Timuri & Richard Bras (ING), LON 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-london18/the-evolution-of-kafka-at-ing-bank/">The Evolution of Kafka at ING Bank</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/the-evolution-of-kafka-at-ing-bank/">abstract</a>),
+          Timor Timuri &amp; Richard Bras (ING), LON 2018
         </li>
       </ul>
-      <p class="c7"><span class="c4 c2"></span></p>
-      <h4 class="c9" id="h.cgin7p2ejyun">
-        <span class="c14 c6">Architecture and Patterns</span>
-      </h4>
-      <ul class="c8 lst-kix_bh3auolkt5q4-0 start">
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/building-event-driven-architectures-with-kafka-and-cloud-events/"
-              >Building Event Driven Architectures with Kafka and Cloud
-              Events</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/building-event-driven-architectures-kafka-cloud-events/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Dan Rosanova (Microsoft), SFO 2019</span>
+
+
+      <h4 id="h.cgin7p2ejyun">Architecture and Patterns</h4>
+
+      <ul>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/building-event-driven-architectures-with-kafka-and-cloud-events/">Building Event Driven Architectures with Kafka and Cloud Events</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/building-event-driven-architectures-kafka-cloud-events/">abstract</a>),
+          Dan Rosanova (Microsoft), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/event-sourcing-stream-processing-and-serverless/"
-              >Event Sourcing, Stream Processing, and Serverless</a
-            ></span
-          ><span class="c4 c2">, Ben Stopford (Confluent), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/event-sourcing-stream-processing-and-serverless/">Event Sourcing, Stream Processing, and Serverless</a>,
+          Ben Stopford (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/shattering-the-monoliths/"
-              >Shattering The Monolith(s)</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/shattering-the-monoliths/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Martin Kess (Namely), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/shattering-the-monoliths/">Shattering The Monolith(s)</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/shattering-the-monoliths/">abstract</a>),
+          Martin Kess (Namely), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/hard-truths-streaming-eventing/"
-              >Hard Truths About Streaming and Eventing</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/hard-truths-streaming-eventing/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Dan Rosanova (Microsoft), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/hard-truths-streaming-eventing/">Hard Truths About Streaming and Eventing</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/hard-truths-streaming-eventing/">abstract</a>),
+          Dan Rosanova (Microsoft), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/complex-event-flows-in-distributed-systems/"
-              >Complex Event Flows in Distributed Systems</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/complex-event-flows-distributed-systems/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Bernd Ruecker (Camunda), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/complex-event-flows-in-distributed-systems/">Complex Event Flows in Distributed Systems</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/complex-event-flows-distributed-systems/">abstract</a>),
+          Bernd Ruecker (Camunda), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/aggregating-billions-of-messages-per-day/"
-              >Cost Effectively and Reliably Aggregating Billions of Messages
-              Per Day Using Apache Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/cost-effectively-reliably-aggregating-billions-messages-per-day-using-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Chunky Gupta & Osman Sarood (Mist Systems), NYC 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/aggregating-billions-of-messages-per-day/">Cost Effectively and Reliably Aggregating Billions of Messages Per Day Using Apache Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/cost-effectively-reliably-aggregating-billions-messages-per-day-using-kafka/">abstract</a>),
+          Chunky Gupta &amp; Osman Sarood (Mist Systems), NYC 2019
         </li>
-      </ul>
-      <ul class="c8 lst-kix_bh3auolkt5q4-0">
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/making-sense-of-your-event-driven-dataflows"
-              >Tracing for Kafka-Based Applications: Making Sense of Your
-              Event-Driven Dataflows</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/tracing-kafka-based-applications-making-sense-event-driven-dataflows/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Jorge Esteban Quilcate Otoya (SYSCO AS), NYC 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/making-sense-of-your-event-driven-dataflows">Tracing for Kafka-Based Applications: Making Sense of Your Event-Driven Dataflows</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/tracing-kafka-based-applications-making-sense-event-driven-dataflows/">abstract</a>),
+          Jorge Esteban Quilcate Otoya (SYSCO AS), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/stream-processing-in-ludicrous-mode/"
-              >From a Million to a Trillion Events Per Day: Stream Processing in
-              Ludicrous Mode</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/million-trillion-events-per-day-stream-processing-ludicrous-mode/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Shrijeet Paliwal (Tesla) NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/stream-processing-in-ludicrous-mode/">From a Million to a Trillion Events Per Day: Stream Processing in Ludicrous Mode</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/million-trillion-events-per-day-stream-processing-ludicrous-mode/">abstract</a>),
+          Shrijeet Paliwal (Tesla) NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/the-migration-to-event-driven-microservices/"
-              >The Migration to Event-Driven Microservices</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/migration-event-driven-microservices/"
-              >abstract</a
-            ></span
-          ><span class="c2 c4">), Adam Bellemare (Flipp), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/the-migration-to-event-driven-microservices/">The Migration to Event-Driven Microservices</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/migration-event-driven-microservices/">abstract</a>),
+          Adam Bellemare (Flipp), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/talking-traffic-data-in-the-drivers-seat/"
-              >Talking Traffic: Data in the Driver&rsquo;s Seat</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/talking-traffic-data-drivers-seat/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Dominique Chanet (Klarrio), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/talking-traffic-data-in-the-drivers-seat/">Talking Traffic: Data in the Driver&rsquo;s Seat</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/talking-traffic-data-drivers-seat/">abstract</a>),
+          Dominique Chanet (Klarrio), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/privacy-engineering-world-of-kafka"
-              >Privacy Engineering for the World of Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/privacy-engineering-world-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Alexander Cook (Privitar), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/privacy-engineering-world-of-kafka">Privacy Engineering for the World of Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/privacy-engineering-world-kafka/">abstract</a>),
+          Alexander Cook (Privitar), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/riddles-of-streaming-code-puzzlers/"
-              >Riddles of Streaming &ndash; Code Puzzlers for Fun & Profit</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/riddles-streaming-code-puzzlers-fun-profit/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Nick Dearden (Confluent), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/riddles-of-streaming-code-puzzlers/">Riddles of Streaming &ndash; Code Puzzlers for Fun & Profit</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/riddles-streaming-code-puzzlers-fun-profit/">abstract</a>),
+          Nick Dearden (Confluent), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/is-kafka-a-database"
-              >Is Kafka a Database?</a
-            ></span
-          ><span class="c4 c2"
-            >, Martin Kleppmann (University of Cambridge), LON 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/is-kafka-a-database">Is Kafka a Database?</a>,
+          Martin Kleppmann (University of Cambridge), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/event-driven-workflow-monitoring-mmicroservices-kafka-zeebe/"
-              >Event-Driven Workflow: Monitoring and Orchestrating Your
-              Microservices Landscape with Kafka and Zeebe</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/event-driven-workflow-monitoring-orchestrating-microservices-landscape-kafka-zeebe/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Mike Winters & Sebastian Menski (Camunda), LON 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/event-driven-workflow-monitoring-mmicroservices-kafka-zeebe/">Event-Driven Workflow: Monitoring and Orchestrating Your Microservices Landscape with Kafka and Zeebe</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/event-driven-workflow-monitoring-orchestrating-microservices-landscape-kafka-zeebe/">abstract</a>),
+          Mike Winters &amp; Sebastian Menski (Camunda), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/handling-gdpr-apache-kafka-comply-freaking-out/"
-              >Handling GDPR with Apache Kafka: How to Comply Without Freaking
-              Out?</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/handling-gdpr-apache-kafka-comply-without-freaking/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), David Jacot (Independent, formally Swisscom), LON 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/handling-gdpr-apache-kafka-comply-freaking-out/">Handling GDPR with Apache Kafka: How to Comply Without Freaking Out?</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/handling-gdpr-apache-kafka-comply-without-freaking/" >abstract</a>),
+          David Jacot (Independent, formally Swisscom), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/one-key-to-rule-them-all/"
-              >One Key to Rule them All</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/one-key-rule/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Richard Noble & Francesco Nobilia (Babylon Health), LON
-            2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/one-key-to-rule-them-all/">One Key to Rule them All</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/one-key-rule/">abstract</a>),
+          Richard Noble &amp; Francesco Nobilia (Babylon Health), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/how-to-use-kafka-and-druid-tame-router-data/"
-              >How To Use Kafka and Druid to Tame Your Router Data</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/use-kafka-druid-tame-router-data-2/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Rachel Pedreschi And Eric Graham (Imply Data), LON 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/how-to-use-kafka-and-druid-tame-router-data/">How To Use Kafka and Druid to Tame Your Router Data</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/use-kafka-druid-tame-router-data-2/">abstract</a>),
+          Rachel Pedreschi And Eric Graham (Imply Data), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-SF18/apache-kafka-and-event-oriented-architecture/"
-              >Apache Kafka and Event-Oriented Architecture</a
-            ></span
-          ><span class="c4 c2">, Jay Kreps (Confluent), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-SF18/apache-kafka-and-event-oriented-architecture/">Apache Kafka and Event-Oriented Architecture</a>,
+          Jay Kreps (Confluent), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/bringing-streaming-data-to-the-masses/"
-              >Bringing Streaming Data To The Masses: Lowering The &ldquo;Cost
-              Of Admission&rdquo; For Your Streaming Data Platform</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/bringing-streaming-data-masses-lowering-cost-admission-streaming-data-platform/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Bob Lehmann (Bayer), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/bringing-streaming-data-to-the-masses/">Bringing Streaming Data To The Masses: Lowering The &ldquo;Cost Of Admission&rdquo; For Your Streaming Data Platform</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/bringing-streaming-data-masses-lowering-cost-admission-streaming-data-platform/">abstract</a>),
+          Bob Lehmann (Bayer), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/breaking-down-a-sql-monolith/"
-              >Breaking Down a SQL Monolith with Change Tracking, Kafka and
-              KStreams/ksqlDB</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/breaking-sql-monolith-change-tracking-kafka-kstream-ksql/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Wanny Morellato (SAP Concur), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/breaking-down-a-sql-monolith/">Breaking Down a SQL Monolith with Change Tracking, Kafka and KStreams/ksqlDB</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/breaking-sql-monolith-change-tracking-kafka-kstream-ksql/">abstract</a>
+          Wanny Morellato (SAP Concur), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/kafka-as-an-eventing-system-to-replatform-a-monolith-into-microservices/"
-              >Kafka as an Eventing System to Replatform a Monolith into
-              Microservices</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-eventing-system-replatform-monolith-microservices/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Madhulika Tripathi (Intuit), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/kafka-as-an-eventing-system-to-replatform-a-monolith-into-microservices/">Kafka as an Eventing System to Replatform a Monolith into Microservices</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-eventing-system-replatform-monolith-microservices/">abstract</a>),
+          Madhulika Tripathi (Intuit), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-london18/keynote-experimentation-using-event-based-systems/"
-              >Experimentation Using Event-based Systems</a
-            ></span
-          ><span class="c4 c2"
-            >, Martin Fowler & Toby Clemson (ThoughtWorks), LON 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-london18/keynote-experimentation-using-event-based-systems/">Experimentation Using Event-based Systems</a>,
+          Martin Fowler &amp; Toby Clemson (ThoughtWorks), LON 2018
         </li>
       </ul>
-      <p class="c7"><span class="c4 c2"></span></p>
-      <h4 class="c9" id="h.q9sg75ccd6il">
-        <span>Data </span><span class="c6 c14">Pipelines</span>
-      </h4>
-      <ul class="c8 lst-kix_jy8uuck07ept-0 start">
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/how-kroger-embraced-a-schema-first-philosophy-in-building-real-time-data-pipelines/"
-              >How Kroger Embraced a &quot;Schema First&quot; Philosophy in
-              Building Real-time Data Pipelines</a
-            ></span
-          ><span class="c2"
-            >, Rob Hoeting, Rob Hammonds & Lauren McDonald (Kroger), </span
-          ><span class="c4 c2">SFO 2019</span>
+
+
+      <h4 id="h.q9sg75ccd6il">Data Pipelines</h4>
+
+      <ul>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/how-kroger-embraced-a-schema-first-philosophy-in-building-real-time-data-pipelines/">How Kroger Embraced a &quot;Schema First&quot; Philosophy in Building Real-time Data Pipelines</a>,
+          Rob Hoeting, Rob Hammonds &amp; Lauren McDonald (Kroger), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/building-stream-processing-applications-with-apache-kafka-using-ksql/"
-              >Building Stream Processing Applications with Apache Kafka Using
-              ksqlDB</a
-            ></span
-          ><span class="c4 c2">, Robin Moffat (Confluent), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/building-stream-processing-applications-with-apache-kafka-using-ksql/">Building Stream Processing Applications with Apache Kafka Using ksqlDB</a>
+          Robin Moffat (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-connect-operational-lessons-learned-from-the-trenches/"
-              >Kafka Connect: Operational Lessons Learned from the Trenches</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-connect-operational-lessons-learned-trenches/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Elizabeth Bennett (Confluent), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-connect-operational-lessons-learned-from-the-trenches/">Kafka Connect: Operational Lessons Learned from the Trenches</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-connect-operational-lessons-learned-trenches/">abstract</a>),
+          Elizabeth Bennett (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/solutions-for-bi-directional-integration-between-oracle-rdbms-and-apache-kafka/"
-              >Solutions for bi-directional integration between Oracle RDBMS and
-              Apache Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/solutions-bi-directional-integration-oracle-rdbms-apache-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c2">), </span
-          ><span class="c4 c2">Guido Schmutz (Trivadis), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/solutions-for-bi-directional-integration-between-oracle-rdbms-and-apache-kafka/">Solutions for bi-directional integration between Oracle RDBMS and Apache Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/solutions-bi-directional-integration-oracle-rdbms-apache-kafka/">abstract</a>),
+          Guido Schmutz (Trivadis), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/streaming-ingestion-of-logging-events-at-airbnb/"
-              >Streaming Ingestion of Logging Events at Airbnb</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/streaming-ingestion-logging-events-airbnb/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2">, Hao Wang (Airbnb), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/streaming-ingestion-of-logging-events-at-airbnb/">Streaming Ingestion of Logging Events at Airbnb</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/streaming-ingestion-logging-events-airbnb/">abstract</a>),
+          Hao Wang (Airbnb), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/no-more-silos-integrating-db-into-apache-kafka/"
-              >No More Silos: Integrating Databases into Apache Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/no-silos-integrating-databases-apache-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2">, Robin Moffatt (Confluent), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/no-more-silos-integrating-db-into-apache-kafka/">No More Silos: Integrating Databases into Apache Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/no-silos-integrating-databases-apache-kafka/">abstract</a>),
+          Robin Moffatt (Confluent), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/lessons-learned-building-a-connector"
-              >Lessons Learned Building a Connector Using Kafka Connect</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/lessons-learned-building-connector-using-kafka-connect/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2"
-            >, &nbsp;Katherine Stanley & Andrew Schofield (IBM UK), NYC
-            2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/lessons-learned-building-a-connector">Lessons Learned Building a Connector Using Kafka Connect</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/lessons-learned-building-connector-using-kafka-connect/">abstract</a>),
+          Katherine Stanley &amp; Andrew Schofield (IBM UK), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/call-of-duty-games/"
-              >Building Scalable and Extendable Data Pipeline for Call of Duty
-              Games</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/building-scalable-extendable-data-pipeline-call-duty-games-lessons-learned/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2"
-            >, Yaroslav Tkachenko (Activision), NYC 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/call-of-duty-games/">Building Scalable and Extendable Data Pipeline for Call of Duty Games</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/building-scalable-extendable-data-pipeline-call-duty-games-lessons-learned/">abstract</a>),
+          Yaroslav Tkachenko (Activision), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/from-zero-to-hero-with-kafka-connect/"
-              >From Zero to Hero with Kafka Connect</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/zero-hero-kafka-connect/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Robin Moffatt (Confluent), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/from-zero-to-hero-with-kafka-connect/">From Zero to Hero with Kafka Connect</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/zero-hero-kafka-connect/">abstract</a>),
+          Robin Moffatt (Confluent), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/change-data-streaming-patterns-microservices-debezium/"
-              >Change Data Streaming Patterns For Microservices With Debezium</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/change-data-streaming-patterns-microservices-debezium-2/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2">, Gunnar Morling (Red Hat), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/change-data-streaming-patterns-microservices-debezium/">Change Data Streaming Patterns For Microservices With Debezium</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/change-data-streaming-patterns-microservices-debezium-2/">abstract</a>),
+          Gunnar Morling (Red Hat), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/beyond-messaging/"
-              >Beyond Messaging: Enterprise-Scale, Multi-Cloud Intelligent
-              Routing</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/beyond-messaging/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2">, Anand Phatak (Adobe), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/beyond-messaging/">Beyond Messaging: Enterprise-Scale, Multi-Cloud Intelligent Routing</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/beyond-messaging/">abstract</a>),
+          Anand Phatak (Adobe), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/you-must-construct-additional-pipelines/"
-              >You Must Construct Additional Pipelines: Pub-Sub on Kafka at
-              Blizzard</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/must-construct-additional-pipelines-pub-sub-kafka-blizzard/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Stephen Parente & Jeff Field (Blizzard), SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/you-must-construct-additional-pipelines/">You Must Construct Additional Pipelines: Pub-Sub on Kafka at Blizzard</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/must-construct-additional-pipelines-pub-sub-kafka-blizzard/">abstract</a>),
+          Stephen Parente &amp; Jeff Field (Blizzard), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/so-you-want-to-write-a-connector/"
-              >So You Want to Write a Connector?</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/want-write-connector/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Randall Hauch (Confluent), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/so-you-want-to-write-a-connector/">So You Want to Write a Connector?</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/want-write-connector/">abstract</a>),
+          Randall Hauch (Confluent), SFO 2018
         </li>
       </ul>
-      <p class="c7"><span class="c4 c2"></span></p>
-      <p class="c7"><span class="c4 c2"></span></p>
-      <h4 class="c9" id="h.p0of6418zdq7">
-        <span class="c14 c6">Kafka Operations</span>
-      </h4>
-      <ul class="c8 lst-kix_sm9rboqwtzur-0 start">
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-on-kubernetes-keeping-it-simple/"
-              >Kafka on Kubernetes: Keeping It Simple</a
-            ></span
-          ><span class="c4 c2">, Nikki Thean (Etsy), SFO 2019</span>
+
+
+      <h4 id="h.p0of6418zdq7">Kafka Operations</h4>
+
+      <ul>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-on-kubernetes-keeping-it-simple/">Kafka on Kubernetes: Keeping It Simple</a>,
+          Nikki Thean (Etsy), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/please-upgrade-apache-kafka-now/"
-              >Please Upgrade Apache Kafka. Now!</a
-            ></span
-          ><span class="c4 c2">, Gwen Shapira (Confluent), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/please-upgrade-apache-kafka-now/">Please Upgrade Apache Kafka. Now!</a>
+          Gwen Shapira (Confluent), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/tackling-kafka-with-a-small-team/"
-              >Tackling Kafka, with a Small Team</a
-            ></span
-          ><span class="c4 c2">, Jaren Glover (Robinhood), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/tackling-kafka-with-a-small-team/">Tackling Kafka, with a Small Team</a>,
+          Jaren Glover (Robinhood), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/secure-kafka-at-scale-in-true-multi-tenant-environment/"
-              >Secure Kafka at scale in true multi-tenant environment</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/secure-kafka-scale-true-multi-tenant-environment/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Vishnu Balusu & Ashok Kadambala (JP Morgan Chase), SFO
-            2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/secure-kafka-at-scale-in-true-multi-tenant-environment/">Secure Kafka at scale in true multi-tenant environment</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/secure-kafka-scale-true-multi-tenant-environment/">abstract</a>),
+          Vishnu Balusu & Ashok Kadambala (JP Morgan Chase), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/running-large-scale-kafka-upgrades-at-yelp/"
-              >Running large scale Kafka upgrades at Yelp</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/running-large-scale-kafka-upgrades-yelp/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Manpreet Singh (Yelp), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/running-large-scale-kafka-upgrades-at-yelp/">Running large scale Kafka upgrades at Yelp</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/running-large-scale-kafka-upgrades-yelp/">abstract</a>),
+          Manpreet Singh (Yelp), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/production-ready-kafka-on-kubernetes/"
-              >Production Ready Kafka on Kubernetes</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/production-ready-kafka-kubernetes/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Devandra Tagare (Lyft), SFO 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/production-ready-kafka-on-kubernetes/">Production Ready Kafka on Kubernetes</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/production-ready-kafka-kubernetes/">abstract</a>),
+          Devandra Tagare (Lyft), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-cluster-federation-at-uber/"
-              >Kafka Cluster Federation at Uber</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-cluster-federation-uber/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Yupeng Fui & Xiaoman Dong (Uber), SFO 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-cluster-federation-at-uber/">Kafka Cluster Federation at Uber</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-cluster-federation-uber/">abstract</a>),
+          Yupeng Fui &amp; Xiaoman Dong (Uber), SFO 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/experiences-operating-apache-kafka-at-scale"
-              >Experiences Operating Apache Kafka&reg; at Scale</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/experiences-operating-apache-kafka-at-scale/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Noa Resare (Apple), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/experiences-operating-apache-kafka-at-scale">Experiences Operating Apache Kafka&reg; at Scale</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/experiences-operating-apache-kafka-at-scale/">abstract</a>),
+          Noa Resare (Apple), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/kafka-pluggable-auth-for-enterprise-security/"
-              >Kafka Pluggable Authorization for Enterprise Security</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-pluggable-authorization-enterprise-security/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Anna Kepler (Viasat), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/kafka-pluggable-auth-for-enterprise-security/">Kafka Pluggable Authorization for Enterprise Security</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-pluggable-authorization-enterprise-security/">abstract</a>),
+          Anna Kepler (Viasat), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/kafka-on-kubernetes-does-it-really-have-to-be-hard/"
-              >Kafka on Kubernetes: Does it really have to be &ldquo;The Hard
-              Way&rdquo;?</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-kubernetes-really-hard-way/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Viktor Gamov and Michael Ng (Confluent), NYC 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/kafka-on-kubernetes-does-it-really-have-to-be-hard/">Kafka on Kubernetes: Does it really have to be &ldquo;The Hard Way&rdquo;?</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-kubernetes-really-hard-way/" >abstract</a>),
+          Viktor Gamov and Michael Ng (Confluent), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/flexible-authentication-strategies-with-sasl-oauthbearer"
-              >Flexible Authentication Strategies with SASL/OAUTHBEARER</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/flexible-authentication-strategies-sasl-oauthbearer/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Michael Kaminski (The New York Times) & Ron Dagostino (State
-            Street Corp), NYC 2019</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/flexible-authentication-strategies-with-sasl-oauthbearer">Flexible Authentication Strategies with SASL/OAUTHBEARER</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/flexible-authentication-strategies-sasl-oauthbearer/">abstract</a>),
+          Michael Kaminski (The New York Times) &amp; Ron Dagostino (State Street Corp), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-ny19/bulletproof-kafka-with-fault-tree-analysis"
-              >Bulletproof Apache Kafka with Fault Tree Analysis</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/bulletproof-kafka-fault-tree-analysis/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Andrey Falko (Lyft), NYC 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-ny19/bulletproof-kafka-with-fault-tree-analysis">Bulletproof Apache Kafka with Fault Tree Analysis</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/bulletproof-kafka-fault-tree-analysis/">abstract</a>),
+          Andrey Falko (Lyft), NYC 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/foundations-of-multi-dc-kafka/"
-              >The Foundations of Multi-DC Kafka</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/foundations-multi-dc-kafka/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Jakub Korab (Confluent), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/foundations-of-multi-dc-kafka/">The Foundations of Multi-DC Kafka</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/foundations-multi-dc-kafka/">abstract</a>),
+          Jakub Korab (Confluent), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/show-me-kafka-tools-increase-productivity/"
-              >Show Me Kafka Tools That Will Increase My Productivity</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/show-kafka-tools-will-increase-productivity-2/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Stephane Maarek (DataCumulus)</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/show-me-kafka-tools-increase-productivity/">Show Me Kafka Tools That Will Increase My Productivity</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/show-kafka-tools-will-increase-productivity-2/">abstract</a>),
+          Stephane Maarek (DataCumulus)
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/running-kafka-in-kubernetes-practical-guide/"
-              >Running Kafka in Kubernetes: A Practical Guide</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/running-kafka-kubernetes-practical-guide/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Katherine Stanley (IBM UK), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/running-kafka-in-kubernetes-practical-guide/">Running Kafka in Kubernetes: A Practical Guide</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/running-kafka-kubernetes-practical-guide/">abstract</a>),
+          Katherine Stanley (IBM UK), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/running-production-kafka-clusters-kubernetes/"
-              >Running Production Kafka Clusters in Kubernetes</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/running-production-kafka-clusters-kubernetes/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Balthazar Rouberol (Datadog), LON 2019</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/running-production-kafka-clusters-kubernetes/">Running Production Kafka Clusters in Kubernetes</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/running-production-kafka-clusters-kubernetes/">abstract</a>),
+          Balthazar Rouberol (Datadog), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-lon19/dont-be-scared-multi-tennant-cluster-support-at-scale/"
-              >Don&rsquo;t Be Scared: Multi-Tenant Cluster Support at Scale</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/dont-scared-multi-tenant-cluster-support-scale/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Kelly Attaway & Cabe Waldrop (Pandora Media)</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-lon19/dont-be-scared-multi-tennant-cluster-support-at-scale/">Don&rsquo;t Be Scared: Multi-Tenant Cluster Support at Scale</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/dont-scared-multi-tenant-cluster-support-scale/">abstract</a>),
+          Kelly Attaway &amp; Cabe Waldrop (Pandora Media), LON 2019
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/kafka-on-zfs/"
-              >Kafka on ZFS: Better Living Through Filesystems</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-zfs-better-living-filesystems/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Hugh O&#39;Brien (Jet.com), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/kafka-on-zfs/">Kafka on ZFS: Better Living Through Filesystems</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-zfs-better-living-filesystems/">abstract</a>),
+          Hugh O&#39;Brien (Jet.com), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/kafka-security-101-and-real-world-tips/"
-              >Kafka Security 101 and Real-World Tips</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/kafka-security-101-real-world-tips/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Stephane Maarek (DataCumulus), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/kafka-security-101-and-real-world-tips/">Kafka Security 101 and Real-World Tips</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-security-101-real-world-tips/">abstract</a>),
+          Stephane Maarek (DataCumulus), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/end-end-security-with-confluent-platform/"
-              >End-to-End Security with Confluent Platform</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/end-end-security-confluent-platform/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Vahid Fereydouny (Confluent), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/end-end-security-with-confluent-platform/">End-to-End Security with Confluent Platform</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/end-end-security-confluent-platform/">abstract</a>),
+          Vahid Fereydouny (Confluent), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/robust-operations-of-kafka-streams/"
-              >Robust Operations of Kafka Streams</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/robust-operations-kafka-streams/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Bill Bejeck (Confluent), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/robust-operations-of-kafka-streams/">Robust Operations of Kafka Streams</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/robust-operations-kafka-streams/">abstract</a>),
+          Bill Bejeck (Confluent), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-sf18/deploying-kafka-streams-applications/"
-              >Deploying Kafka Streams Applications with Docker and
-              Kubernetes</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/deploying-kafka-streams-applications-docker-kubernetes/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2"
-            >), Gwen Shapira & Matthias J. Sax (Confluent), SFO 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-sf18/deploying-kafka-streams-applications/">Deploying Kafka Streams Applications with Docker and Kubernetes</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/deploying-kafka-streams-applications-docker-kubernetes/">abstract</a>),
+          Gwen Shapira &amp; Matthias J. Sax (Confluent), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-london18/urp-excuse-you-the-three-metrics-you-have-to-know/"
-              >URP? Excuse You! The Three Metrics You Have to Know</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/urp-excuse-three-metrics-know/"
-              >abstract</a
-            ></span
-          ><span class="c4 c2">), Todd Palino (LinkedIn), SFO 2018</span>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-london18/urp-excuse-you-the-three-metrics-you-have-to-know/">URP? Excuse You! The Three Metrics You Have to Know</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/urp-excuse-three-metrics-know/">abstract</a>),
+          Todd Palino (LinkedIn), SFO 2018
         </li>
-        <li class="c3">
-          <span class="c1"
-            ><a
-              target="_blank"
-              href="https://www.confluent.io/kafka-summit-london18/monitor-kafka-like-a-pro/"
-              >Monitor Kafka Like a Pro</a
-            ></span
-          ><span class="c2">&nbsp;(</span
-          ><span class="c1"
-            ><a
-              target="_blank"
-              href="https://kafka-summit.org/sessions/monitor-kafka-like-pro/"
-              >abstract</a
-            ></span
-          ><span class="c2">)</span
-          ><span class="c4 c2"
-            >, Gwen Shapira & Xavier L&eacute;aut&eacute; (Confluent), LON 2018</span
-          >
+        <li>
+          <a target="_blank" href="https://www.confluent.io/kafka-summit-london18/monitor-kafka-like-a-pro/">Monitor Kafka Like a Pro</a>
+          (<a target="_blank" href="https://kafka-summit.org/sessions/monitor-kafka-like-pro/">abstract</a>),
+          Gwen Shapira &amp; Xavier L&eacute;aut&eacute; (Confluent), LON 2018
         </li>
       </ul>
+
+
     </section>
   </div>
 

--- a/videos.html
+++ b/videos.html
@@ -22,6 +22,34 @@
 
       <ul>
         <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/jay-kreps-confluent-keynote-kafka-cloud/">Kafka &hearts; Cloud (Keynote)</a>,
+          Jay Kreps (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/tradeoffs-in-distributed-systems-design-is-kafka-the-best/">Trade-offs in Distributed Systems Design: Is Kafka The Best?</a>,
+          Ben Stopford &amp; Michael G. Noll (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/the-flux-capacitor-of-kafka-streams-and-ksqldb/">The Flux Capacitor of Kafka Streams and ksqlDB</a>,
+          Matthias J. Sax (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/crossing-the-streams-the-new-streaming-foreign-key-join-feature-in-kafka-streams/">Crossing the Streams: the New Streaming Foreign-Key Join Feature in Kafka Streams</a>,
+          John Roesler (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/welcome-to-kafka-were-glad-youre-here/">Welcome to Kafka; We're Glad You're Here</a>,
+          Dave Klein (Centene), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/gwen-shapira-confluent-keynote-kafkas-new-architecture/">Kafka's New Architecture (Keynote)</a>,
+          Gwen Shapira (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/getting-started-with-apache-kafka-a-contributors-journey/">Getting Started with Apache Kafka – a Contributor's Journey</a>,
+          Israel Ekpo (Microsoft) &amp; Matthias J. Sax (Confluent) &amp; Nikolay Izhikov (Sberbank), KS 2020
+        </li>
+        <li>
           <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-needs-no-keeper/">Kafka Needs no (Zoo)Keeper</a>
           (<a target="_blank" href="https://kafka-summit.org/sessions/kafka-needs-no-keeper/">abstract</a>),
           Jason Gustafson &amp; Colin McCabe (Confluent), SFO 2019
@@ -85,6 +113,38 @@
       </h4>
 
       <ul>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/building-event-streaming-applications-with-pac-man/">Building Event Streaming Applications with Pac-Man</a>,
+          Ricardo Ferreira (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/apache-kafka-tiered-storage-and-tensorflow-for-streaming-machine-learning-without-a-data-lake/">Apache Kafka, Tiered Storage and TensorFlow for Streaming Machine Learning without a Data Lake</a>,
+          Kai Waehner (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/ksql-ops-running-ksqldb-in-the-wild/">KSQL-ops! Running ksqlDB in the Wild</a>,
+          Simon Aubury (ThoughtWorks), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/streaming-towards-our-quantum-future/">Streaming Towards Our Quantum Future</a>,
+          David Elbert &amp; Tyrel McQueen (Johns Hopkins University), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/kafkaconsumer-decoupling-consumption-and-processing-for-better-resource-utilization/">KafkaConsumer – Decoupling Consumption and Processing for Better Resource Utilization</a>,
+          Igor Buzatovi&#263; (Inovativni trendovi d.o.o), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/can-kafka-handle-a-lyft-ride/">Can Kafka Handle a Lyft Ride?</a>,
+          Andrey Falko &amp; Can Cecen (Lyft), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/flattening-the-curve-with-kafka/">Flattening the Curve with Kafka</a>,
+          Rishi Tarar (Northrop Grumman Corp.), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/risk-management-in-retail-with-stream-processing/">Risk Management in Retail with Stream Processing</a>,
+          Daniel Jagielski (Virtuslab/Tesco), KS 2020
+        </li>
         <li>
           <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/0-60-teslas-streaming-data-platform/">0-60: Tesla&rsquo;s Streaming Data Platform</a>
           (<a target="_blank" href="https://kafka-summit.org/sessions/0-60-teslas-streaming-data-platform/">abstract</a>),
@@ -269,6 +329,38 @@
 
       <ul>
         <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/reacting-to-an-event-driven-world/">Reacting to an Event-Driven World</a>,
+          Kate Stanley &amp; Grace Jansen (IBM), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/a-tale-of-two-data-centers-kafka-streams-resiliency/">A Tale of Two Data Centers: Kafka Streams Resiliency</a>,
+          Anna McDonald (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/kafka-as-your-data-lake-is-it-feasible/">Kafka as your Data Lake – is it Feasible?</a>,
+          Guido Schmutz (Trivadis), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/gdpr-compliance-transparent-handing-of-personally-identifiable-information-in-event-driven-systems/">GDPR Compliance: Transparent Handing of Personally Identifiable Information in Event-Driven Systems</a>,
+          Masih Derkani (SolarWinds), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/synchronous-commands-over-apache-kafka/">Synchronous Commands over Apache Kafka</a>,
+          Neil Buesing (Object Partners, Inc), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/hybrid-kafka-taking-real-time-analytics-to-the-business/">Hybrid Kafka, Taking Real-time Analytics to the Business</a>,
+          Cody Irwin (Google Cloud) &amp; Josh Treichel (Confluent) &amp; Jeff Ferguson (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/i-dont-always-test-my-streams-but-when-i-do-i-do-it-in-production/">I Don't Always Test My Streams, But When I Do, I Do it in Production</a>,
+          Viktor Gamov (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/building-information-systems-using-event-modeling/">Building Information Systems using Event Modeling</a>,
+          Bobby Calderwood (Evident Systems), KS 2020
+        </li>
+        <li>
           <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/building-event-driven-architectures-with-kafka-and-cloud-events/">Building Event Driven Architectures with Kafka and Cloud Events</a>
           (<a target="_blank" href="https://kafka-summit.org/sessions/building-event-driven-architectures-kafka-cloud-events/">abstract</a>),
           Dan Rosanova (Microsoft), SFO 2019
@@ -384,6 +476,18 @@
 
       <ul>
         <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/apache-kafka-and-ksqldb-in-action-lets-build-a-streaming-data-pipeline/">Apache Kafka and ksqlDB in Action: Let's Build a Streaming Data Pipeline!</a>,
+          Robin Moffat (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/change-data-capture-pipelines-with-debezium-and-kafka-streams/">Change Data Capture Pipelines with Debezium and Kafka Streams</a>,
+          Gunnar Morling (Red Hat), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/bravo-six-going-realtime-transitioning-activision-data-pipeline-to-streaming/">Bravo Six, Going Realtime. Transitioning Activision Data Pipeline to Streaming</a>,
+          Yaroslav Tkachenko (Activision), KS 2020
+        </li>
+        <li>
           <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/how-kroger-embraced-a-schema-first-philosophy-in-building-real-time-data-pipelines/">How Kroger Embraced a &quot;Schema First&quot; Philosophy in Building Real-time Data Pipelines</a>,
           Rob Hoeting, Rob Hammonds &amp; Lauren McDonald (Kroger), SFO 2019
         </li>
@@ -455,6 +559,22 @@
       </h4>
 
       <ul>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/fully-managed-multi-tenant-kafka-clusters-tips-tricks-and-tools/">Fully-Managed, Multi-Tenant Kafka Clusters: Tips, Tricks, and Tools</a>,
+          Christopher Beard (Bloomberg), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/overcoming-the-perils-of-kafka-secret-sprawl/">Overcoming the Perils of Kafka Secret Sprawl</a>,
+          Tejal Adsul (Confluent), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/kafka-lag-monitoring-for-human-beings/">Kafka Lag Monitoring For Human Beings</a>,
+          Elad Leev (AppsFlyer), KS 2020
+        </li>
+        <li>
+          <a target="_blank" href="https://www.confluent.io/resources/kafka-summit-2020/sharing-is-caring-toward-creating-self-tuning-multi-tenant-kafka/">Sharing is Caring: Toward Creating Self-tuning Multi-tenant Kafka</a>,
+          Anna Povzner (Confluent), KS 2020
+        </li>
         <li>
           <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/kafka-on-kubernetes-keeping-it-simple/">Kafka on Kubernetes: Keeping It Simple</a>,
           Nikki Thean (Etsy), SFO 2019

--- a/videos.html
+++ b/videos.html
@@ -917,11 +917,6 @@
           >
         </li>
       </ul>
-      <ul class="c8 lst-kix_bh3auolkt5q4-1 start">
-        <li class="c10">
-          <span class="c4 c2">Consider moving to Use Cases</span>
-        </li>
-      </ul>
       <ul class="c8 lst-kix_bh3auolkt5q4-0">
         <li class="c3">
           <span class="c1"

--- a/videos.html
+++ b/videos.html
@@ -15,7 +15,10 @@
       </p>
 
 
-      <h4 id="h.28sj93j7rek1">Kafka Internals and Fundamentals</h4>
+      <h4 class="anchor-heading">
+        <a class="anchor-link" id="kafka_internals_fundamentals" href="#kafka_internals_fundamentals"></a>
+        <a href="#kafka_internals_fundamentals">Kafka Internals and Fundamentals</a>
+      </h4>
 
       <ul>
         <li>
@@ -76,7 +79,11 @@
       </ul>
 
 
-      <h4 id="h.e1o0run8si2r">Applications and Use Cases</h4>
+      <h4 class="anchor-heading">
+        <a class="anchor-link" id="applications_use_cases" href="#applications_use_cases"></a>
+        <a href="#applications_use_cases">Applications and Use Cases</a>
+      </h4>
+
       <ul>
         <li>
           <a target="_blank" href="https://www.confluent.io/kafka-summit-san-francisco-2019/0-60-teslas-streaming-data-platform/">0-60: Tesla&rsquo;s Streaming Data Platform</a>
@@ -255,7 +262,10 @@
       </ul>
 
 
-      <h4 id="h.cgin7p2ejyun">Architecture and Patterns</h4>
+      <h4 class="anchor-heading">
+        <a class="anchor-link" id="architecture_patterns" href="#architecture_patterns"></a>
+        <a href="#architecture_patterns">Architecture and Patterns</a>
+      </h4>
 
       <ul>
         <li>
@@ -367,7 +377,10 @@
       </ul>
 
 
-      <h4 id="h.q9sg75ccd6il">Data Pipelines</h4>
+      <h4 class="anchor-heading">
+        <a class="anchor-link" id="data_pipelines" href="#data_pipelines"></a>
+        <a href="#data_pipelines">Data Pipelines</a>
+      </h4>
 
       <ul>
         <li>
@@ -436,7 +449,10 @@
       </ul>
 
 
-      <h4 id="h.p0of6418zdq7">Kafka Operations</h4>
+      <h4 class="anchor-heading">
+        <a class="anchor-link" id="kafka_operations" href="#kafka_operations"></a>
+        <a href="#kafka_operations">Kafka Operations</a>
+      </h4>
 
       <ul>
         <li>


### PR DESCRIPTION
This PR adds the thirty best Kafka Summit 2020 talks as rated by the community (summit attendees).

To make maintenance of the Videos page easier, I also refactored (read: cleaned up) the HTML of the original page, which was very messy to deal with. I also added a table of contents as the page has now a length of a few screens.