### PR TITLE
MINOR: Fix the wrong HTML format in powered by page

### DIFF
--- a/powered-by.html
+++ b/powered-by.html
@@ -91,7 +91,7 @@
         "link": "http://www.cerner.com/",
         "logo": "cerner.png",
         "logoBgColor": "#ffffff",
-        "description": "Kafka is used with HBase and Storm as described <a href='http://blog.cloudera.com/blog/2014/11/how-cerner-uses-cdh-with-apache-kafka/' target='_blank'here.</a>"
+        "description": "Kafka is used with HBase and Storm as described <a href='http://blog.cloudera.com/blog/2014/11/how-cerner-uses-cdh-with-apache-kafka/' target='_blank'>here.</a>"
     }, {
         "link": "https://www.coursera.org/",
         "logo": "coursera.png",
@@ -111,7 +111,7 @@
         "link": "http://www.cisco.com/",
         "logo": "cisco.png",
         "logoBgColor": "#ffffff",
-        "description": "Cisco is using Kafka as part of their OpenSOC (Security Operations Center). More details <a href='http://opensoc.github.io/' target='_blank'here.</a>"
+        "description": "Cisco is using Kafka as part of their OpenSOC (Security Operations Center). More details <a href='http://opensoc.github.io/' target='_blank'>here.</a>"
     }, {
         "link": "http://www.cityzendata.com/",
         "logo": "cityzen.png",
@@ -196,7 +196,7 @@
         "link": "http://graylog2.org/",
         "logo": "graylog2.jpg",
         "logoBgColor": "#ffffff",
-        "description": "Graylog2 is a free and open source log management and data analysis system. It's using Kafka as default transport for Graylog2 Radio. The use case is described <a href='http://support.torch.sh/help/kb/graylog2-server/using-graylog2-radio-v020x' target='_blank'here</a>."
+        "description": "Graylog2 is a free and open source log management and data analysis system. It's using Kafka as default transport for Graylog2 Radio. The use case is described <a href='http://support.torch.sh/help/kb/graylog2-server/using-graylog2-radio-v020x' target='_blank'>here</a>."
     },  {
         "link": "https://www.hackerrank.com/",
         "logo": "hacker.png",
@@ -266,7 +266,7 @@
         "link": "http://loggly.com/",
         "logo": "loggly.png",
         "logoBgColor": "#ffffff",
-        "description": "Loggly is the world's most popular cloud-based log management. Our cloud-based log management service helps DevOps and technical teams make sense of the the massive quantity of logs. Kafka is used as part of our <a href='http://www.loggly.com/behind-the-screens' target='_blank'log collection and processing infrastructure.</a>"
+        "description": "Loggly is the world's most popular cloud-based log management. Our cloud-based log management service helps DevOps and technical teams make sense of the the massive quantity of logs. Kafka is used as part of our <a href='http://www.loggly.com/behind-the-screens' target='_blank'>log collection and processing infrastructure.</a>"
     }, {
         "link": "http://web.livefyre.com/",
         "logo": "livefyre.png",
@@ -336,7 +336,7 @@
         "link": "http://www.parsely.com/",
         "logo": "parsely.png",
         "logoBgColor": "#ffffff",
-        "description": "Kafka is used for all <a href='http://www.parsely.com/misc/slides/logs/#1' target=_blank'>data integration </a> of analytics event data."
+        "description": "Kafka is used for all <a href='http://www.parsely.com/misc/slides/logs/#1' target='_blank'>data integration </a> of analytics event data."
     }, {
         "link": "http://www.paypal.com/",
         "logo": "paypal.png",
@@ -366,7 +366,7 @@
         "link": "http://sematext.com/",
         "logo": "sematext.png",
         "logoBgColor": "#ffffff",
-        "description": "In <a href='http://sematext.com/spm' target='_blank'SPM</a> (performance monitoring + alerting), Kafka is used for metrics collection and feeds SPM's in-memory data aggregation (OLAP cube creation) as well as our CEP/Alerts servers (see also: <a href='http://blog.sematext.com/2013/10/16/announcement-spm-performance-monitoring-for-kafka/' target=_blank'>SPM for Kafka performance monitoring</a>). In <a href='http://sematext.com/search-analytics' target='_blank'>SA (search analytics)</a> Kafka is used in search and click stream collection before being aggregated and persisted. In <a href='http://sematext.com/logsene' target='_blank'Logsene (log analytics)</a> Kafka is used to pass logs and other events from front-end receivers to the persistent backend."
+        "description": "In <a href='http://sematext.com/spm' target='_blank'>SPM (performance monitoring + alerting)</a>, Kafka is used for metrics collection and feeds SPM's in-memory data aggregation (OLAP cube creation) as well as our CEP/Alerts servers (see also: <a href='http://blog.sematext.com/2013/10/16/announcement-spm-performance-monitoring-for-kafka/' target='_blank'>SPM for Kafka performance monitoring</a>). In <a href='http://sematext.com/search-analytics' target='_blank'>SA (search analytics)</a> Kafka is used in search and click stream collection before being aggregated and persisted. In <a href='http://sematext.com/logsene' target='_blank'>Logsene (log analytics)</a> Kafka is used to pass logs and other events from front-end receivers to the persistent backend."
     }, {
         "link": "http://www.skyscanner.net/",
         "logo": "skyscanner.png",


### PR DESCRIPTION
When visiting the powered by page, I suddenly found the hyperlink text is weird in SemaText.
![image](https://user-images.githubusercontent.com/43372967/98776447-e63dc900-2429-11eb-9e85-1bb0929d0807.png)

After investigation, I found it's because we didn't end the `<a>` tag content well. We missed some right angle bracket (>) and some single quote ('), so that some text are disappeared on the page. Ex:
![image](https://user-images.githubusercontent.com/43372967/98776683-65cb9800-242a-11eb-815a-9427d52fb39b.png)

We should end with the text `here` with hyperlink.

**Fix those issues!**
example after fixed:
![image](https://user-images.githubusercontent.com/43372967/98776817-a4615280-242a-11eb-8a74-87912f51af8b.png)

