### PR TITLE
Remove erroneous extra <code>

### DIFF
--- a/27/design.html
+++ b/27/design.html
@@ -453,7 +453,7 @@
     <p>
     Let's discuss a concrete example of such a stream. Say we have a topic containing user email addresses; every time a user updates their email address we send a message to this topic using their user id as the
     primary key. Now say we send the following messages over some time period for a user with id 123, each message corresponding to a change in email address (messages for other ids are omitted):
-    <pre class="line-numbers"><code class="language-text"><code>       123 => bill@microsoft.com
+    <pre class="line-numbers"><code class="language-text">       123 => bill@microsoft.com
                 .
                 .
                 .


### PR DESCRIPTION
Before this patch:

![Screenshot from 2020-11-26 09-13-19](https://user-images.githubusercontent.com/879487/100331258-d4caf400-2fc7-11eb-815d-df069fa4a937.png)


After this patch (excuse the find-in-page highlighting):

![Screenshot from 2020-11-26 09-12-38](https://user-images.githubusercontent.com/879487/100331281-dc8a9880-2fc7-11eb-8ccb-71324341e3ce.png)

