### PR TITLE
Use downloads.apache.org for current releases

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -9,7 +9,7 @@
     <p>2.7.0 is the latest release. The current stable version is 2.7.0.</p>
 
     <p>
-    You can verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://www.apache.org/dist/kafka/KEYS">KEYS</a>.
+    You can verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://downloads.apache.org/kafka/KEYS">KEYS</a>.
     </p>
 
     <span id="2.7.0"></span>
@@ -19,16 +19,16 @@
             Released Dec 21, 2020
         </li>
         <li>
-            <a href="https://www.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://downloads.apache.org/kafka/2.7.0/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.7.0/kafka-2.7.0-src.tgz">kafka-2.7.0-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.7.0/kafka-2.7.0-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.7.0/kafka-2.7.0-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.7.0/kafka-2.7.0-src.tgz">kafka-2.7.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/2.7.0/kafka-2.7.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.7.0/kafka-2.7.0-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.7.0/kafka_2.12-2.7.0.tgz">kafka_2.12-2.7.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.7.0/kafka_2.12-2.7.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.7.0/kafka_2.12-2.7.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.7.0/kafka_2.13-2.7.0.tgz">kafka_2.13-2.7.0.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.7.0/kafka_2.13-2.7.0.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.7.0/kafka_2.13-2.7.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.7.0/kafka_2.12-2.7.0.tgz">kafka_2.12-2.7.0.tgz</a> (<a href="https://downloads.apache.org/kafka/2.7.0/kafka_2.12-2.7.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.7.0/kafka_2.12-2.7.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.7.0/kafka_2.13-2.7.0.tgz">kafka_2.13-2.7.0.tgz</a> (<a href="https://downloads.apache.org/kafka/2.7.0/kafka_2.13-2.7.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.7.0/kafka_2.13-2.7.0.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -51,7 +51,7 @@
     </ul>
 
     <p>
-        For more information, please read the detailed <a href="https://www.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html">Release Notes</a>.
+        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/2.7.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="2.6.1"></span>
@@ -61,16 +61,16 @@
             Released January 07, 2021
         </li>
         <li>
-            <a href="https://www.apache.org/dist/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://downloads.apache.org/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.6.1/kafka-2.6.1-src.tgz">kafka-2.6.1-src.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.6.1/kafka-2.6.1-src.tgz">kafka-2.6.1-src.tgz</a> (<a href="https://downloads.apache.org/kafka/2.6.1/kafka-2.6.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.6.1/kafka-2.6.1-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.6.1/kafka_2.12-2.6.1.tgz">kafka_2.12-2.6.1.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.6.1/kafka_2.13-2.6.1.tgz">kafka_2.13-2.6.1.tgz</a> (<a href="https://www.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz.asc">asc</a>, <a href="https://www.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.6.1/kafka_2.12-2.6.1.tgz">kafka_2.12-2.6.1.tgz</a> (<a href="https://downloads.apache.org/kafka/2.6.1/kafka_2.12-2.6.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.6.1/kafka_2.12-2.6.1.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.6.1/kafka_2.13-2.6.1.tgz">kafka_2.13-2.6.1.tgz</a> (<a href="https://downloads.apache.org/kafka/2.6.1/kafka_2.13-2.6.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.6.1/kafka_2.13-2.6.1.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -79,7 +79,7 @@
 
     <p>
         Kafka 2.6.1 fixes 41 issues since the 2.6.0 release.
-        For more information, please read the detailed <a href="https://www.apache.org/dist/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>.
+        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="2.6.0"></span>


### PR DESCRIPTION
As per https://www.apache.org/legal/release-policy.html, projects should use downloads.apache.org for current release artifacts instead of www.apache.org/dist.