### PR TITLE
MINOR: update the old anchor #intro_topic into the new one

### DIFF
--- a/27/quickstart.html
+++ b/27/quickstart.html
@@ -82,7 +82,7 @@ $ bin/kafka-server-start.sh config/server.properties</code></pre>
       <p>
           Example events are payment transactions, geolocation updates from mobile phones, shipping orders, sensor measurements
           from IoT devices or medical equipment, and much more. These events are organized and stored in
-          <a href="/documentation/#intro_topics"><em>topics</em></a>.
+          <a href="/documentation/#intro_concepts_and_terms"><em>topics</em></a>.
           Very simplified, a topic is similar to a folder in a filesystem, and the events are the files in that folder.
       </p>
 
@@ -95,7 +95,7 @@ $ bin/kafka-server-start.sh config/server.properties</code></pre>
       <p>
           All of Kafka's command line tools have additional options: run the <code>kafka-topics.sh</code> command without any
           arguments to display usage information. For example, it can also show you
-          <a href="/documentation/#intro_topics">details such as the partition count</a>
+          <a href="/documentation/#intro_concepts_and_terms">details such as the partition count</a>
           of the new topic:
       </p>
 


### PR DESCRIPTION
Accidentally found the anchor # intro_topic doesn't exist anymore, and cause the quick start page has a wrong link. Correct it as the new # intro_concepts_and_terms anchor

![image](https://user-images.githubusercontent.com/43372967/108479343-95632980-72d0-11eb-8ffe-93dee8f26eda.png)
