### PR TITLE
Added documentation fix for KAFKA-12360

### DIFF
--- a/27/generated/streams_config.html
+++ b/27/generated/streams_config.html
@@ -141,7 +141,7 @@
 </li>
 <li>
 <h4><a id="max.task.idle.ms"></a><a id="streamsconfigs_max.task.idle.ms" href="#streamsconfigs_max.task.idle.ms">max.task.idle.ms</a></h4>
-<p>Maximum amount of time in milliseconds a stream task will stay idle when not all of its partition buffers contain records, to avoid potential out-of-order record processing across multiple input streams.</p>
+<p>Maximum amount of time in milliseconds a stream task will stay idle when not all of its partition buffers contain records, to avoid potential out-of-order record processing across multiple input streams. The value must be lower than <code>max.poll.interval.ms</code> to avoid rebalancing of unresponsive tasks.</p>
 <table><tbody>
 <tr><th>Type:</th><td>long</td></tr>
 <tr><th>Default:</th><td>0</td></tr>


### PR DESCRIPTION
The fix clarify the use of max.task.idle.ms, as pointed out in https://issues.apache.org/jira/browse/KAFKA-12360