### PR TITLE
Changed the 2.6.1 links to use the archives

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -109,16 +109,16 @@
             Released January 07, 2021
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.6.1/kafka-2.6.1-src.tgz">kafka-2.6.1-src.tgz</a> (<a href="https://downloads.apache.org/kafka/2.6.1/kafka-2.6.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.6.1/kafka-2.6.1-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz">kafka-2.6.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.6.1/kafka_2.12-2.6.1.tgz">kafka_2.12-2.6.1.tgz</a> (<a href="https://downloads.apache.org/kafka/2.6.1/kafka_2.12-2.6.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.6.1/kafka_2.12-2.6.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.6.1/kafka_2.13-2.6.1.tgz">kafka_2.13-2.6.1.tgz</a> (<a href="https://downloads.apache.org/kafka/2.6.1/kafka_2.13-2.6.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.6.1/kafka_2.13-2.6.1.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz">kafka_2.12-2.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz">kafka_2.13-2.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -127,7 +127,7 @@
 
     <p>
         Kafka 2.6.1 fixes 41 issues since the 2.6.0 release.
-        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>.
+        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="2.6.0"></span>


### PR DESCRIPTION
Prior to removing the 2.6.1 release artifacts from the distribution SVN repo (https://dist.apache.org/repos/dist/release/kafka)