### PR TITLE
fixing mobile logo

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2484,9 +2484,9 @@ ul.video-list {
         margin-top: 16rem;
     }
     .logo-link {
-        width: 170px;
+        width: 100px;
         height: 50px;
-        background-size: 168px auto;
+        background-size: 93px auto;
         background-repeat: no-repeat;
     }
     .content {


### PR DESCRIPTION
Noticed the logo is off on mobile when I clicked through via an article.

Not sure when this happened, but here's the fix.

current:
![Screen Shot 2021-06-16 at 2 50 27 PM](https://user-images.githubusercontent.com/66280178/122275954-46aa5280-ceb2-11eb-808b-75ed69af6745.png)

fix:
![Screen Shot 2021-06-16 at 2 50 41 PM](https://user-images.githubusercontent.com/66280178/122275950-4611bc00-ceb2-11eb-9365-6176a8599a57.png)
