### PR TITLE
MINOR: Publish web site via .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+publish:
+   whoami: asf-site


### PR DESCRIPTION
As per ASF Infra, web site should switch to method of publishing via the .asf.yaml meta-file.

https://infra-reports.apache.org/site-source/ 