### PR TITLE
Change 2.8.0 downloads to use archives

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -47,16 +47,16 @@
             Released April 19, 2021
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/2.8.0/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/2.8.0/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka-2.8.0-src.tgz">kafka-2.8.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/2.8.0/kafka-2.8.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.8.0/kafka-2.8.0-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka-2.8.0-src.tgz">kafka-2.8.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.0/kafka-2.8.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka-2.8.0-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.12-2.8.0.tgz">kafka_2.12-2.8.0.tgz</a> (<a href="https://downloads.apache.org/kafka/2.8.0/kafka_2.12-2.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.8.0/kafka_2.12-2.8.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz">kafka_2.13-2.8.0.tgz</a> (<a href="https://downloads.apache.org/kafka/2.8.0/kafka_2.13-2.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/2.8.0/kafka_2.13-2.8.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz">kafka_2.12-2.8.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.13-2.8.0.tgz">kafka_2.13-2.8.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.13-2.8.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.13-2.8.0.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -85,7 +85,7 @@
     </ul>
 
     <p>
-        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/2.8.0/RELEASE_NOTES.html">Release Notes</a>.
+        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.8.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="2.7.1"></span>


### PR DESCRIPTION
Now that 2.8.1 has been released, we can change the 2.8.0 download links to use the archive site.