### PR TITLE
KAFKA-13374: update doc to allow read from leader/followers

### DIFF
--- a/31/design.html
+++ b/31/design.html
@@ -313,7 +313,7 @@
     replication factor is one.
     <p>
     The unit of replication is the topic partition. Under non-failure conditions, each partition in Kafka has a single leader and zero or more followers. The total number of replicas including the leader constitute the
-    replication factor. All reads and writes go to the leader of the partition. Typically, there are many more partitions than brokers and the leaders are evenly distributed among brokers. The logs on the followers are
+    replication factor. All writes go to the leader of the partition, and reads can go to the leader or the followers of the partition. Typically, there are many more partitions than brokers and the leaders are evenly distributed among brokers. The logs on the followers are
     identical to the leader's log&mdash;all have the same offsets and messages in the same order (though, of course, at any given time the leader may have a few as-yet unreplicated messages at the end of its log).
     <p>
     Followers consume messages from the leader just as a normal Kafka consumer would and apply them to their own log. Having the followers pull from the leader has the nice property of allowing the follower to naturally


### PR DESCRIPTION
After KIP-392, we allow consumers to fetch data from leader or followers. Update the doc.
PR for kafka repo: https://github.com/apache/kafka/pull/11408