### PR TITLE
MINOR: Unsubscribe mailing lists

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -13,21 +13,21 @@
 		<ul>
 			<li>
 				<b>User mailing list</b>: A list for general user questions about Kafka&reg;. To subscribe, send an email to <a href="mailto:users-subscribe@kafka.apache.org">users-subscribe@kafka.apache.org</a>. Once subscribed, you can ask general user questions by mailing to <a href="mailto:users@kafka.apache.org">users@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?users@kafka.apache.org">here</a>.
+				To unsubscribe, send an email to <a href="mailto:users-unsubscribe@kafka.apache.org">users-unsubscribe@kafka.apache.org</a>.
 			</li>
 			<li>
 				<b>Developer mailing list</b>: A list for discussion on Kafka&reg; development. To subscribe, send an email to <a href="mailto:dev-subscribe@kafka.apache.org">dev-subscribe@kafka.apache.org</a>. Once subscribed, you can have discussion on Kafka&reg; development by mailing to <a href="mailto:dev@kafka.apache.org">dev@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?dev@kafka.apache.org">here</a>.
+				To unsubscribe, send an email to <a href="mailto:dev-unsubscribe@kafka.apache.org">dev-unsubscribe@kafka.apache.org</a>.
 			</li>
 			<li>
 				<b>JIRA mailing list</b>: A list to track Kafka&reg; <a href="https://issues.apache.org/jira/projects/KAFKA">JIRA</a> notifications. To subscribe, send an email to <a href="mailto:jira-subscribe@kafka.apache.org">jira-subscribe@kafka.apache.org</a>. Archives are available <a href="https://lists.apache.org/list.html?jira@kafka.apache.org">here</a>.
+				To unsubscribe, send an email to <a href="mailto:jira-unsubscribe@kafka.apache.org">jira-unsubscribe@kafka.apache.org</a>.
 			</li>
 			<li>
 				<b>Commit mailing list</b>: A list to track Kafka&reg; commits. To subscribe, send an email to <a href="mailto:commits-subscribe@kafka.apache.org">commits-subscribe@kafka.apache.org</a>. Archives are available <a href="http://mail-archives.apache.org/mod_mbox/kafka-commits">here</a>.
+				To unsubscribe, send an email to <a href="mailto:commits-unsubscribe@kafka.apache.org">commits-unsubscribe@kafka.apache.org</a>.
 			</li>
 		</ul>
-
-		<p>
-		To unsubscribe from any of these you just change the word "subscribe" to "unsubscribe" in the email adresses above.
-		</p>
 
 		<p>
 		Prior to the move to Apache we had a Google group we used for discussion. Archives can be found <a href="http://groups.google.com/group/kafka-dev">here</a>. After that we were in Apache Incubator which has its own archives for <a href="http://mail-archives.apache.org/mod_mbox/incubator-kafka-users/">user</a>, <a href="http://mail-archives.apache.org/mod_mbox/incubator-kafka-dev/">dev</a>, and <a href="http://mail-archives.apache.org/mod_mbox/incubator-kafka-commits/">commit</a> lists.


### PR DESCRIPTION
We fairly frequently get people emailing `dev@` asking how to describe. Although this was described on /contact, it maybe wasn't very obvious for people not reading the whole page. So give explicit instructions to unsubscribe from each list.