### PR TITLE
Move IRC pointer to libera.chat

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -35,7 +35,11 @@
 
 		<h3>IRC</h3>
 		<p>
-			We have an IRC channel where there is often a few people hanging around if you want an interactive discussion. You can find us on chat.freenode.net	in #apache-kafka room (previously #kafka). The irc log can be found <a href="https://botbot.me/freenode/apache-kafka/">here</a>.
+			We have an IRC channel where there is often a few people hanging around if you want an interactive discussion. You can find us on libera.chat in #apache-kafka room (previously #kafka).
+
+<!--
+The irc log can be found <a href="https://botbot.me/freenode/apache-kafka/">here</a>.
+-->
 		</p>
 
 


### PR DESCRIPTION
1) It looks like you have moved your primary IRC presence to libera.chat, as you should. Update the website accordingly.

2) The link to botbot.me is no longer accurate, and it references freenode anyways. Remove link to defunct irc log site.