### PR TITLE
KAFKA-13868: Add ASF links to the footer including privacy policy

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -901,6 +901,7 @@ tr:nth-child(odd) {
     color: #888888;
     padding: 2rem 0;
     background: white;
+    text-align: center;
 }
 .footer__legal {
     margin: 0 2rem;

--- a/includes/_footer.htm
+++ b/includes/_footer.htm
@@ -4,9 +4,17 @@
 		<div class="footer">
 			<div class="footer__inner">
 				<div class="footer__legal">
-					<span class="footer__legal__one">The contents of this website are &copy; 2017 <a href="https://www.apache.org/" target="_blank">Apache Software Foundation</a> under the terms of the <a href="https://www.apache.org/licenses/LICENSE-2.0.html" target="_blank">Apache License v2</a>.</span>
+					<span class="footer__legal__one">The contents of this website are &copy; 2022 <a href="https://www.apache.org/" target="_blank">Apache Software Foundation</a> under the terms of the <a href="https://www.apache.org/licenses/LICENSE-2.0.html" target="_blank">Apache License v2</a>.</span>
 					<span class="footer__legal__two">Apache Kafka, Kafka, and the Kafka logo are either registered trademarks or trademarks of The Apache Software Foundation</span>
 					<span class="footer__legal__three">in the United States and other countries.</span>
+					<div>
+						<a href="https://kafka.apache.org/project-security" target="_blank" rel="noreferrer">Security</a>&nbsp;|&nbsp;
+						<a href="https://www.apache.org/foundation/sponsorship.html" target="_blank" rel="noreferrer">Donate</a>&nbsp;|&nbsp;
+						<a href="https://www.apache.org/foundation/thanks.html" target="_blank" rel="noreferrer">Thanks</a>&nbsp;|&nbsp;
+						<a href="https://apache.org/events/current-event" target="_blank" rel="noreferrer">Events</a>&nbsp;|&nbsp;
+						<a href="https://apache.org/licenses/" target="_blank" rel="noreferrer">License</a>&nbsp;|&nbsp;
+						<a href="https://privacy.apache.org/policies/privacy-policy-public.html" target="_blank" rel="noreferrer">Privacy</a>
+					</div>
 				</div>
 				<a class="apache-feather" target="_blank" href="http://www.apache.org">
 					<img width="40" src="/images/feather-small.png" alt="Apache Feather">

--- a/includes/_top.htm
+++ b/includes/_top.htm
@@ -151,48 +151,6 @@
 						</ul>
 					</li>
 					<li class="top-nav-item" role="menuitem">
-						<a href="#" class="top-nav-item-anchor" aria-haspopup="true" aria-expanded="false" aria-controls="nav-community-menu">
-							Apache Software
-						</a>
-						<ul class="top-nav-menu" aria-hidden="true" role="menu" id="nav-community-menu" title="Apache Homepage">
-							<li class="top-nav-menu-item" role="menuitem">
-								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/" target="_blank">
-									Apache Homepage
-								</a>
-							</li>
-							<li class="top-nav-menu-item" role="menuitem">
-								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/licenses/">
-									License
-								</a>
-							</li>
-							<li class="top-nav-menu-item" role="menuitem">
-								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/events/current-event">
-									Events
-								</a>
-							</li>
-							<li class="top-nav-menu-item" role="menuitem">
-								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/foundation/sponsorship.html" target="_blank">
-									Sponsorship
-								</a>
-							</li>
-							<li class="top-nav-menu-item" role="menuitem">
-								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/foundation/thanks.html">
-									Sponsors
-								</a>
-							</li>
-							<li class="top-nav-menu-item" role="menuitem">
-								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/security/">
-									Security
-								</a>
-							</li>
-							<li class="top-nav-menu-item" role="menuitem">
-								<a class="top-nav-anchor" tabindex="-1" href="https://privacy.apache.org/policies/privacy-policy-public.html">
-									Privacy
-								</a>
-							</li>
-						</ul>
-					</li>
-					<li class="top-nav-item" role="menuitem">
 						<a href="/downloads" class="top-nav-download" tabindex="-1" id="top-nav-download">
 							Download Kafka
 						</a>

--- a/includes/_top.htm
+++ b/includes/_top.htm
@@ -151,6 +151,48 @@
 						</ul>
 					</li>
 					<li class="top-nav-item" role="menuitem">
+						<a href="#" class="top-nav-item-anchor" aria-haspopup="true" aria-expanded="false" aria-controls="nav-community-menu">
+							Apache Software
+						</a>
+						<ul class="top-nav-menu" aria-hidden="true" role="menu" id="nav-community-menu" title="Apache Homepage">
+							<li class="top-nav-menu-item" role="menuitem">
+								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/" target="_blank">
+									Apache Homepage
+								</a>
+							</li>
+							<li class="top-nav-menu-item" role="menuitem">
+								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/licenses/">
+									License
+								</a>
+							</li>
+							<li class="top-nav-menu-item" role="menuitem">
+								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/events/current-event">
+									Events
+								</a>
+							</li>
+							<li class="top-nav-menu-item" role="menuitem">
+								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/foundation/sponsorship.html" target="_blank">
+									Sponsorship
+								</a>
+							</li>
+							<li class="top-nav-menu-item" role="menuitem">
+								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/foundation/thanks.html">
+									Sponsors
+								</a>
+							</li>
+							<li class="top-nav-menu-item" role="menuitem">
+								<a class="top-nav-anchor" tabindex="-1" href="https://www.apache.org/security/">
+									Security
+								</a>
+							</li>
+							<li class="top-nav-menu-item" role="menuitem">
+								<a class="top-nav-anchor" tabindex="-1" href="https://privacy.apache.org/policies/privacy-policy-public.html">
+									Privacy
+								</a>
+							</li>
+						</ul>
+					</li>
+					<li class="top-nav-item" role="menuitem">
 						<a href="/downloads" class="top-nav-download" tabindex="-1" id="top-nav-download">
 							Download Kafka
 						</a>


### PR DESCRIPTION
**Why**
As per the [Apache branding policy](https://www.apache.org/foundation/marks/pmcs#navigation), every project website's homepage must feature certain text links back to key pages on the main www.apache.org website.

**What**
Added ASF related links to footer which includes the required links including Privacy Policy requirement outlined in https://issues.apache.org/jira/browse/KAFKA-13868 

**Tested**
Tested the change by running website locally. The new footer looks as follows:
<img width="1435" alt="Screenshot 2022-07-18 at 18 24 03" src="https://user-images.githubusercontent.com/71267/179559594-c856f589-1e9b-4892-82fd-b1c157c87fc3.png">

