### PR TITLE
KAFKA-13868: Replace Google Analytics with Matomo

### DIFF
--- a/google29eadbd0256e020c.html
+++ b/google29eadbd0256e020c.html
@@ -1,1 +1,0 @@
-google-site-verification: google29eadbd0256e020c.html

--- a/google7bff870a0cde1d0d.html
+++ b/google7bff870a0cde1d0d.html
@@ -1,1 +1,0 @@
-google-site-verification: google7bff870a0cde1d0d.html

--- a/googlebc99ea69c42cb214.html
+++ b/googlebc99ea69c42cb214.html
@@ -1,1 +1,0 @@
-google-site-verification: googlebc99ea69c42cb214.html

--- a/includes/_footer.htm
+++ b/includes/_footer.htm
@@ -374,16 +374,5 @@
 				});
 			}());
 		</script>
-
-		<script>
-			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-			(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-			})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-			ga('create', 'UA-7818013-4', 'apache.org');
-			ga('send', 'pageview');
-
-		</script>
 	</body>
 </html>

--- a/includes/_header.htm
+++ b/includes/_header.htm
@@ -59,4 +59,21 @@
 				}
 			}
 		</script>
+		<!-- Matomo -->
+		<script>
+			var _paq = window._paq = window._paq || [];
+			/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+			/* We explicitly disable cookie tracking to avoid privacy issues */
+			_paq.push(['disableCookies']);
+			_paq.push(['trackPageView']);
+			_paq.push(['enableLinkTracking']);
+			(function() {
+				var u="//matomo.privacy.apache.org/";
+				_paq.push(['setTrackerUrl', u+'matomo.php']);
+				_paq.push(['setSiteId', '26']);
+				var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+				g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+			})();
+		</script>
+		<!-- End Matomo Code -->
 	</head>


### PR DESCRIPTION
As per the [ASF privacy policy](https://privacy.apache.org/faq/committers.html), Google Analytics should be replaced with Apache hosted version of Matomo to remain complaint with GDPR.

Email thread where we received the site Id that is used with Matomo: https://lists.apache.org/thread/0rpo0ffcd70c2yxfnqfqk43oyg7c8x8d 

## Code changes
- Remove Google Analytics script
- Remote `google-site-verification` files which are [used by Google to verify the ownership of site](https://university.webflow.com/lesson/google-site-verification). After verification of ownership, owners can send the site for indexing etc. This is also required to observe the analytics. However, the Apache website should not be associated with any particular Google account and hence, I deleted these files. 
- Add Matomo script to the `<head>` section (all JS scripts should ideally be placed there and not in `<body>`).

## Results
After deploying the changes, we should be able to analyse the results at https://analytics.apache.org/index.php?module=MultiSites&action=index&idSite=1&period=day&date=yesterday