### PR TITLE
KAFKA-13868: Replace YouTube embedded video with hyperlinks

### DIFF
--- a/intro.html
+++ b/intro.html
@@ -6,18 +6,7 @@
   <div class="right">
 		<div class="page-header">
       <h1 class="page-header-title">Introduction</h1>
-      <p class="page-header-text">Everything you need to know about Kafka in 10 minutes</p>
-
-      <div class="page-header-video">
-        <iframe
-          class="youtube-embed page-header-video-embed"
-          width="480" height="270"
-          src="https://www.youtube.com/embed/FKgi3n-FyNU?modestbranding=1"
-          frameborder="0"
-          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-        </iframe>
-      </div>
-      
+      <p class="page-header-text"><a href="https://www.youtube.com/embed/FKgi3n-FyNU">Watch video: Everything you need to know about Kafka in 10 minutes</a></p>
     </div>
 <!-- should always link the latest release's documentation -->
     <!--#include virtual="/32/introduction.html" -->

--- a/quickstart.html
+++ b/quickstart.html
@@ -5,18 +5,7 @@
   <!--#include virtual="includes/_nav.htm" -->
     <div class="page-header">
       <h1 class="page-header-title">Apache Kafka Quickstart</h1>
-      <p class="page-header-text">Interested in getting started with Kafka?  Follow the instructions in this quickstart, or watch the video below.</p>
-
-      <div class="page-header-video">
-        <iframe
-          class="youtube-embed page-header-video-embed"
-          width="480" height="270"
-          src="https://www.youtube.com/embed/FKgi3n-FyNU?modestbranding=1"
-          frameborder="0"
-          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-        </iframe>
-      </div>
-      
+      <p class="page-header-text">Interested in getting started with Kafka?  Follow the instructions in this quickstart, or <a href="https://www.youtube.com/embed/FKgi3n-FyNU">watch the video.</a></p>
     </div>
 <!-- should always link the latest release's documentation -->
     <!--#include virtual="32/quickstart.html" -->


### PR DESCRIPTION
As per the [discussion in the community](https://lists.apache.org/thread/p24xvbf8nkvxpbj668vc0g3x3lojsnk4), we want to replace the embedded YouTube videos with hyperlinks to satisfy the [ASF privacy policy](https://privacy.apache.org/faq/committers.html).

This code change replaces the embedded videos from two of the pages on the website with hyperlinks.

**Before**
![Screenshot 2022-07-25 at 19 31 50](https://user-images.githubusercontent.com/71267/180839003-da0f967c-019b-449e-a7c3-3bbac37611dd.png)
![Screenshot 2022-07-25 at 19 32 13](https://user-images.githubusercontent.com/71267/180839020-b37a118d-b8ca-480e-8832-bd19b29cfbdd.png)

**After**
![Screenshot 2022-07-25 at 19 32 01](https://user-images.githubusercontent.com/71267/180839040-591e67df-8053-4633-9c35-52d7fd32fd0c.png)
![Screenshot 2022-07-25 at 19 32 23](https://user-images.githubusercontent.com/71267/180839061-355b3e06-1e9c-40da-89b0-aefd95ee5be5.png)

