### PR TITLE
Correct the year of release date for 2.7.1 in downloads.html

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -341,7 +341,7 @@
     <h3 class="download-version">2.7.1<a href="#2.7.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
     <ul>
         <li>
-            Released May 10, 2020
+            Released May 10, 2021
         </li>
         <li>
             <a href="https://archive.apache.org/dist/kafka/2.7.1/RELEASE_NOTES.html">Release Notes</a>


### PR DESCRIPTION
This is a super tiny thing, but could be misleading. I believe the release date year is not correct given 2.7.0 released later than 2.7.1 is a contradiction.  I also download the build to verify this, I can see the files are created in April 2021.