### PR TITLE
MINOR: quick fix for TOC handle

### DIFF
--- a/33/ops.html
+++ b/33/ops.html
@@ -1388,7 +1388,7 @@ $ bin/kafka-acls.sh \
 
   <pre class="line-numbers"><code class="language-bash"> &gt; bin/kafka-storage.sh format --cluster-id uuid --config server_properties</code></pre>
 
-  <p>It is possible for the <code>bin/kafka-storage.sh format<code> command above to fail with a message like <code>Log directory ... is already formatted<code>. This can happend when combined mode is used and only the metadata log directory was lost but not the others. In that case and only in that case, can you run the <code>kafka-storage.sh format</code> command with the <code>--ignore-formatted</code> option.</p>
+  <p>It is possible for the <code>bin/kafka-storage.sh format</code> command above to fail with a message like <code>Log directory ... is already formatted</code>. This can happend when combined mode is used and only the metadata log directory was lost but not the others. In that case and only in that case, can you run the <code>kafka-storage.sh format</code> command with the <code>--ignore-formatted</code> option.</p>
 
   <p>Start the KRaft controller after formatting the log directories.</p>
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1215,7 +1215,7 @@ nav .btn {
 }
 .content.documentation--current .right {
     max-width: 65rem;
-    margin: 0 0 0 33rem;
+    margin: 0 0 0 auto;
 }
 .content.documentation--current.expanded .right {
     max-width: 85rem;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1215,7 +1215,7 @@ nav .btn {
 }
 .content.documentation--current .right {
     max-width: 65rem;
-    margin: 0 0 0 auto;
+    margin: 0 0 0 33rem;
 }
 .content.documentation--current.expanded .right {
     max-width: 85rem;


### PR DESCRIPTION
Seen in the prerelease of the 3.3 docs, the TOC handle overlaps with the main contents of the `.right` div.

The left margin for this div was "auto", which was not getting calculated correctly. This patch sets the left margin to 33 rem which is what the actual left margin is supposed to be. Since the TOC and handle are fixed width, it's okay to use a fixed margin as well.



**Current 3.3 docs:**

----------------
<img width="955" alt="image" src="https://user-images.githubusercontent.com/55116/192832666-3534e0aa-b242-4ffa-97e1-e49a16b61164.png">

----------------

**With this patch:**

----------------
<img width="952" alt="image" src="https://user-images.githubusercontent.com/55116/192832744-006838ea-04f6-480c-a7b7-c8964b9f7473.png">

----------------

There is likely some other issue in the body elements causing this margin to get miscalculated, though I couldn't find the root cause. 

Tested in Chrome 106.0.5249.61 and Safari 15.6.1 on Mac OS 12.5.1.
