### PR TITLE
MINOR: Fix closing code tag

### DIFF
--- a/33/generated/producer_config.html
+++ b/33/generated/producer_config.html
@@ -541,7 +541,7 @@
 </li>
 <li>
 <h4><a id="partitioner.availability.timeout.ms"></a><a id="producerconfigs_partitioner.availability.timeout.ms" href="#producerconfigs_partitioner.availability.timeout.ms">partitioner.availability.timeout.ms</a></h4>
-<p>If a broker cannot process produce requests from a partition for <code>partitioner.availability.timeout.ms</code> time, the partitioner treats that partition as not available.  If the value is 0, this logic is disabled. Note: this setting has no effect if a custom partitioner is used or <code>partitioner.adaptive.partitioning.enable<code/> is set to 'false'</p>
+<p>If a broker cannot process produce requests from a partition for <code>partitioner.availability.timeout.ms</code> time, the partitioner treats that partition as not available.  If the value is 0, this logic is disabled. Note: this setting has no effect if a custom partitioner is used or <code>partitioner.adaptive.partitioning.enable</code> is set to 'false'</p>
 <table><tbody>
 <tr><th>Type:</th><td>long</td></tr>
 <tr><th>Default:</th><td>0</td></tr>


### PR DESCRIPTION
Without this closing tag, all configs below `partitioner.availability.timeout.ms` are rendered in `code` blocks: https://kafka.apache.org/documentation/#consumerconfigs