### PR TITLE
MINOR: Rename description of flatMapValues transformation

### DIFF
--- a/33/streams/developer-guide/dsl-api.html
+++ b/33/streams/developer-guide/dsl-api.html
@@ -463,7 +463,7 @@ KStream&lt;String, Integer&gt; transformed = stream.flatMap(
 // Java 7 example: cf. `map` for how to create `KeyValueMapper` instances</code></pre>
                         </td>
                     </tr>
-                    <tr class="row-even"><td><p class="first"><strong>FlatMap (values only)</strong></p>
+                    <tr class="row-even"><td><p class="first"><strong>FlatMapValues</strong></p>
                         <ul class="last simple">
                             <li>KStream &rarr; KStream</li>
                         </ul>


### PR DESCRIPTION
The table of (stateless) transformations uses the transformation name in the first column and a description in the second column. I adjusted the transformation name for FlatMapValues accordingly.

See also [Kafka #8431](https://github.com/apache/kafka/pull/8431)

@bbejeck 