### PR TITLE
Update website for 3.4.0 release

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="33/documentation.html" -->
+<!--#include virtual="34/documentation.html" -->

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../33/documentation.html" -->
+<!--#include virtual="../34/documentation.html" -->

--- a/documentation/streams/architecture.html
+++ b/documentation/streams/architecture.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../33/streams/architecture.html" -->
+<!--#include virtual="../../34/streams/architecture.html" -->

--- a/documentation/streams/core-concepts.html
+++ b/documentation/streams/core-concepts.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../33/streams/core-concepts.html" -->
+<!--#include virtual="../../34/streams/core-concepts.html" -->

--- a/documentation/streams/developer-guide/app-reset-tool.html
+++ b/documentation/streams/developer-guide/app-reset-tool.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/app-reset-tool.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/app-reset-tool.html" -->

--- a/documentation/streams/developer-guide/config-streams.html
+++ b/documentation/streams/developer-guide/config-streams.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/config-streams.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/config-streams.html" -->

--- a/documentation/streams/developer-guide/datatypes.html
+++ b/documentation/streams/developer-guide/datatypes.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/datatypes.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/datatypes.html" -->

--- a/documentation/streams/developer-guide/dsl-api.html
+++ b/documentation/streams/developer-guide/dsl-api.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/dsl-api.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/dsl-api.html" -->

--- a/documentation/streams/developer-guide/dsl-topology-naming.html
+++ b/documentation/streams/developer-guide/dsl-topology-naming.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/dsl-topology-naming.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/dsl-topology-naming.html" -->

--- a/documentation/streams/developer-guide/index.html
+++ b/documentation/streams/developer-guide/index.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/index.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/index.html" -->

--- a/documentation/streams/developer-guide/interactive-queries.html
+++ b/documentation/streams/developer-guide/interactive-queries.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/interactive-queries.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/interactive-queries.html" -->

--- a/documentation/streams/developer-guide/manage-topics.html
+++ b/documentation/streams/developer-guide/manage-topics.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/manage-topics.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/manage-topics.html" -->

--- a/documentation/streams/developer-guide/memory-mgmt.html
+++ b/documentation/streams/developer-guide/memory-mgmt.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/memory-mgmt.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/memory-mgmt.html" -->

--- a/documentation/streams/developer-guide/processor-api.html
+++ b/documentation/streams/developer-guide/processor-api.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/processor-api.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/processor-api.html" -->

--- a/documentation/streams/developer-guide/running-app.html
+++ b/documentation/streams/developer-guide/running-app.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/running-app.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/running-app.html" -->

--- a/documentation/streams/developer-guide/security.html
+++ b/documentation/streams/developer-guide/security.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/security.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/security.html" -->

--- a/documentation/streams/developer-guide/testing.html
+++ b/documentation/streams/developer-guide/testing.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/testing.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/testing.html" -->

--- a/documentation/streams/developer-guide/write-streams.html
+++ b/documentation/streams/developer-guide/write-streams.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../33/streams/developer-guide/write-streams.html" -->
+<!--#include virtual="../../../34/streams/developer-guide/write-streams.html" -->

--- a/documentation/streams/index.html
+++ b/documentation/streams/index.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../33/streams/index.html" -->
+<!--#include virtual="../../34/streams/index.html" -->

--- a/documentation/streams/quickstart.html
+++ b/documentation/streams/quickstart.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../33/streams/quickstart.html" -->
+<!--#include virtual="../../34/streams/quickstart.html" -->

--- a/documentation/streams/upgrade-guide.html
+++ b/documentation/streams/upgrade-guide.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../33/streams/upgrade-guide.html" -->
+<!--#include virtual="../../34/streams/upgrade-guide.html" -->

--- a/downloads.html
+++ b/downloads.html
@@ -6,10 +6,38 @@
 	<div class="right">
     <h1>Download</h1>
 
-    <p>3.3.2 is the latest release. The current stable version is 3.3.2.</p>
+    <p>3.4.0 is the latest release. The current stable version is 3.4.0</p>
 
     <p>
     You can verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://downloads.apache.org/kafka/KEYS">KEYS</a>.
+    </p>
+
+    <span id="3.4.0"></span>
+    <h3 class="download-version">3.4.0<a href="#3.4.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+    <ul>
+        <li>
+            Released Feb 7, 2023
+        </li>
+        <li>
+            <a href="https://downloads.apache.org/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>
+        </li>
+        <li>
+            Source download: <a href="https://downloads.apache.org/kafka/3.4.0/kafka-3.4.0-src.tgz">kafka-3.4.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.4.0/kafka-3.4.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.4.0/kafka-3.4.0-src.tgz.sha512">sha512</a>)
+        </li>
+        <li>
+            Binary downloads:
+            <ul>
+                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.12-3.4.0.tgz">kafka_2.12-3.4.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.12-3.4.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.12-3.4.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.13-3.4.0.tgz">kafka_2.13-3.4.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.13-3.4.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.13-3..tgz.sha512">sha512</a>)</li>
+            </ul>
+            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+        </li>
+    </ul>
+
+    <p>
+        Kafka 3.4.0 includes a significant number of new features and fixes.
+        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>
     </p>
 
     <span id="3.3.2"></span>

--- a/intro.html
+++ b/intro.html
@@ -29,7 +29,7 @@
         </div>
     </div>
 <!-- should always link the latest release's documentation -->
-    <!--#include virtual="/33/introduction.html" -->
+    <!--#include virtual="/34/introduction.html" -->
 
 <!--#include virtual="includes/_footer.htm" -->
 

--- a/protocol.html
+++ b/protocol.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="33/protocol.html" -->
+<!--#include virtual="34/protocol.html" -->

--- a/quickstart.html
+++ b/quickstart.html
@@ -30,7 +30,7 @@
     </div>
 
 <!-- should always link the latest release's documentation -->
-    <!--#include virtual="33/quickstart.html" -->
+    <!--#include virtual="34/quickstart.html" -->
 <!--#include virtual="includes/_footer.htm" -->
 <script>
 // Show selected style on nav item

--- a/uses.html
+++ b/uses.html
@@ -7,7 +7,7 @@
 		<h1 class="content-title">Use cases</h1>
 
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="33/uses.html" -->
+<!--#include virtual="34/uses.html" -->
 
 <!--#include virtual="includes/_footer.htm" -->
 


### PR DESCRIPTION
This PR updates the "33" template references to "34" for the 3.4.0 release. It also adds the released artifacts to the downloads page and points the documentation page at the 3.4 documentation page