### PR TITLE
MINOR: explicitly set listener host name

### DIFF
--- a/34/ops.html
+++ b/34/ops.html
@@ -3673,7 +3673,7 @@ zookeeper.connect=localhost:2181
   <pre>
 # Sample ZK broker server.properties listening on 9092
 broker.id=0
-listeners=PLAINTEXT://:9092
+listeners=PLAINTEXT://localhost:9092
 advertised.listeners=PLAINTEXT://localhost:9092
 listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
 
@@ -3715,7 +3715,7 @@ controller.listener.names=CONTROLLER</pre>
 # Sample KRaft broker server.properties listening on 9092
 process.roles=broker
 node.id=0
-listeners=PLAINTEXT://:9092
+listeners=PLAINTEXT://localhost:9092
 advertised.listeners=PLAINTEXT://localhost:9092
 listener.security.protocol.map=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
 


### PR DESCRIPTION
Workaround the error:
```
org.apache.kafka.common.errors.InvalidRequestException: Received request api key LEADER_AND_ISR which is not enabled
[2023-02-08 12:06:25,776] ERROR Exception while processing request from 192.168.1.11:9092-192.168.1.11:57210-107 (kafka.network.Processor)
```

by explicitly set listener host name