### PR TITLE
KAFKA-14751: Official website CONTACT page IRC channel link change

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -35,7 +35,7 @@
 
 		<h3>IRC</h3>
 		<p>
-			We have an IRC channel where there is often a few people hanging around if you want an interactive discussion. You can find us on chat.freenode.net	in #apache-kafka room (previously #kafka). The irc log can be found <a href="https://botbot.me/freenode/apache-kafka/">here</a>.
+			We have an IRC channel where there is often a few people hanging around if you want an interactive discussion. You can find us on webchat.freenode.net	in #apache-kafka room (previously #kafka). The irc log can be found <a href="https://botbot.me/freenode/apache-kafka/">here</a>.
 		</p>
 
 


### PR DESCRIPTION
"chat.freenode.net" this link should be change to "webchat.freenode.net", since the previous link currently cat not connected.