### PR TITLE
MINOR: Update Chris Egerton's section in committers page

### DIFF
--- a/committers.html
+++ b/committers.html
@@ -385,8 +385,8 @@
         </td>
         <td>
           Chris Egerton<br>
-          Committer<br>
-          <a href="https://www.linkedin.com/in/chris-egerton-93886148/">/in/chris-egerton-93886148</a><br>
+          Committer, and PMC member<br>
+          <a href="https://twitter.com/C0urante">@C0urante</a><br>
           <a href="https://github.com/C0urante/">github.com/C0urante</a><br>
         </td>
       </tr>


### PR DESCRIPTION
- Adds PMC member title
- Replaces LinkedIn with Twitter