### PR TITLE
Use ASF self service portal to get JIRA account

### DIFF
--- a/contributing.html
+++ b/contributing.html
@@ -44,7 +44,7 @@
 
 		The easiest way to get started working with the code base is to pick up a really easy JIRA and work on that. This will help you get familiar with the code base, build system, review process, etc. We flag these kind of starter bugs <a href="https://issues.apache.org/jira/issues/?jql=project%20%3D%20KAFKA%20AND%20labels%20%3D%20newbie%20AND%20status%20%3D%20Open">here</a>.
 		<p>
-		Please contact us to be added to the contributor list with your JIRA account username provided in the email. After that you can assign yourself to the JIRA ticket you have started working on so others will notice.
+		Please request a JIRA account using <a href="https://selfserve.apache.org/jira-account.html">ASF's Self-serve portal</a>. After that you can assign yourself to the JIRA ticket you have started working on so others will notice.
 		</p>
                 <p>
                 If your work is considered a "major change" then you would need to initiate a Kafka Improvement Proposal (KIP) along with the JIRA ticket (more details can be found <a href="https://cwiki.apache.org/confluence/display/KAFKA/Kafka+Improvement+Proposals">here</a>). Please ask us to grant you the permission on wiki space in order to create a KIP wiki page.


### PR DESCRIPTION
We no longer require users to ask the dev mailing list to setup a JIRA account.