### PR TITLE
MINOR: Update collaborators to 10

### DIFF
--- a/contributing.html
+++ b/contributing.html
@@ -89,7 +89,7 @@
 		</p>
 
 		<p>
-		In an effort to keep the Apache Kafka project running smoothly, and also to help contributors become committers, we have enabled these roles (See <a href="https://github.com/apache/kafka/blob/trunk/.asf.yaml">the Apache Kafka Infra config</a>). To keep this process lightweight and fair, we keep the list of contributors full by specifying the top N non-committers (sorted by number of commits they have authored in the last 12 months), where N is the maximum size of that list (currently 20). Authorship is determined by <code>git shortlog</code>. The list will be updated as part of the major/minor release process, three to four times a year.
+		In an effort to keep the Apache Kafka project running smoothly, and also to help contributors become committers, we have enabled these roles (See <a href="https://github.com/apache/kafka/blob/trunk/.asf.yaml">the Apache Kafka Infra config</a>). To keep this process lightweight and fair, we keep the list of contributors full by specifying the top N non-committers (sorted by number of commits they have authored in the last 12 months), where N is the maximum size of that list (currently 10). Authorship is determined by <code>git shortlog</code>. The list will be updated as part of the major/minor release process, three to four times a year.
 		</p>
 
 	<script>

--- a/contributing.html
+++ b/contributing.html
@@ -81,7 +81,7 @@
 		<h2>Collaborators</h2>
 
 		<p>
-		The Apache build infrastructure has provided two roles to make project management easier. These roles allow non-committers to perform some administrative actions like triaging pull requests or triggering builds. They are:
+		The Apache build infrastructure has provided two roles to make project management easier. These roles allow non-committers to perform some administrative actions like triaging pull requests or triggering builds. See the ASF documentation (note: you need to be logged in to the wiki):
 		<ul>
 			<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-JenkinsPRwhitelisting">Jenkins PR Whitelisted Users</a></li>
 			<li><a href="https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=Git+-+.asf.yaml+features#Git.asf.yamlfeatures-AssigningexternalcollaboratorswiththetriageroleonGitHub">Github Collaborators</a></li>


### PR DESCRIPTION
The wiki page documented a limit of 20 people in the collaborators list, but when we merged the change, we were notified that that limit is actually 10 people.