### PR TITLE
MINOR: Added missing Kafka Broker docs for metrics.jmx.(include|exclude) configs

### DIFF
--- a/26/generated/kafka_config.html
+++ b/26/generated/kafka_config.html
@@ -2046,6 +2046,28 @@
 </tbody></table>
 </li>
 <li>
+<h4><a id="metrics.jmx.whitelist" href="#metrics.jmx.whitelist">metrics.jmx.whitelist</a></h4>
+<p>RegEx for included metrics available over JMX.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.blacklist" href="#metrics.jmx.blacklist">metrics.jmx.blacklist</a></h4>
+<p>RegEx for excluded metrics available over JMX. Will exclude metrics available configured by <code>metrics.jmx.whitelist</code>.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
 <h4><a id="password.encoder.cipher.algorithm" href="#password.encoder.cipher.algorithm">password.encoder.cipher.algorithm</a></h4>
 <p>The Cipher algorithm used for encoding dynamically configured passwords.</p>
 <table><tbody>

--- a/27/generated/kafka_config.html
+++ b/27/generated/kafka_config.html
@@ -2134,6 +2134,50 @@
 </tbody></table>
 </li>
 <li>
+<h4><a id="metrics.jmx.include" href="#metrics.jmx.include">metrics.jmx.include</a></h4>
+<p>RegEx for included metrics available over JMX.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>RegEx for excluded metrics available over JMX. Will exclude metrics available configured by <code>metrics.jmx.include</code>.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.whitelist" href="#metrics.jmx.whitelist">metrics.jmx.whitelist</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.include</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.exclude</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
 <h4><a id="password.encoder.cipher.algorithm"></a><a id="brokerconfigs_password.encoder.cipher.algorithm" href="#brokerconfigs_password.encoder.cipher.algorithm">password.encoder.cipher.algorithm</a></h4>
 <p>The Cipher algorithm used for encoding dynamically configured passwords.</p>
 <table><tbody>

--- a/28/generated/kafka_config.html
+++ b/28/generated/kafka_config.html
@@ -2156,6 +2156,50 @@
 </tbody></table>
 </li>
 <li>
+<h4><a id="metrics.jmx.include" href="#metrics.jmx.include">metrics.jmx.include</a></h4>
+<p>RegEx for included metrics available over JMX.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>RegEx for excluded metrics available over JMX. Will exclude metrics available configured by <code>metrics.jmx.include</code>.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.whitelist" href="#metrics.jmx.whitelist">metrics.jmx.whitelist</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.include</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.exclude</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
 <h4><a id="password.encoder.cipher.algorithm"></a><a id="brokerconfigs_password.encoder.cipher.algorithm" href="#brokerconfigs_password.encoder.cipher.algorithm">password.encoder.cipher.algorithm</a></h4>
 <p>The Cipher algorithm used for encoding dynamically configured passwords.</p>
 <table><tbody>

--- a/30/generated/kafka_config.html
+++ b/30/generated/kafka_config.html
@@ -2299,6 +2299,50 @@
 </tbody></table>
 </li>
 <li>
+<h4><a id="metrics.jmx.include" href="#metrics.jmx.include">metrics.jmx.include</a></h4>
+<p>RegEx for included metrics available over JMX.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>RegEx for excluded metrics available over JMX. Will exclude metrics available configured by <code>metrics.jmx.include</code>.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.whitelist" href="#metrics.jmx.whitelist">metrics.jmx.whitelist</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.include</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.exclude</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
 <h4><a id="password.encoder.cipher.algorithm"></a><a id="brokerconfigs_password.encoder.cipher.algorithm" href="#brokerconfigs_password.encoder.cipher.algorithm">password.encoder.cipher.algorithm</a></h4>
 <p>The Cipher algorithm used for encoding dynamically configured passwords.</p>
 <table><tbody>

--- a/31/generated/kafka_config.html
+++ b/31/generated/kafka_config.html
@@ -2321,6 +2321,50 @@
 </tbody></table>
 </li>
 <li>
+<h4><a id="metrics.jmx.include" href="#metrics.jmx.include">metrics.jmx.include</a></h4>
+<p>RegEx for included metrics available over JMX.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>RegEx for excluded metrics available over JMX. Will exclude metrics available configured by <code>metrics.jmx.include</code>.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.whitelist" href="#metrics.jmx.whitelist">metrics.jmx.whitelist</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.include</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.exclude</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
 <h4><a id="password.encoder.cipher.algorithm"></a><a id="brokerconfigs_password.encoder.cipher.algorithm" href="#brokerconfigs_password.encoder.cipher.algorithm">password.encoder.cipher.algorithm</a></h4>
 <p>The Cipher algorithm used for encoding dynamically configured passwords.</p>
 <table><tbody>

--- a/32/generated/kafka_config.html
+++ b/32/generated/kafka_config.html
@@ -2332,6 +2332,50 @@
 </tbody></table>
 </li>
 <li>
+<h4><a id="metrics.jmx.include" href="#metrics.jmx.include">metrics.jmx.include</a></h4>
+<p>RegEx for included metrics available over JMX.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>RegEx for excluded metrics available over JMX. Will exclude metrics available configured by <code>metrics.jmx.include</code>.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.whitelist" href="#metrics.jmx.whitelist">metrics.jmx.whitelist</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.include</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.exclude</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
 <h4><a id="password.encoder.cipher.algorithm"></a><a id="brokerconfigs_password.encoder.cipher.algorithm" href="#brokerconfigs_password.encoder.cipher.algorithm">password.encoder.cipher.algorithm</a></h4>
 <p>The Cipher algorithm used for encoding dynamically configured passwords.</p>
 <table><tbody>

--- a/33/generated/kafka_config.html
+++ b/33/generated/kafka_config.html
@@ -2365,6 +2365,50 @@
 </tbody></table>
 </li>
 <li>
+<h4><a id="metrics.jmx.include" href="#metrics.jmx.include">metrics.jmx.include</a></h4>
+<p>RegEx for included metrics available over JMX.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>RegEx for excluded metrics available over JMX. Will exclude metrics available configured by <code>metrics.jmx.include</code>.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.whitelist" href="#metrics.jmx.whitelist">metrics.jmx.whitelist</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.include</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.exclude</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
 <h4><a id="password.encoder.cipher.algorithm"></a><a id="brokerconfigs_password.encoder.cipher.algorithm" href="#brokerconfigs_password.encoder.cipher.algorithm">password.encoder.cipher.algorithm</a></h4>
 <p>The Cipher algorithm used for encoding dynamically configured passwords.</p>
 <table><tbody>

--- a/34/generated/kafka_config.html
+++ b/34/generated/kafka_config.html
@@ -2398,6 +2398,50 @@
 </tbody></table>
 </li>
 <li>
+<h4><a id="metrics.jmx.include" href="#metrics.jmx.include">metrics.jmx.include</a></h4>
+<p>RegEx for included metrics available over JMX.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>RegEx for excluded metrics available over JMX. Will exclude metrics available configured by <code>metrics.jmx.include</code>.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.whitelist" href="#metrics.jmx.whitelist">metrics.jmx.whitelist</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.include</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.exclude</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
 <h4><a id="password.encoder.cipher.algorithm"></a><a id="brokerconfigs_password.encoder.cipher.algorithm" href="#brokerconfigs_password.encoder.cipher.algorithm">password.encoder.cipher.algorithm</a></h4>
 <p>The Cipher algorithm used for encoding dynamically configured passwords.</p>
 <table><tbody>

--- a/35/generated/kafka_config.html
+++ b/35/generated/kafka_config.html
@@ -2398,6 +2398,50 @@
 </tbody></table>
 </li>
 <li>
+<h4><a id="metrics.jmx.include" href="#metrics.jmx.include">metrics.jmx.include</a></h4>
+<p>RegEx for included metrics available over JMX.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>RegEx for excluded metrics available over JMX. Will exclude metrics available configured by <code>metrics.jmx.include</code>.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.whitelist" href="#metrics.jmx.whitelist">metrics.jmx.whitelist</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.include</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>".*" (all metrics)</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
+<h4><a id="metrics.jmx.exclude" href="#metrics.jmx.exclude">metrics.jmx.exclude</a></h4>
+<p>DEPRECATED: An alias for <code>metrics.jmx.exclude</code>, which should be used instead of this config.</p>
+<table><tbody>
+<tr><th>Type:</th><td>string</td></tr>
+<tr><th>Default:</th><td>""</td></tr>
+<tr><th>Valid Values:</th><td>Valid RegEx</td></tr>
+<tr><th>Importance:</th><td>low</td></tr>
+<tr><th>Update Mode:</th><td>read-only</td></tr>
+</tbody></table>
+</li>
+<li>
 <h4><a id="password.encoder.cipher.algorithm"></a><a id="brokerconfigs_password.encoder.cipher.algorithm" href="#brokerconfigs_password.encoder.cipher.algorithm">password.encoder.cipher.algorithm</a></h4>
 <p>The Cipher algorithm used for encoding dynamically configured passwords.</p>
 <table><tbody>


### PR DESCRIPTION
Added documentation about Kafka Brokers JMX configurable beans. This was introduced by [KIP-544](https://cwiki.apache.org/confluence/display/KAFKA/KIP-544%3A+Make+metrics+exposed+via+JMX+configurable), which was available since [Apache Kafka 2.6.0](https://issues.apache.org/jira/browse/KAFKA-9106), but it was never published in the docs.

Also, by following [KIP-629](https://cwiki.apache.org/confluence/display/KAFKA/KIP-629%3A+Use+racially+neutral+terms+in+our+codebase), the config was changed.

You can see the config in the [JmxReporter class](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/common/metrics/JmxReporter.java#L53-L59).

This PR adds the documentation since Apache Kafka 2.6.0 for this change, including the name change with the former config deprecated.