### PR TITLE
MINOR: Use archive.apache.org for old releases

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -76,16 +76,16 @@
             Released Feb 7, 2023
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.4.0/kafka-3.4.0-src.tgz">kafka-3.4.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.4.0/kafka-3.4.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.4.0/kafka-3.4.0-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka-3.4.0-src.tgz">kafka-3.4.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.0/kafka-3.4.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka-3.4.0-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.12-3.4.0.tgz">kafka_2.12-3.4.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.12-3.4.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.12-3.4.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.13-3.4.0.tgz">kafka_2.13-3.4.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.13-3.4.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.4.0/kafka_2.13-3.4.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.12-3.4.0.tgz">kafka_2.12-3.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.12-3.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.12-3.4.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz">kafka_2.13-3.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -95,7 +95,7 @@
     <p>
         Kafka 3.4.0 includes a significant number of new features and fixes.
         For more information, please read our <a href="https://blogs.apache.org/kafka/entry/what-s-new-in-apache9" target="_blank">blog post</a>
-        and the detailed <a href="https://downloads.apache.org/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>.
+        and the detailed <a href="https://archive.apache.org/dist/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.3.2"></span>
@@ -105,16 +105,16 @@
             Released Jan 23, 2023
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.3.2/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.3.2/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.3.2/kafka-3.3.2-src.tgz">kafka-3.3.2-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.3.2/kafka-3.3.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.3.2/kafka-3.3.2-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka-3.3.2-src.tgz">kafka-3.3.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.2/kafka-3.3.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka-3.3.2-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.3.2/kafka_2.12-3.3.2.tgz">kafka_2.12-3.3.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.3.2/kafka_2.12-3.3.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.3.2/kafka_2.12-3.3.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.3.2/kafka_2.13-3.3.2.tgz">kafka_2.13-3.3.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.3.2/kafka_2.13-3.3.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.3.2/kafka_2.13-3.3.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.12-3.3.2.tgz">kafka_2.12-3.3.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.12-3.3.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.12-3.3.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.13-3.3.2.tgz">kafka_2.13-3.3.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.13-3.3.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.13-3.3.2.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -123,7 +123,7 @@
 
     <p>
         Kafka 3.3.2 fixes 20 issues since the 3.3.1 release.
-        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/3.3.2/RELEASE_NOTES.html">Release Notes</a>
+        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.3.2/RELEASE_NOTES.html">Release Notes</a>
     </p>
 
     <span id="3.3.1"></span>
@@ -177,16 +177,16 @@
             Released Sept 19, 2022
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.2.3/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.2.3/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.2.3/kafka-3.2.3-src.tgz">kafka-3.2.3-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.2.3/kafka-3.2.3-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.2.3/kafka-3.2.3-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka-3.2.3-src.tgz">kafka-3.2.3-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.3/kafka-3.2.3-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka-3.2.3-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.2.3/kafka_2.12-3.2.3.tgz">kafka_2.12-3.2.3.tgz</a> (<a href="https://downloads.apache.org/kafka/3.2.3/kafka_2.12-3.2.3.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.2.3/kafka_2.12-3.2.3.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.2.3/kafka_2.13-3.2.3.tgz">kafka_2.13-3.2.3.tgz</a> (<a href="https://downloads.apache.org/kafka/3.2.3/kafka_2.13-3.2.3.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.2.3/kafka_2.13-3.2.3.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.12-3.2.3.tgz">kafka_2.12-3.2.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.12-3.2.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.12-3.2.3.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.13-3.2.3.tgz">kafka_2.13-3.2.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.13-3.2.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.13-3.2.3.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -195,7 +195,7 @@
 
     <p>
         Kafka 3.2.3 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 7 other issues since the 3.2.1 release.
-        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/3.2.3/RELEASE_NOTES.html">Release Notes</a>.
+        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.2.3/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.2.2"></span>
@@ -285,16 +285,16 @@
             Released Sept 19, 2022
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.1.2/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.1.2/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.1.2/kafka-3.1.2-src.tgz">kafka-3.1.2-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.1.2/kafka-3.1.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.1.2/kafka-3.1.2-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka-3.1.2-src.tgz">kafka-3.1.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.2/kafka-3.1.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka-3.1.2-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.1.2/kafka_2.12-3.1.2.tgz">kafka_2.12-3.1.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.1.2/kafka_2.12-3.1.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.1.2/kafka_2.12-3.1.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.1.2/kafka_2.13-3.1.2.tgz">kafka_2.13-3.1.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.1.2/kafka_2.13-3.1.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.1.2/kafka_2.13-3.1.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.12-3.1.2.tgz">kafka_2.12-3.1.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.12-3.1.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.12-3.1.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.13-3.1.2.tgz">kafka_2.13-3.1.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.13-3.1.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.13-3.1.2.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -303,7 +303,7 @@
 
     <p>
         Kafka 3.1.2 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 4 other issues since the 3.1.1 release.
-        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/3.1.2/RELEASE_NOTES.html">Release Notes</a>.
+        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.1.2/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.1.1"></span>
@@ -377,7 +377,7 @@
     </ul>
 
     <p>
-        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/3.1.0/RELEASE_NOTES.html">Release Notes</a>.
+        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.1.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.0.2"></span>
@@ -387,16 +387,16 @@
             Released Sept 19, 2022
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.0.2/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.0.2/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.0.2/kafka-3.0.2-src.tgz">kafka-3.0.2-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.0.2/kafka-3.0.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.0.2/kafka-3.0.2-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka-3.0.2-src.tgz">kafka-3.0.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.2/kafka-3.0.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka-3.0.2-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.0.2/kafka_2.12-3.0.2.tgz">kafka_2.12-3.0.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.0.2/kafka_2.12-3.0.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.0.2/kafka_2.12-3.0.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.0.2/kafka_2.13-3.0.2.tgz">kafka_2.13-3.0.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.0.2/kafka_2.13-3.0.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.0.2/kafka_2.13-3.0.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.12-3.0.2.tgz">kafka_2.12-3.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.12-3.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.12-3.0.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.13-3.0.2.tgz">kafka_2.13-3.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.13-3.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.13-3.0.2.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -405,7 +405,7 @@
 
     <p>
         Kafka 3.0.2 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 10 other issues since the 3.0.1 release.
-        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/3.0.2/RELEASE_NOTES.html">Release Notes</a>.
+        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.0.2/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.0.1"></span>


### PR DESCRIPTION
As per https://www.apache.org/legal/release-policy.html#archived