### PR TITLE
MINOR: Website changes for 3.5.1 release

### DIFF
--- a/35/upgrade.html
+++ b/35/upgrade.html
@@ -19,6 +19,22 @@
 
 <script id="upgrade-template" type="text/x-handlebars-template">
 
+<h4><a id="upgrade_3_5_1" href="#upgrade_3_5_1">Upgrading to 3.5.1 from any version 0.8.x through 3.4.x</a></h4>
+    All upgrade steps remain same as <a id="upgrade_3_5_0" href="#upgrade_3_5_0">upgrading to 3.5.0</a>
+    <h5><a id="upgrade_351_notable" href="#upgrade_351_notable">Notable changes in 3.5.1</a></h5>
+    <ul>
+        <li>
+            Upgraded the dependency, snappy-java, to a version which is not vulnerable to
+            <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-34455">CVE-2023-34455.</a>
+            You can find more information about the CVE at <a href="https://kafka.apache.org/cve-list#CVE-2023-34455">Kafka CVE list.</a>
+        </li>
+        <li>
+            Fixed a regression introduced in 3.3.0, which caused <code>security.protocol</code> configuration values to be restricted to
+            upper case only. After the fix, <code>security.protocol</code> values are case insensitive.
+            See <a href="https://issues.apache.org/jira/browse/KAFKA-15053">KAFKA-15053</a> for details.
+        </li>
+    </ul>
+
 <h4><a id="upgrade_3_5_0" href="#upgrade_3_5_0">Upgrading to 3.5.0 from any version 0.8.x through 3.4.x</a></h4>
 
     <h5><a id="upgrade_350_notable" href="#upgrade_350_notable">Notable changes in 3.5.0</a></h5>

--- a/35/upgrade.html
+++ b/35/upgrade.html
@@ -20,7 +20,7 @@
 <script id="upgrade-template" type="text/x-handlebars-template">
 
 <h4><a id="upgrade_3_5_1" href="#upgrade_3_5_1">Upgrading to 3.5.1 from any version 0.8.x through 3.4.x</a></h4>
-    All upgrade steps remain same as <a id="upgrade_3_5_0" href="#upgrade_3_5_0">upgrading to 3.5.0</a>
+    All upgrade steps remain same as <a href="#upgrade_3_5_0">upgrading to 3.5.0</a>
     <h5><a id="upgrade_351_notable" href="#upgrade_351_notable">Notable changes in 3.5.1</a></h5>
     <ul>
         <li>

--- a/blog.html
+++ b/blog.html
@@ -24,6 +24,32 @@
             <h1 class="content-title">Blog</h1>
             <article>
                 <h2 class="bullet">
+                    <a id="apache_kafka_351_release_announcement"></a>
+                    <a href="#apache_kafka_351_release_announcement">Apache Kafka 3.5.1 Release Announcement</a>
+                </h2>
+                21 July 2023 - Divij Vaidya (<a href="https://twitter.com/divijvaidya">@DivijVaidya</a>)
+                <p>We are proud to announce the release of Apache Kafka 3.5.1. This is a security patch release. It upgrades the dependency, snappy-java, to a version which is not vulnerable to <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-34455">CVE-2023-34455</a>. You can find more information about the CVE at <a href="https://kafka.apache.org/cve-list#CVE-2023-3445">Kafka CVE list</a>. For a full list of changes, be sure to check the <a href="https://downloads.apache.org/kafka/3.5.1/RELEASE_NOTES.html">release notes</a>.</p>
+                <p>See the <a href="https://kafka.apache.org/35/documentation.html#upgrade_3_5_1">Upgrading to 3.5.1 from any version 0.8.x through 3.4.x</a> section in the documentation for the list of notable changes and detailed upgrade steps.</p>
+                <h3>Kafka Broker, Controller, Producer, Consumer and Admin Client</h3>
+                <ul>
+                    <li>
+                        Upgraded the dependency, snappy-java, to a version which is not vulnerable to
+                        <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-34455">CVE-2023-34455.</a>
+                        You can find more information about the CVE at <a href="https://kafka.apache.org/cve-list#CVE-2023-34455">Kafka CVE list.</a>
+                    </li>
+                    <li>
+                        Fixed a regression introduced in 3.3.0, which caused <code>security.protocol</code> configuration values to be restricted to
+                        upper case only. After the fix, <code>security.protocol</code> values are case insensitive.
+                        See <a href="https://issues.apache.org/jira/browse/KAFKA-15053">KAFKA-15053</a> for details.
+                    </li>
+                </ul>
+                <h3>Summary</h3>
+                <p>This was a community effort, so thank you to everyone who contributed to this release, including all our users and our 22 authors. Please report an unintended omission.
+                    <p>Alyssa Huang, Aman Singh, andymg3, Bo Gao, Calvin Liu, Chia-Ping Tsai, Chris Egerton, d00791190, Damon Xie, David Arthur, David Jacot, Divij Vaidya, DL1231, ezio, Manikumar Reddy, Manyanda Chitimbo, Mickael Maison, minjian.cai, Proven Provenzano, Sambhav Jain, vamossagar12, Yash Mayya</p>
+                </p>
+            </article>
+            <article>
+                <h2 class="bullet">
                     <a id="apache_kafka_350_release_announcement"></a>
                     <a href="#apache_kafka_350_release_announcement">Apache Kafka 3.5.0 Release Announcement</a>
                 </h2>

--- a/cve-list.html
+++ b/cve-list.html
@@ -24,7 +24,7 @@ This page lists all security vulnerabilities fixed in released versions of Apach
         </tr>
         <tr>
           <td>Fixed versions</td>
-          <td>3.5.1 (in-progress, <a href="https://lists.apache.org/thread/fkqy14bx8dc2ffrtvxyrg5f9fobjd2fd">tentative release end of July 2023</a>)</td>
+          <td>3.5.1</td>
         </tr>
         <tr>
           <td>Impact</td>

--- a/downloads.html
+++ b/downloads.html
@@ -6,10 +6,39 @@
 	<div class="right">
     <h1>Download</h1>
 
-    <p>3.5.0 is the latest release. The current stable version is 3.5.0</p>
+    <p>3.5.1 is the latest release. The current stable version is 3.5.1</p>
 
     <p>
     You can verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://downloads.apache.org/kafka/KEYS">KEYS</a>.
+    </p>
+
+    <span id="3.5.1"></span>
+    <h3 class="download-version">3.5.1<a href="#3.5.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+    <ul>
+        <li>
+            Released Jul 21, 2023
+        </li>
+        <li>
+            <a href="https://downloads.apache.org/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>
+        </li>
+        <li>
+            Source download: <a href="https://downloads.apache.org/kafka/3.5.1/kafka-3.5.1-src.tgz">kafka-3.5.1-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.1/kafka-3.5.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.1/kafka-3.5.1-src.tgz.sha512">sha512</a>)
+        </li>
+        <li>
+            Binary downloads:
+            <ul>
+                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.12-3.5.1.tgz">kafka_2.12-3.5.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.12-3.5.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.12-3.5.1.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.13-3.5.1.tgz">kafka_2.13-3.5.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.13-3.5.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.13-3.5.1.tgz.sha512">sha512</a>)</li>
+            </ul>
+            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+        </li>
+    </ul>
+
+    <p>
+        Kafka 3.5.1 is a security patch release. It contains security fixes and regression fixes.
+        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_351_release_announcement" target="_blank">blog post</a>
+        and the detailed <a href="https://downloads.apache.org/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.5.0"></span>
@@ -19,16 +48,16 @@
             Released Jun 15, 2023
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.5.0/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.5.0/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.5.0/kafka-3.5.0-src.tgz">kafka-3.5.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.0/kafka-3.5.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.0/kafka-3.5.0-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka-3.5.0-src.tgz">kafka-3.5.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.0/kafka-3.5.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka-3.5.0-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.5.0/kafka_2.12-3.5.0.tgz">kafka_2.12-3.5.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.0/kafka_2.12-3.5.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.0/kafka_2.12-3.5.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.5.0/kafka_2.13-3.5.0.tgz">kafka_2.13-3.5.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.0/kafka_2.13-3.5.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.0/kafka_2.13-3.5.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.12-3.5.0.tgz">kafka_2.12-3.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.12-3.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.12-3.5.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz">kafka_2.13-3.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -38,7 +67,7 @@
     <p>
         Kafka 3.5.0 includes a significant number of new features and fixes.
         For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_350_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://downloads.apache.org/kafka/3.5.0/RELEASE_NOTES.html">Release Notes</a>.
+        and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.4.1"></span>


### PR DESCRIPTION
## Changes:
1. Modify the download section to add links to new version
2. Modify the download section to move prior versions to archive links.
3. Modify the upgrade section to add information about new version.
4. Add blog for new version.
5. Remove in-progress mentioned in CVE list.

## Testing
Tested locally. Verified all links. Screenshots attached.

![Screenshot 2023-07-22 at 13 06 16](https://github.com/apache/kafka-site/assets/71267/f300e353-21df-4940-8770-6f880925c824)
![Screenshot 2023-07-22 at 12 57 33](https://github.com/apache/kafka-site/assets/71267/ebc4e647-0c57-4775-b748-bb67216ecfa7)
![Screenshot 2023-07-22 at 10 38 01](https://github.com/apache/kafka-site/assets/71267/020c79e3-00b4-4a6a-9e5d-0e4029a3e157)
