### PR TITLE
MINOR: Fix blog post ordering by date desc

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -24,6 +24,19 @@
             <h1 class="content-title">Blog</h1>
             <article>
                 <h2 class="bullet">
+                    <a id="apache_kafka_352_release_announcement"></a>
+                    <a href="#apache_kafka_352_release_announcement">Apache Kafka 3.5.2 Release Announcement</a>
+                </h2>
+                11 December 2023 - Luke Chen (<a href="https://twitter.com/showuon1">@showuon1</a>)
+                <p>We are proud to announce the release of Apache Kafka 3.5.2. This is a bugfix release. It contains many bug fixes including upgrades the Snappy and Rocksdb dependencies. For a full list of changes, be sure to check the <a href="https://downloads.apache.org/kafka/3.5.2/RELEASE_NOTES.html">release notes</a>.</p>
+                <p>See the <a href="https://kafka.apache.org/documentation.html#upgrade_3_5_2">Upgrading to 3.5.2 from any version 0.8.x through 3.4.x</a> section in the documentation for the list of notable changes and detailed upgrade steps.</p>
+                <h3>Summary</h3>
+                <p>This was a community effort, so thank you to everyone who contributed to this release:</br>
+                    A. Sophie Blee-Goldman, Anna Sophie Blee-Goldman, atu-sharm, bachmanity1, Bill Bejeck, Calvin Liu, Chase Thomas, Chris Egerton, Christo Lolov, Colin P. McCabe, Colin Patrick McCabe, David Arthur, David Jacot, Divij Vaidya, Farooq Qaiser, Federico Valeri, flashmouse, Florin Akermann, Greg Harris, Guozhang Wang, Hao Li, hudeqi, Ismael Juma, Jason Gustafson, José Armando García Sancio, Josep Prat, Levani Kokhreidze, lixy, Lucas Brutschy, Luke Chen, Manikumar Reddy, Matthias J. Sax, Mickael Maison, Nick Telford, Okada Haruki, Omnia G.H Ibrahim, Philip Nee, Qichao Chu (@ex172000), Mickael Maison, Rajini Sivaram, Ritika Reddy, Robert Wagner, Rohan, Ron Dagostino, Sagar Rao, Said Boudjelda, sciclon2, Viktor Somogyi-Vass, Vincent Jiang, Xiaobing Fang, Yash Mayya
+                </p>
+            </article>
+            <article>
+                <h2 class="bullet">
                     <a id="apache_kafka_361_release_announcement"></a>
                     <a href="#apache_kafka_361_release_announcement">Apache Kafka 3.6.1 Release Announcement</a>
                 </h2>
@@ -171,19 +184,6 @@
 
                 <p>This was a community effort, so thank you to everyone who contributed to this release, including all our users and our 139 contributors: <br>
                     A. Sophie Blee-Goldman, Aaron Ai, Abhijeet Kumar, aindriu-aiven, Akhilesh Chaganti, Alexandre Dupriez, Alexandre Garnier, Alok Thatikunta, Alyssa Huang, Aman Singh, Andras Katona, Andrew Schofield, Andrew Grant, Aneel Kumar, Anton Agestam, Artem Livshits, atu-sharm, bachmanity1, Bill Bejeck, Bo Gao, Bruno Cadonna, Calvin Liu, Chaitanya Mukka, Chase Thomas, Cheryl Simmons, Chia-Ping Tsai, Chris Egerton, Christo Lolov, Clay Johnson, Colin P. McCabe, Colt McNealy, d00791190, Damon Xie, Danica Fine, Daniel Scanteianu, Daniel Urban, David Arthur, David Jacot, David Mao, dengziming, Deqi Hu, Dimitar Dimitrov, Divij Vaidya, DL1231, Dániel Urbán, Erik van Oosten, ezio, Farooq Qaiser, Federico Valeri, flashmouse, Florin Akermann, Gabriel Oliveira, Gantigmaa Selenge, Gaurav Narula, GeunJae Jeon, Greg Harris, Guozhang Wang, Hailey Ni, Hao Li, Hector Geraldino, hudeqi, hzh0425, Iblis Lin, iit2009060, Ismael Juma, Ivan Yurchenko, James Shaw, Jason Gustafson, Jeff Kim, Jim Galasyn, John Roesler, Joobi S B, Jorge Esteban Quilcate Otoya, Josep Prat, Joseph (Ting-Chou) Lin, José Armando García Sancio, Jun Rao, Justine Olshan, Kamal Chandraprakash, Keith Wall, Kirk True, Lianet Magrans, LinShunKang, Liu Zeyu, lixy, Lucas Bradstreet, Lucas Brutschy, Lucent-Wong, Lucia Cerchie, Luke Chen, Manikumar Reddy, Manyanda Chitimbo, Maros Orsak, Matthew de Detrich, Matthias J. Sax, maulin-vasavada, Max Riedel, Mehari Beyene, Michal Cabak (@miccab), Mickael Maison, Milind Mantri, minjian.cai, mojh7, Nikolay, Okada Haruki, Omnia G H Ibrahim, Owen Leung, Philip Nee, prasanthV, Proven Provenzano, Purshotam Chauhan, Qichao Chu, Rajini Sivaram, Randall Hauch, Renaldo Baur Filho, Ritika Reddy, Rittika Adhikari, Rohan, Ron Dagostino, Sagar Rao, Said Boudjelda, Sambhav Jain, Satish Duggana, sciclon2, Shekhar Rajak, Sungyun Hur, Sushant Mahajan, Tanay Karmarkar, tison, Tom Bentley, vamossagar12, Victoria Xia, Vincent Jiang, vveicc, Walker Carlson, Yash Mayya, Yi-Sheng Lien, Ziming Deng, 蓝士钦
-                </p>
-            </article>
-            <article>
-                <h2 class="bullet">
-                    <a id="apache_kafka_352_release_announcement"></a>
-                    <a href="#apache_kafka_352_release_announcement">Apache Kafka 3.5.2 Release Announcement</a>
-                </h2>
-                11 December 2023 - Luke Chen (<a href="https://twitter.com/showuon1">@showuon1</a>)
-                <p>We are proud to announce the release of Apache Kafka 3.5.2. This is a bugfix release. It contains many bug fixes including upgrades the Snappy and Rocksdb dependencies. For a full list of changes, be sure to check the <a href="https://downloads.apache.org/kafka/3.5.2/RELEASE_NOTES.html">release notes</a>.</p>
-                <p>See the <a href="https://kafka.apache.org/documentation.html#upgrade_3_5_2">Upgrading to 3.5.2 from any version 0.8.x through 3.4.x</a> section in the documentation for the list of notable changes and detailed upgrade steps.</p>
-                <h3>Summary</h3>
-                <p>This was a community effort, so thank you to everyone who contributed to this release:</br>
-                    A. Sophie Blee-Goldman, Anna Sophie Blee-Goldman, atu-sharm, bachmanity1, Bill Bejeck, Calvin Liu, Chase Thomas, Chris Egerton, Christo Lolov, Colin P. McCabe, Colin Patrick McCabe, David Arthur, David Jacot, Divij Vaidya, Farooq Qaiser, Federico Valeri, flashmouse, Florin Akermann, Greg Harris, Guozhang Wang, Hao Li, hudeqi, Ismael Juma, Jason Gustafson, José Armando García Sancio, Josep Prat, Levani Kokhreidze, lixy, Lucas Brutschy, Luke Chen, Manikumar Reddy, Matthias J. Sax, Mickael Maison, Nick Telford, Okada Haruki, Omnia G.H Ibrahim, Philip Nee, Qichao Chu (@ex172000), Mickael Maison, Rajini Sivaram, Ritika Reddy, Robert Wagner, Rohan, Ron Dagostino, Sagar Rao, Said Boudjelda, sciclon2, Viktor Somogyi-Vass, Vincent Jiang, Xiaobing Fang, Yash Mayya
                 </p>
             </article>
             <article>


### PR DESCRIPTION
This change applies a blog post ordering by date desc. 
This is what people usually expect from a blog.