### PR TITLE
MINOR: Add docker in list of templates that get rendered

### DIFF
--- a/includes/_footer.htm
+++ b/includes/_footer.htm
@@ -41,7 +41,8 @@
 					'quickstart-docker',
 					'toc',
 					'upgrade',
-					'content'
+					'content',
+					'docker'
 				];
 
 				// loop through all Handlebar templates on the page and render them


### PR DESCRIPTION
Adds support for docker in documentation from 3.7.0 onwards