### PR TITLE
Add get support page

### DIFF
--- a/includes/_top.htm
+++ b/includes/_top.htm
@@ -153,6 +153,11 @@
 									Contact us
 								</a>
 							</li>
+							<li class="top-nav-menu-item" role="menuitem">
+								<a class="top-nav-anchor" tabindex="-1" href="/support">
+									Get support
+								</a>
+							</li>
 						</ul>
 					</li>
 					<li class="top-nav-item" role="menuitem">

--- a/support.html
+++ b/support.html
@@ -1,0 +1,54 @@
+<!--#include virtual="includes/_header.htm" -->
+<body class="page-contact ">
+<!--#include virtual="includes/_top.htm" -->
+<div class="content">
+	<!--#include virtual="includes/_nav.htm" -->
+	<div class="right">
+		<h1 class="content-title">Support</h1>
+		<h3>Community support</h3>
+
+		<p>
+			This is an open source project so the amount of time community members have available to help resolve your issue
+			is often limited as help is provided on a volunteer basis from
+			<a href="https://www.apache.org/foundation/how-it-works/#hats" target="_blank">individuals</a>.
+			However, it is free, and you are often able to discuss issues with the developers who actually wrote the code
+			you are running.
+		</p>
+		<p>
+			If you are encountering a problem by using Apache Kafka then you can send an email to the <a href="mailto:users@kafka.apache.org">users@kafka.apache.org</a> mailing list.
+			You need follow the subscribe instructions before sending email from the <a href="https://kafka.apache.org/contact">contact us</a> page.
+			If you’re fairly certain you’re hitting a bug please report it via our <a href="https://issues.apache.org/jira/projects/KAFKA">issue trackers</a>.
+			Be sure to review the tickets list and read the documentation carefully as they contain tips and tricks about working with Apache communities in general and
+			Apache Kafka in particular.
+		</p>
+
+		<h3>Commercial support</h3>
+		<p>
+			Apache Kafka is a widely used project. As such, several companies have built products and services around Apache Kafka.
+			This page is dedicated to providing descriptions of those offerings and links to more information.
+			Companies are definitely encouraged to update this page directly or send a mail to the Apache Kafka PMC with a description
+			of your offerings, and we can update the page. The products and services listed on this page are provided for
+			information use only to our users. The Apache Kafka PMC does not endorse or recommend any of the products or services
+			on this page. See below for information about what is appropriate to add to the page.
+		</p>
+
+		<ul>
+			<li><a href="https://www.yupiik.com" target="_blank">Yupiik</a> contributes and commits to many Apache projects. Provides consulting, training and support
+				for Apache Kafka and related projects like Apache ActiveMQ, Apache Camel, Apache Karaf.</li>
+		</ul>
+
+		<h3>Policy for additions to this page</h3>
+
+		<p>
+			Companies are free to add information about their products and services to this page (please keep entries in
+			alphabetical order). The information must be factual and informational in nature and not be a marketing statement.
+			Statements that promote your products and services over other offerings on the page will not be tolerated and
+			will be removed. Such marketing statements can be added to your own pages on your own site, but not here.
+			When in doubt, email the Apache Kafka dev list (see <a href="https://kafka.apache.org/contact">Mailing Lists</a>) and ask. We’d be happy to help.
+		</p>
+
+		<script>
+// Show selected style on nav item
+$(function() { $('.b-nav__contact').addClass('selected'); });
+</script>
+<!--#include virtual="includes/_footer.htm" -->


### PR DESCRIPTION
Proposal to add a `get support` page to describe how community and commercial support is working, like we have in many other Apache projects.
