### PR TITLE
37: Add download section for the latest 3.7 release

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -6,10 +6,43 @@
 	<div class="right">
     <h1>Download</h1>
 
-    <p>3.6.1 is the latest release. The current stable version is 3.6.1</p>
+    <p>3.7.0 is the latest release. The current stable version is 3.7.0</p>
 
     <p>
     You can verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://downloads.apache.org/kafka/KEYS">KEYS</a>.
+    </p>
+
+
+    <span id="3.7.0"></span>
+    <h3 class="download-version">3.7.0<a href="#3.7.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+    <ul>
+        <li>
+            Released Feb 21, 2024
+        </li>
+        <li>
+            <a href="https://downloads.apache.org/kafka/3.7.0/RELEASE_NOTES.html">Release Notes</a>
+        </li>
+        <li>
+            Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.7.0-rc4/images/sha256-3e324d2bd331570676436b24f625e5dcf1facdfbd62efcffabc6b69b1abc13cc?context=explore">apache/kafka:3.7.0</a>.
+        </li>
+        <li>
+            Source download: <a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.7.0-src.tgz">kafka-3.7.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.7.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.7.0-src.tgz.sha512">sha512</a>)
+        </li>
+        <li>
+            Binary downloads:
+            <ul>
+                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.7.0/kafka_2.12-3.7.0.tgz">kafka_2.12-3.7.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.0/kafka_2.12-3.7.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.0/kafka_2.12-3.7.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.7.0/kafka_2.13-3.7.0.tgz">kafka_2.13-3.7.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.0/kafka_2.13-3.7.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.0/kafka_2.13-3.7.0.tgz.sha512">sha512</a>)</li>
+            </ul>
+            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+        </li>
+    </ul>
+
+    <p>
+        Kafka 3.7.0 includes a significant number of new features and fixes.
+        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_360_release_announcement" target="_blank">blog post</a>
+        and the detailed <a href="https://downloads.apache.org/kafka/3.7.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.6.1"></span>

--- a/downloads.html
+++ b/downloads.html
@@ -41,7 +41,7 @@
 
     <p>
         Kafka 3.7.0 includes a significant number of new features and fixes.
-        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_360_release_announcement" target="_blank">blog post</a>
+        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_370_release_announcement" target="_blank">blog post</a>
         and the detailed <a href="https://downloads.apache.org/kafka/3.7.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 

--- a/downloads.html
+++ b/downloads.html
@@ -17,13 +17,13 @@
     <h3 class="download-version">3.7.0<a href="#3.7.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
     <ul>
         <li>
-            Released Feb 21, 2024
+            Released Feb 27, 2024
         </li>
         <li>
             <a href="https://downloads.apache.org/kafka/3.7.0/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.7.0-rc4/images/sha256-3e324d2bd331570676436b24f625e5dcf1facdfbd62efcffabc6b69b1abc13cc?context=explore">apache/kafka:3.7.0</a>.
+            Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.7.0/images/sha256-3e324d2bd331570676436b24f625e5dcf1facdfbd62efcffabc6b69b1abc13cc">apache/kafka:3.7.0</a>.
         </li>
         <li>
             Source download: <a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.7.0-src.tgz">kafka-3.7.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.7.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.7.0-src.tgz.sha512">sha512</a>)


### PR DESCRIPTION
This patch updates the downloads page of the website to mention the latest release and link to the download artifacts