### PR TITLE
Fixed links to Streams Developer Guide subpages

### DIFF
--- a/10/architecture.html
+++ b/10/architecture.html
@@ -98,7 +98,7 @@
 
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data,
-        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl">Kafka Streams DSL</a>, for example, automatically creates
+        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html">Kafka Streams DSL</a>, for example, automatically creates
         and manages such state stores when you are calling stateful operators such as <code>join()</code> or <code>aggregate()</code>, or when you are windowing a stream.
     </p>
 

--- a/10/core-concepts.html
+++ b/10/core-concepts.html
@@ -76,8 +76,8 @@
     <img class="centered" src="/{{version}}/images/streams-architecture-topology.jpg" style="width:400px">
 
     <p>
-        Kafka Streams offers two ways to define the stream processing topology: the <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl"><b>Kafka Streams DSL</b></a> provides
-        the most common data transformation operations such as <code>map</code>, <code>filter</code>, <code>join</code> and <code>aggregations</code> out of the box; the lower-level <a href="/{{version}}/documentation/streams/developer-guide#streams_processor"><b>Processor API</b></a> allows
+        Kafka Streams offers two ways to define the stream processing topology: the <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html"><b>Kafka Streams DSL</b></a> provides
+        the most common data transformation operations such as <code>map</code>, <code>filter</code>, <code>join</code> and <code>aggregations</code> out of the box; the lower-level <a href="/{{version}}/documentation/streams/developer-guide/processor-api.html"><b>Processor API</b></a> allows
         developers define and connect custom processors as well as to interact with <a href="#streams_state">state stores</a>.
     </p>
 
@@ -131,7 +131,7 @@
         Some stream processing applications don't require state, which means the processing of a message is independent from
         the processing of all other messages.
         However, being able to maintain state opens up many possibilities for sophisticated stream processing applications: you
-        can join input streams, or group and aggregate data records. Many such stateful operators are provided by the <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl"><b>Kafka Streams DSL</b></a>.
+        can join input streams, or group and aggregate data records. Many such stateful operators are provided by the <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html"><b>Kafka Streams DSL</b></a>.
     </p>
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data.

--- a/10/streams/architecture.html
+++ b/10/streams/architecture.html
@@ -103,7 +103,7 @@
 
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data,
-        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl">Kafka Streams DSL</a>, for example, automatically creates
+        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html">Kafka Streams DSL</a>, for example, automatically creates
         and manages such state stores when you are calling stateful operators such as <code>join()</code> or <code>aggregate()</code>, or when you are windowing a stream.
     </p>
 

--- a/10/streams/core-concepts.html
+++ b/10/streams/core-concepts.html
@@ -80,7 +80,7 @@
 
     <p>
         Kafka Streams offers two ways to define the stream processing topology: the <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html"><b>Kafka Streams DSL</b></a> provides
-        the most common data transformation operations such as <code>map</code>, <code>filter</code>, <code>join</code> and <code>aggregations</code> out of the box; the lower-level <a href="/{{version}}/documentation/streams/developer-guide#streams_processor"><b>Processor API</b></a> allows
+        the most common data transformation operations such as <code>map</code>, <code>filter</code>, <code>join</code> and <code>aggregations</code> out of the box; the lower-level <a href="/{{version}}/documentation/streams/developer-guide/processor-api.html"><b>Processor API</b></a> allows
         developers define and connect custom processors as well as to interact with <a href="#streams_state">state stores</a>.
     </p>
 
@@ -134,7 +134,7 @@
         Some stream processing applications don't require state, which means the processing of a message is independent from
         the processing of all other messages.
         However, being able to maintain state opens up many possibilities for sophisticated stream processing applications: you
-        can join input streams, or group and aggregate data records. Many such stateful operators are provided by the <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl"><b>Kafka Streams DSL</b></a>.
+        can join input streams, or group and aggregate data records. Many such stateful operators are provided by the <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html"><b>Kafka Streams DSL</b></a>.
     </p>
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data.

--- a/10/streams/tutorial.html
+++ b/10/streams/tutorial.html
@@ -478,7 +478,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/10/tutorial.html
+++ b/10/tutorial.html
@@ -476,7 +476,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/11/streams/architecture.html
+++ b/11/streams/architecture.html
@@ -111,7 +111,7 @@
 
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data,
-        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl">Kafka Streams DSL</a>, for example, automatically creates
+        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html">Kafka Streams DSL</a>, for example, automatically creates
         and manages such state stores when you are calling stateful operators such as <code>join()</code> or <code>aggregate()</code>, or when you are windowing a stream.
     </p>
 

--- a/11/streams/tutorial.html
+++ b/11/streams/tutorial.html
@@ -478,7 +478,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/20/streams/architecture.html
+++ b/20/streams/architecture.html
@@ -111,7 +111,7 @@
 
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data,
-        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl">Kafka Streams DSL</a>, for example, automatically creates
+        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html">Kafka Streams DSL</a>, for example, automatically creates
         and manages such state stores when you are calling stateful operators such as <code>join()</code> or <code>aggregate()</code>, or when you are windowing a stream.
     </p>
 

--- a/20/streams/tutorial.html
+++ b/20/streams/tutorial.html
@@ -476,7 +476,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/21/streams/architecture.html
+++ b/21/streams/architecture.html
@@ -111,7 +111,7 @@
 
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data,
-        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl">Kafka Streams DSL</a>, for example, automatically creates
+        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html">Kafka Streams DSL</a>, for example, automatically creates
         and manages such state stores when you are calling stateful operators such as <code>join()</code> or <code>aggregate()</code>, or when you are windowing a stream.
     </p>
 

--- a/21/streams/tutorial.html
+++ b/21/streams/tutorial.html
@@ -476,7 +476,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/22/streams/architecture.html
+++ b/22/streams/architecture.html
@@ -111,7 +111,7 @@
 
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data,
-        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl">Kafka Streams DSL</a>, for example, automatically creates
+        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html">Kafka Streams DSL</a>, for example, automatically creates
         and manages such state stores when you are calling stateful operators such as <code>join()</code> or <code>aggregate()</code>, or when you are windowing a stream.
     </p>
 

--- a/22/streams/tutorial.html
+++ b/22/streams/tutorial.html
@@ -476,7 +476,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/23/streams/architecture.html
+++ b/23/streams/architecture.html
@@ -111,7 +111,7 @@
 
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data,
-        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl">Kafka Streams DSL</a>, for example, automatically creates
+        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html">Kafka Streams DSL</a>, for example, automatically creates
         and manages such state stores when you are calling stateful operators such as <code>join()</code> or <code>aggregate()</code>, or when you are windowing a stream.
     </p>
 

--- a/23/streams/tutorial.html
+++ b/23/streams/tutorial.html
@@ -480,7 +480,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/24/streams/architecture.html
+++ b/24/streams/architecture.html
@@ -111,7 +111,7 @@
 
     <p>
         Kafka Streams provides so-called <b>state stores</b>, which can be used by stream processing applications to store and query data,
-        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide#streams_dsl">Kafka Streams DSL</a>, for example, automatically creates
+        which is an important capability when implementing stateful operations. The <a href="/{{version}}/documentation/streams/developer-guide/dsl-api.html">Kafka Streams DSL</a>, for example, automatically creates
         and manages such state stores when you are calling stateful operators such as <code>join()</code> or <code>aggregate()</code>, or when you are windowing a stream.
     </p>
 

--- a/24/streams/tutorial.html
+++ b/24/streams/tutorial.html
@@ -480,7 +480,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/25/streams/tutorial.html
+++ b/25/streams/tutorial.html
@@ -465,7 +465,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/26/streams/tutorial.html
+++ b/26/streams/tutorial.html
@@ -453,7 +453,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/27/streams/tutorial.html
+++ b/27/streams/tutorial.html
@@ -453,7 +453,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/28/streams/tutorial.html
+++ b/28/streams/tutorial.html
@@ -453,7 +453,7 @@
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/30/streams/tutorial.html
+++ b/30/streams/tutorial.html
@@ -452,7 +452,7 @@ source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/31/streams/tutorial.html
+++ b/31/streams/tutorial.html
@@ -452,7 +452,7 @@ source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>Counts</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/32/streams/tutorial.html
+++ b/32/streams/tutorial.html
@@ -452,7 +452,7 @@ source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/33/streams/tutorial.html
+++ b/33/streams/tutorial.html
@@ -452,7 +452,7 @@ source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/34/streams/tutorial.html
+++ b/34/streams/tutorial.html
@@ -452,7 +452,7 @@ source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/35/streams/tutorial.html
+++ b/35/streams/tutorial.html
@@ -452,7 +452,7 @@ source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/36/streams/tutorial.html
+++ b/36/streams/tutorial.html
@@ -1,4 +1,4 @@
-<!--
+z<!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
  this work for additional information regarding copyright ownership.
@@ -452,7 +452,7 @@ source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>

--- a/37/streams/tutorial.html
+++ b/37/streams/tutorial.html
@@ -452,7 +452,7 @@ source.flatMapValues(new ValueMapper&lt;String, Iterable&lt;String&gt;&gt;() {
     <p>
         Note that the <code>count</code> operator has a <code>Materialized</code> parameter that specifies that the
         running count should be stored in a state store named <code>counts-store</code>.
-        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide#streams_interactive_queries">Developer Manual</a>.
+        This <code>counts-store</code> store can be queried in real-time, with details described in the <a href="/{{version}}/documentation/streams/developer-guide/interactive-queries.html">Developer Manual</a>.
     </p>
 
     <p>


### PR DESCRIPTION
As it seems the Developer Guide page has been changed for Version 1.0.x and sections for "Streams DSL", "Processor API" and "Interactive Queries" got new, separate pages.

But some links have not been changed from links targeting anchors to links to the new subpages