### PR TITLE
MINOR: Use archive repository for older releases

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -176,7 +176,7 @@
                     <a href="#apache_kafka_360_release_announcement">Apache Kafka 3.6.0 Release Announcement</a>
                 </h2>
                 10 Oct 2023 - Satish Duggana (<a href="https://twitter.com/0xeed">@SatishDuggana</a>)
-                <p>We are proud to announce the release of Apache Kafka 3.6.0. This release contains many new features and improvements. This blog post will highlight some of the more prominent features. For a full list of changes, be sure to check the <a href="https://downloads.apache.org/kafka/3.6.0/RELEASE_NOTES.html">release notes</a>.</p>
+                <p>We are proud to announce the release of Apache Kafka 3.6.0. This release contains many new features and improvements. This blog post will highlight some of the more prominent features. For a full list of changes, be sure to check the <a href="https://archive.apache.org/dist/kafka/3.6.0/RELEASE_NOTES.html">release notes</a>.</p>
                 <p>See the <a href="https://kafka.apache.org/36/documentation.html#upgrade_3_6_0">Upgrading to 3.6.0 from any version 0.8.x through 3.5.x</a> section in the documentation for the list of notable changes and detailed upgrade steps.</p>
                 <p>
                     The ability to migrate Kafka clusters from a ZooKeeper metadata system to a KRaft metadata system is
@@ -314,7 +314,7 @@
                     <a href="#apache_kafka_351_release_announcement">Apache Kafka 3.5.1 Release Announcement</a>
                 </h2>
                 21 July 2023 - Divij Vaidya (<a href="https://twitter.com/divijvaidya">@DivijVaidya</a>)
-                <p>We are proud to announce the release of Apache Kafka 3.5.1. This is a security patch release. It upgrades the dependency, snappy-java, to a version which is not vulnerable to <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-34455">CVE-2023-34455</a>. You can find more information about the CVE at <a href="https://kafka.apache.org/cve-list#CVE-2023-3445">Kafka CVE list</a>. For a full list of changes, be sure to check the <a href="https://downloads.apache.org/kafka/3.5.1/RELEASE_NOTES.html">release notes</a>.</p>
+                <p>We are proud to announce the release of Apache Kafka 3.5.1. This is a security patch release. It upgrades the dependency, snappy-java, to a version which is not vulnerable to <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-34455">CVE-2023-34455</a>. You can find more information about the CVE at <a href="https://kafka.apache.org/cve-list#CVE-2023-3445">Kafka CVE list</a>. For a full list of changes, be sure to check the <a href="https://archive.apache.org/dist/kafka/3.5.1/RELEASE_NOTES.html">release notes</a>.</p>
                 <p>See the <a href="https://kafka.apache.org/35/documentation.html#upgrade_3_5_1">Upgrading to 3.5.1 from any version 0.8.x through 3.4.x</a> section in the documentation for the list of notable changes and detailed upgrade steps.</p>
                 <h3>Kafka Broker, Controller, Producer, Consumer and Admin Client</h3>
                 <ul>
@@ -340,7 +340,7 @@
                     <a href="#apache_kafka_350_release_announcement">Apache Kafka 3.5.0 Release Announcement</a>
                 </h2>
                 15 June 2023 - Mickael Maison (<a href="https://twitter.com/MickaelMaison">@MickaelMaison</a>)
-                <p>We are proud to announce the release of Apache Kafka 3.5.0. This release contains many new features and improvements. This blog post will highlight some of the more prominent features. For a full list of changes, be sure to check the <a href="https://downloads.apache.org/kafka/3.5.0/RELEASE_NOTES.html">release notes</a>.</p>
+                <p>We are proud to announce the release of Apache Kafka 3.5.0. This release contains many new features and improvements. This blog post will highlight some of the more prominent features. For a full list of changes, be sure to check the <a href="https://archive.apache.org/dist/kafka/3.5.0/RELEASE_NOTES.html">release notes</a>.</p>
                 <p>See the <a href="https://kafka.apache.org/35/documentation.html#upgrade_3_5_0">Upgrading to 3.5.0 from any version 0.8.x through 3.4.x</a> section in the documentation for the list of notable changes and detailed upgrade steps.</p>
                 <p>The ability to migrate Kafka clusters from ZK to KRaft mode with no downtime is still an early access feature. It is currently only suitable for testing in non production environments. See <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-866+ZooKeeper+to+KRaft+Migration">KIP-866</a> for more details.</p>
 		<p><it>Note: ZooKeeper is now marked deprecated in this release. ZooKeeper is planned to be removed in Apache Kafka 4.0. (Cf <a href="/documentation#zk_depr">ZooKeeper Deprecation</a>)</it><p>

--- a/downloads.html
+++ b/downloads.html
@@ -109,16 +109,16 @@
             Released Dec 11, 2023
         </li>
         <li>
-            <a href="https://archive.apache.org/dist/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://downloads.apache.org/kafka/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz">kafka-3.5.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://downloads.apache.org/kafka/kafka/3.5.2/kafka-3.5.2-src.tgz">kafka-3.5.2-src.tgz</a> (<a href="https://downloads.apache.org/kafka/kafka/3.5.2/kafka-3.5.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/kafka/3.5.2/kafka-3.5.2-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz">kafka_2.12-3.5.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz">kafka_2.13-3.5.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/kafka/3.5.2/kafka_2.12-3.5.2.tgz">kafka_2.12-3.5.2.tgz</a> (<a href="https://downloads.apache.org/kafka/kafka/3.5.2/kafka_2.12-3.5.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/kafka/3.5.2/kafka_2.12-3.5.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/kafka/3.5.2/kafka_2.13-3.5.2.tgz">kafka_2.13-3.5.2.tgz</a> (<a href="https://downloads.apache.org/kafka/kafka/3.5.2/kafka_2.13-3.5.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/kafka/3.5.2/kafka_2.13-3.5.2.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -128,7 +128,7 @@
     <p>
         Kafka 3.5.2 contains security fixes and bug fixes.
         For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_352_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>.
+        and the detailed <a href="https://downloads.apache.org/kafka/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.5.1"></span>

--- a/downloads.html
+++ b/downloads.html
@@ -80,16 +80,16 @@
             Released Oct 10, 2023
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.6.0/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.6.0/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.6.0/kafka-3.6.0-src.tgz">kafka-3.6.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.6.0/kafka-3.6.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.6.0/kafka-3.6.0-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka-3.6.0-src.tgz">kafka-3.6.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.0/kafka-3.6.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka-3.6.0-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.6.0/kafka_2.12-3.6.0.tgz">kafka_2.12-3.6.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.6.0/kafka_2.12-3.6.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.6.0/kafka_2.12-3.6.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.6.0/kafka_2.13-3.6.0.tgz">kafka_2.13-3.6.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.6.0/kafka_2.13-3.6.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.6.0/kafka_2.13-3.6.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.12-3.6.0.tgz">kafka_2.12-3.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.12-3.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.12-3.6.0.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz">kafka_2.13-3.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -99,7 +99,7 @@
     <p>
         Kafka 3.6.0 includes a significant number of new features and fixes.
         For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_360_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://downloads.apache.org/kafka/3.6.0/RELEASE_NOTES.html">Release Notes</a>.
+        and the detailed <a href="https://archive.apache.org/dist/kafka/3.6.0/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.5.2"></span>
@@ -109,16 +109,16 @@
             Released Dec 11, 2023
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.5.2/kafka-3.5.2-src.tgz">kafka-3.5.2-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.2/kafka-3.5.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.2/kafka-3.5.2-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz">kafka-3.5.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.5.2/kafka_2.12-3.5.2.tgz">kafka_2.12-3.5.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.2/kafka_2.12-3.5.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.2/kafka_2.12-3.5.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.5.2/kafka_2.13-3.5.2.tgz">kafka_2.13-3.5.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.2/kafka_2.13-3.5.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.2/kafka_2.13-3.5.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz">kafka_2.12-3.5.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz">kafka_2.13-3.5.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -128,7 +128,7 @@
     <p>
         Kafka 3.5.2 contains security fixes and bug fixes.
         For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_352_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://downloads.apache.org/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>.
+        and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.5.1"></span>
@@ -138,16 +138,16 @@
             Released Jul 21, 2023
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.5.1/kafka-3.5.1-src.tgz">kafka-3.5.1-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.1/kafka-3.5.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.1/kafka-3.5.1-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka-3.5.1-src.tgz">kafka-3.5.1-src.tgz</a> (<a href="https://archive.apache.org/dist/3.5.1/kafka-3.5.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka-3.5.1-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.12-3.5.1.tgz">kafka_2.12-3.5.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.12-3.5.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.12-3.5.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.13-3.5.1.tgz">kafka_2.13-3.5.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.13-3.5.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.5.1/kafka_2.13-3.5.1.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.12-3.5.1.tgz">kafka_2.12-3.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.12-3.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.12-3.5.1.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz">kafka_2.13-3.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -157,7 +157,7 @@
     <p>
         Kafka 3.5.1 is a security patch release. It contains security fixes and regression fixes.
         For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_351_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://downloads.apache.org/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>.
+        and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>.
     </p>
 
     <span id="3.5.0"></span>
@@ -196,16 +196,16 @@
             Released Jun 6, 2023
         </li>
         <li>
-            <a href="https://downloads.apache.org/kafka/3.4.1/RELEASE_NOTES.html">Release Notes</a>
+            <a href="https://archive.apache.org/dist/kafka/3.4.1/RELEASE_NOTES.html">Release Notes</a>
         </li>
         <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.4.1/kafka-3.4.1-src.tgz">kafka-3.4.1-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.4.1/kafka-3.4.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.4.1/kafka-3.4.1-src.tgz.sha512">sha512</a>)
+            Source download: <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka-3.4.1-src.tgz">kafka-3.4.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.1/kafka-3.4.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka-3.4.1-src.tgz.sha512">sha512</a>)
         </li>
         <li>
             Binary downloads:
             <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.4.1/kafka_2.12-3.4.1.tgz">kafka_2.12-3.4.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.4.1/kafka_2.12-3.4.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.4.1/kafka_2.12-3.4.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.4.1/kafka_2.13-3.4.1.tgz">kafka_2.13-3.4.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.4.1/kafka_2.13-3.4.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.4.1/kafka_2.13-3.4.1.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz">kafka_2.12-3.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz.sha512">sha512</a>)</li>
+                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.13-3.4.1.tgz">kafka_2.13-3.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.13-3.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.13-3.4.1.tgz.sha512">sha512</a>)</li>
             </ul>
             We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
             built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
@@ -214,7 +214,7 @@
 
     <p>
         Kafka 3.4.1 fixes 58 issues since the 3.4.0 release.
-        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/3.4.1/RELEASE_NOTES.html">Release Notes</a>
+        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.4.1/RELEASE_NOTES.html">Release Notes</a>
     </p>
 
     <span id="3.4.0"></span>


### PR DESCRIPTION
Before removing older releases from the svn repo, this updates their links to use the Apache archive instead of the mirrors.