### PR TITLE
MINOR: make ZK migrating to KRaft feature as production ready

### DIFF
--- a/37/ops.html
+++ b/37/ops.html
@@ -3780,12 +3780,6 @@ foo
 
   <h4 class="anchor-heading"><a id="kraft_zk_migration" class="anchor-link"></a><a href="#kraft_zk_migration">ZooKeeper to KRaft Migration</a></h4>
 
-  <p>
-    <b>ZooKeeper to KRaft migration is considered an Early Access feature and is not recommended for production clusters.</b>
-    Please report issues with ZooKeeper to KRaft migration using the
-    <a href="https://issues.apache.org/jira/projects/KAFKA" target="_blank">project JIRA</a> and the "kraft" component.
-  </p>
-
   <h3>Terminology</h3>
   <ul>
     <li>Brokers that are in <b>ZK mode</b> store their metadata in Apache ZooKepeer. This is the old mode of handling metadata.</li>


### PR DESCRIPTION
Ref: https://github.com/apache/kafka/pull/15552

The current document about Zookeeper to kraft migration is depreciated.
Accord to [KIP-833: Mark KRaft as Production Ready](https://cwiki.apache.org/confluence/display/KAFKA/KIP-833%3A+Mark+KRaft+as+Production+Ready), the migration from ZK mode supported as GA.