### PR TITLE
[MINOR] Add youtube to content security policy

### DIFF
--- a/includes/_header.htm
+++ b/includes/_header.htm
@@ -15,6 +15,7 @@
 		<meta property="og:description" content="Apache Kafka: A Distributed Streaming Platform." />
 		<meta property="og:site_name" content="Apache Kafka" />
 		<meta property="og:type" content="website" />
+		<meta http-equiv="Content-Security-Policy" content="frame-src youtube.com www.youtube.com">
 		<link href="/css/fonts.css" rel="stylesheet">
 		<script src="/js/jquery.min.js"></script>
 		<script defer src="/js/fontawesome.js"></script>


### PR DESCRIPTION
This change should fix the broken video on quickstart page https://kafka.apache.org/quickstart.
Currently observing following error:-
`quickstart:297 Refused to frame 'https://www.youtube.com/' because it violates the following Content Security Policy directive: "frame-src 'self'"`
