### PR TITLE
MINOR: remove reference to IRC channel

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -33,12 +33,6 @@
 		Prior to the move to Apache we had a Google group we used for discussion. Archives can be found <a href="http://groups.google.com/group/kafka-dev">here</a>. After that we were in Apache Incubator which has its own archives for <a href="http://mail-archives.apache.org/mod_mbox/incubator-kafka-users/">user</a>, <a href="http://mail-archives.apache.org/mod_mbox/incubator-kafka-dev/">dev</a>, and <a href="http://mail-archives.apache.org/mod_mbox/incubator-kafka-commits/">commit</a> lists.
 		</p>
 
-		<h3>IRC</h3>
-		<p>
-			We have an IRC channel where there is often a few people hanging around if you want an interactive discussion. You can find us on webchat.freenode.net	in #apache-kafka room (previously #kafka). The irc log can be found <a href="https://botbot.me/freenode/apache-kafka/">here</a>.
-		</p>
-
-
 <script>
 // Show selected style on nav item
 $(function() { $('.b-nav__contact').addClass('selected'); });


### PR DESCRIPTION
The channel on freenode seems abandoned (6 users, no topic).

The channel on libera.chat is explicitly unofficial.