### PR TITLE
KAFKA-16794 Move CSP header from _header.htm to .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,4 +10,4 @@ RewriteRule ^/?(\d+)/javadoc - [S=2]
 RewriteRule ^/?(\d+)/images/ - [S=1]
 RewriteCond $2 !=protocol
 RewriteRule ^/?(\d+)/([a-z]+)(\.html)? /$1/documentation#$2 [R=302,L,NE]
-Header set Content-Security-Policy "frame-src  youtube.com www.youtube.com"
+Header set Content-Security-Policy "frame-src youtube.com www.youtube.com"

--- a/.htaccess
+++ b/.htaccess
@@ -10,3 +10,4 @@ RewriteRule ^/?(\d+)/javadoc - [S=2]
 RewriteRule ^/?(\d+)/images/ - [S=1]
 RewriteCond $2 !=protocol
 RewriteRule ^/?(\d+)/([a-z]+)(\.html)? /$1/documentation#$2 [R=302,L,NE]
+Header set Content-Security-Policy "frame-src  youtube.com www.youtube.com"

--- a/.htaccess
+++ b/.htaccess
@@ -10,4 +10,4 @@ RewriteRule ^/?(\d+)/javadoc - [S=2]
 RewriteRule ^/?(\d+)/images/ - [S=1]
 RewriteCond $2 !=protocol
 RewriteRule ^/?(\d+)/([a-z]+)(\.html)? /$1/documentation#$2 [R=302,L,NE]
-Header set Content-Security-Policy "frame-src youtube.com www.youtube.com"
+Header set Content-Security-Policy "frame-src https://youtube.com https://www.youtube.com"

--- a/includes/_header.htm
+++ b/includes/_header.htm
@@ -15,7 +15,6 @@
 		<meta property="og:description" content="Apache Kafka: A Distributed Streaming Platform." />
 		<meta property="og:site_name" content="Apache Kafka" />
 		<meta property="og:type" content="website" />
-		<meta http-equiv="Content-Security-Policy" content="frame-src youtube.com www.youtube.com">
 		<link href="/css/fonts.css" rel="stylesheet">
 		<script src="/js/jquery.min.js"></script>
 		<script defer src="/js/fontawesome.js"></script>


### PR DESCRIPTION
Because this ticket https://issues.apache.org/jira/browse/KAFKA-16794, Some people can't watch the youtube video, because the CSP configuration added in the meta tag, so I move CSP configuration  to the apache httpd server config, to resolve this problem.