### PR TITLE
MINOR: Mention confirming email subscriptions to contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -28,6 +28,9 @@
 				To unsubscribe, send an email to <a href="mailto:commits-unsubscribe@kafka.apache.org">commits-unsubscribe@kafka.apache.org</a>.
 			</li>
 		</ul>
+		<p>
+		For all Apache mailing lists, you must confirm your subscription by replying to an email. See the <a href="https://www.apache.org/foundation/mailinglists">Apache Mailing Lists</a> page for more information.
+		</p>
 
 		<p>
 		Prior to the move to Apache we had a Google group we used for discussion. Archives can be found <a href="http://groups.google.com/group/kafka-dev">here</a>. After that we were in Apache Incubator which has its own archives for <a href="http://mail-archives.apache.org/mod_mbox/incubator-kafka-users/">user</a>, <a href="http://mail-archives.apache.org/mod_mbox/incubator-kafka-dev/">dev</a>, and <a href="http://mail-archives.apache.org/mod_mbox/incubator-kafka-commits/">commit</a> lists.


### PR DESCRIPTION
Some users partially subscribe to the mailing list, possibly because we don't mention the second step of replying to the confirmation email. Mentioning this succinctly in the page and linking to the ASF documentation could help make this less likely.