### PR TITLE
MINOR: Fix plugin path instructions in 3.8 quickstart

### DIFF
--- a/38/quickstart.html
+++ b/38/quickstart.html
@@ -237,7 +237,7 @@ This is my second event</code></pre>
             Edit the <code class="language-bash">config/connect-standalone.properties</code> file, add or change the <code>plugin.path</code> configuration property match the following, and save the file:
         </p>
 
-        <pre class="line-numbers"><code class="language-bash">$ echo "plugin.path=libs/connect-file-{{fullDotVersion}}.jar &gt;&gt; config/connect-standalone.properties"</code></pre>
+        <pre class="line-numbers"><code class="language-bash">$ echo "plugin.path=libs/connect-file-{{fullDotVersion}}.jar" &gt;&gt; "config/connect-standalone.properties"</code></pre>
 
         <p>
             Then, start by creating some seed data to test with:

--- a/38/quickstart.html
+++ b/38/quickstart.html
@@ -237,7 +237,7 @@ This is my second event</code></pre>
             Edit the <code class="language-bash">config/connect-standalone.properties</code> file, add or change the <code>plugin.path</code> configuration property match the following, and save the file:
         </p>
 
-        <pre class="line-numbers"><code class="language-bash">$ echo "plugin.path=libs/connect-file-{{fullDotVersion}}.jar" &gt;&gt; "config/connect-standalone.properties"</code></pre>
+        <pre class="line-numbers"><code class="language-bash">$ echo "plugin.path=libs/connect-file-{{fullDotVersion}}.jar" &gt;&gt; config/connect-standalone.properties</code></pre>
 
         <p>
             Then, start by creating some seed data to test with:


### PR DESCRIPTION
This ports a fix contained in https://github.com/apache/kafka/pull/16375 over to 3.8.