### PR TITLE
Fix powered-by page

### DIFF
--- a/powered-by.html
+++ b/powered-by.html
@@ -802,10 +802,10 @@
         "logoBgColor": "#ffffff",
         "description": "Edenlab FHIR engineers use Kafka to manage real-time data flow between dozens of microservices in our product - <a href=https://kodjin.com>Kodjin Interoperability Suite</a> - a low-code FHIR-based infrastructure for healthcare data management (contains FHIR Server, Terminology Service, and Mapper). Edenlab is a custom software and product development company focused primarily on healthcare data interoperability. We are also working with some major customers from the Fintech space (like Mastercard ® and Raffeisen BankInternational)."
     }, {
-	"link': "https://spitha.io/",
-	"logo": "spitha.png",
-	"logoBgColor": "#ffffff",
-	"description": "Based in South Korea, SPITHA is a team of experts specializing in Apache Kafka. We are driven by the question of how to make Kafka easier for users, and with that in mind, we are developing 'Felice,' a robust tool designed to streamline the operation and management of Kafka. Alongside this, we offer in-depth technical consulting and support services to provide comprehensive solutions to our clients."    
+        "link": "https://spitha.io/",
+        "logo": "spitha.png",
+        "logoBgColor": "#ffffff",
+        "description": "Based in South Korea, SPITHA is a team of experts specializing in Apache Kafka. We are driven by the question of how to make Kafka easier for users, and with that in mind, we are developing 'Felice,' a robust tool designed to streamline the operation and management of Kafka. Alongside this, we offer in-depth technical consulting and support services to provide comprehensive solutions to our clients."    
     }];
 </script>
 


### PR DESCRIPTION
Fix the page, one powered-by entity used mixed quotes (`"` and `'`) in a key