### PR TITLE
MINOR: inter.broker.protocol.version is not clearly in KRaft and Zookeeper mode

### DIFF
--- a/33/generated/kafka_config.html
+++ b/33/generated/kafka_config.html
@@ -1211,7 +1211,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br>This configuration is only applicable in Zookeeper mode.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.3-IV3</td></tr>

--- a/33/generated/kafka_config.html
+++ b/33/generated/kafka_config.html
@@ -1211,7 +1211,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.3-IV3</td></tr>

--- a/34/generated/kafka_config.html
+++ b/34/generated/kafka_config.html
@@ -1233,7 +1233,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br>This configuration is only applicable in Zookeeper mode.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.4-IV0</td></tr>

--- a/34/generated/kafka_config.html
+++ b/34/generated/kafka_config.html
@@ -1233,7 +1233,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.4-IV0</td></tr>

--- a/35/generated/kafka_config.html
+++ b/35/generated/kafka_config.html
@@ -1233,7 +1233,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br>This configuration is only applicable in Zookeeper mode.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.5-IV2</td></tr>

--- a/35/generated/kafka_config.html
+++ b/35/generated/kafka_config.html
@@ -1233,7 +1233,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.5-IV2</td></tr>

--- a/36/generated/kafka_config.html
+++ b/36/generated/kafka_config.html
@@ -1233,7 +1233,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br>This configuration is only applicable in Zookeeper mode.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.6-IV2</td></tr>

--- a/36/generated/kafka_config.html
+++ b/36/generated/kafka_config.html
@@ -1233,7 +1233,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.6-IV2</td></tr>

--- a/37/generated/kafka_config.html
+++ b/37/generated/kafka_config.html
@@ -1354,7 +1354,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.7-IV4</td></tr>

--- a/37/generated/kafka_config.html
+++ b/37/generated/kafka_config.html
@@ -1354,7 +1354,7 @@
 </li>
 <li>
 <h4><a id="inter.broker.protocol.version"></a><a id="brokerconfigs_inter.broker.protocol.version" href="#brokerconfigs_inter.broker.protocol.version">inter.broker.protocol.version</a></h4>
-<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br> This configuration is only applicable in Zookeeper mode, Use `metadata.version` config for KRaft instead.</p>
+<p>Specify which version of the inter-broker protocol will be used.<br> This is typically bumped after all brokers were upgraded to a new version.<br> Example of some valid values are: 0.8.0, 0.8.1, 0.8.1.1, 0.8.2, 0.8.2.0, 0.8.2.1, 0.9.0.0, 0.9.0.1 Check MetadataVersion for the full list.<br>This configuration is only applicable in Zookeeper mode.</p>
 <table><tbody>
 <tr><th>Type:</th><td>string</td></tr>
 <tr><th>Default:</th><td>3.7-IV4</td></tr>


### PR DESCRIPTION
In Zookeeper mode, use `inter.broker.protocol.version' configuration to setting the MV, but it doesn't work in KRaft mode, thus I think the document should description more clearly on the config.