### PR TITLE
KAFKA-17353: Separate unsupported releases in downloads page on website

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -5,2243 +5,2217 @@
 	<!--#include virtual="includes/_nav.htm" -->
 	<div class="right">
     <h1>Download</h1>
-
-    <p>3.8.0 is the latest release. The current stable version is 3.8.0</p>
-
-    <p>
-    You can verify your download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://downloads.apache.org/kafka/KEYS">KEYS</a>.
-    </p>
-
-    <span id="3.8.0"></span>
-    <h3 class="download-version">3.8.0<a href="#3.8.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released July 29, 2024
-        </li>
-        <li>
-            <a href="https://downloads.apache.org/kafka/3.8.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.8.0/images/sha256-c9aea96a4813e77e703541b1d8f7d58c9ee05b77353da33684db55c840548791">apache/kafka:3.8.0</a>.
-        </li>
-        <li>
-            Docker Native image: <a href="https://hub.docker.com/layers/apache/kafka-native/3.8.0/images/sha256-e1b3af1f501bb1d0c2dc11ce4fb04d0132568c9da18232bdd25643b587599ded">apache/kafka-native:3.8.0</a>.
-        </li>
-        <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.8.0/kafka-3.8.0-src.tgz">kafka-3.8.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka-3.8.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.8.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz">kafka_2.12-3.8.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz">kafka_2.13-3.8.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.8.0 includes a significant number of new features and fixes.
-        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_380_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://downloads.apache.org/kafka/3.8.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.7.1"></span>
-    <h3 class="download-version">3.7.1<a href="#3.7.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Jun 28, 2024
-        </li>
-        <li>
-            <a href="https://downloads.apache.org/kafka/3.7.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.7.1/images/sha256-3940ef8e220ead51db7057e9ee0554bfe7c7faac725bb49ac5fcf3b8d0db33b9">apache/kafka:3.7.1</a>.
-        </li>
-        <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.7.1/kafka-3.7.1-src.tgz">kafka-3.7.1-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.1/kafka-3.7.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.1/kafka-3.7.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.12-3.7.1.tgz">kafka_2.12-3.7.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.12-3.7.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.12-3.7.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.13-3.7.1.tgz">kafka_2.13-3.7.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.13-3.7.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.13-3.7.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.7.1 includes a significant number of new features and fixes.
-        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_371_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://downloads.apache.org/kafka/3.7.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.7.0"></span>
-    <h3 class="download-version">3.7.0<a href="#3.7.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Feb 27, 2024
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.7.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.7.0/images/sha256-3e324d2bd331570676436b24f625e5dcf1facdfbd62efcffabc6b69b1abc13cc">apache/kafka:3.7.0</a>.
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka-3.7.0-src.tgz">kafka-3.7.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.7.0/kafka-3.7.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka-3.7.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.12-3.7.0.tgz">kafka_2.12-3.7.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.12-3.7.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.12-3.7.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.13-3.7.0.tgz">kafka_2.13-3.7.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.13-3.7.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.13-3.7.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.7.0 includes a significant number of new features and fixes.
-        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_370_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://archive.apache.org/dist/kafka/3.7.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.6.2"></span>
-    <h3 class="download-version">3.6.2<a href="#3.6.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Apr 4, 2024
-        </li>
-        <li>
-            <a href="https://downloads.apache.org/kafka/3.6.2/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://downloads.apache.org/kafka/3.6.2/kafka-3.6.2-src.tgz">kafka-3.6.2-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.6.2/kafka-3.6.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.6.2/kafka-3.6.2-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.12-3.6.2.tgz">kafka_2.12-3.6.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.12-3.6.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.12-3.6.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.13-3.6.2.tgz">kafka_2.13-3.6.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.13-3.6.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.13-3.6.2.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.6.2 fixes 28 issues since the 3.6.1 release.
-        For more information, please read the detailed <a href="https://downloads.apache.org/kafka/3.6.2/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.6.1"></span>
-    <h3 class="download-version">3.6.1<a href="#3.6.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Dec 7, 2023
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.6.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka-3.6.1-src.tgz">kafka-3.6.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.1/kafka-3.6.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka-3.6.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.12-3.6.1.tgz">kafka_2.12-3.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.12-3.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.12-3.6.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.13-3.6.1.tgz">kafka_2.13-3.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.13-3.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.13-3.6.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.6.1 fixes 30 issues since the 3.6.0 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.6.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.6.0"></span>
-    <h3 class="download-version">3.6.0<a href="#3.6.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Oct 10, 2023
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.6.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka-3.6.0-src.tgz">kafka-3.6.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.0/kafka-3.6.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka-3.6.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.12-3.6.0.tgz">kafka_2.12-3.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.12-3.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.12-3.6.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz">kafka_2.13-3.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.6.0 includes a significant number of new features and fixes.
-        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_360_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://archive.apache.org/dist/kafka/3.6.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.5.2"></span>
-    <h3 class="download-version">3.5.2<a href="#3.5.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Dec 11, 2023
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz">kafka-3.5.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz">kafka_2.12-3.5.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz">kafka_2.13-3.5.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.5.2 contains security fixes and bug fixes.
-        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_352_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.5.1"></span>
-    <h3 class="download-version">3.5.1<a href="#3.5.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Jul 21, 2023
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka-3.5.1-src.tgz">kafka-3.5.1-src.tgz</a> (<a href="https://archive.apache.org/dist/3.5.1/kafka-3.5.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka-3.5.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.12-3.5.1.tgz">kafka_2.12-3.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.12-3.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.12-3.5.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz">kafka_2.13-3.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.5.1 is a security patch release. It contains security fixes and regression fixes.
-        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_351_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.5.0"></span>
-    <h3 class="download-version">3.5.0<a href="#3.5.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Jun 15, 2023
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.5.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka-3.5.0-src.tgz">kafka-3.5.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.0/kafka-3.5.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka-3.5.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.12-3.5.0.tgz">kafka_2.12-3.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.12-3.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.12-3.5.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz">kafka_2.13-3.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.5.0 includes a significant number of new features and fixes.
-        For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_350_release_announcement" target="_blank">blog post</a>
-        and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.4.1"></span>
-    <h3 class="download-version">3.4.1<a href="#3.4.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Jun 6, 2023
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.4.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka-3.4.1-src.tgz">kafka-3.4.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.1/kafka-3.4.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka-3.4.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz">kafka_2.12-3.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.13-3.4.1.tgz">kafka_2.13-3.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.13-3.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.13-3.4.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.4.1 fixes 58 issues since the 3.4.0 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.4.1/RELEASE_NOTES.html">Release Notes</a>
-    </p>
-
-    <span id="3.4.0"></span>
-    <h3 class="download-version">3.4.0<a href="#3.4.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Feb 7, 2023
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka-3.4.0-src.tgz">kafka-3.4.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.0/kafka-3.4.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka-3.4.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.12-3.4.0.tgz">kafka_2.12-3.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.12-3.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.12-3.4.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz">kafka_2.13-3.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.4.0 includes a significant number of new features and fixes.
-        For more information, please read our <a href="https://blogs.apache.org/kafka/entry/what-s-new-in-apache9" target="_blank">blog post</a>
-        and the detailed <a href="https://archive.apache.org/dist/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.3.2"></span>
-    <h3 class="download-version">3.3.2<a href="#3.3.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Jan 23, 2023
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.3.2/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka-3.3.2-src.tgz">kafka-3.3.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.2/kafka-3.3.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka-3.3.2-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.12-3.3.2.tgz">kafka_2.12-3.3.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.12-3.3.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.12-3.3.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.13-3.3.2.tgz">kafka_2.13-3.3.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.13-3.3.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.13-3.3.2.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.3.2 fixes 20 issues since the 3.3.1 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.3.2/RELEASE_NOTES.html">Release Notes</a>
-    </p>
-
-    <span id="3.3.1"></span>
-    <h3 class="download-version">3.3.1<a href="#3.3.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released October 3, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.3.1/RELEASE_NOTES.html">3.3.1</a> and <a href="https://archive.apache.org/dist/kafka/3.3.0/RELEASE_NOTES.html">3.3.0</a> Release Notes
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka-3.3.1-src.tgz">kafka-3.3.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.1/kafka-3.3.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka-3.3.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.12-3.3.1.tgz">kafka_2.12-3.3.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.12-3.3.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.12-3.3.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz">kafka_2.13-3.3.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.3.1 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>KIP-833: Mark KRaft as Production Ready</li>
-        <li>KIP-778: KRaft to KRaft upgrades</li>
-        <li>KIP-835: Monitor KRaft Controller Quorum health</li>
-        <li>KIP-794: Strictly Uniform Sticky Partitioner</li>
-        <li>KIP-834: Pause/resume KafkaStreams topologies</li>
-        <li>KIP-618: Exactly-Once support for source connectors</li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.3.1/RELEASE_NOTES.html">3.3.1</a> and <a href="https://archive.apache.org/dist/kafka/3.3.0/RELEASE_NOTES.html">3.3.0</a> Release Notes.
-    </p>
-
-    <span id="3.3.0"></span>
-    <h3 class="download-version">3.3.0<a href="#3.3.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <p>A significant bug was found in the 3.3.0 release after artifacts were pushed to Apache and Maven central but prior to the release announcement. As a result, the decision was made to not announce 3.3.0 and instead release 3.3.1 with the fix. It is recommended that 3.3.0 not be used.</p>
-
-    <span id="3.2.3"></span>
-    <h3 class="download-version">3.2.3<a href="#3.2.3"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Sept 19, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.2.3/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka-3.2.3-src.tgz">kafka-3.2.3-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.3/kafka-3.2.3-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka-3.2.3-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.12-3.2.3.tgz">kafka_2.12-3.2.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.12-3.2.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.12-3.2.3.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.13-3.2.3.tgz">kafka_2.13-3.2.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.13-3.2.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.13-3.2.3.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.2.3 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 7 other issues since the 3.2.1 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.2.3/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.2.2"></span>
-    <h3 class="download-version">3.2.2<a href="#3.2.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <p>A significant bug was found in the 3.2.2 release after artifacts were pushed to Maven central but prior to the release announcement. 
-    As a result the decision was taken to not announce 3.2.2 and release 3.2.3 with the fix. 
-    It is recommended that 3.2.2 not be used.</p>
-
-    <span id="3.2.1"></span>
-    <h3 class="download-version">3.2.1<a href="#3.2.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Jul 29, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.2.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka-3.2.1-src.tgz">kafka-3.2.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.1/kafka-3.2.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka-3.2.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.12-3.2.1.tgz">kafka_2.12-3.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.12-3.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.12-3.2.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.13-3.2.1.tgz">kafka_2.13-3.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.13-3.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.13-3.2.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.2.1 fixes 13 issues since the 3.2.0 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.2.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.2.0"></span>
-    <h3 class="download-version">3.2.0<a href="#3.2.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released May 17, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.2.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka-3.2.0-src.tgz">kafka-3.2.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.0/kafka-3.2.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka-3.2.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.12-3.2.0.tgz">kafka_2.12-3.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.12-3.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.12-3.2.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.13-3.2.0.tgz">kafka_2.13-3.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.13-3.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.13-3.2.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.2.0 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>log4j 1.x is replaced with reload4j</li>
-        <li>StandardAuthorizer for KRaft (KIP-801)</li>
-        <li>Send a hint to the partition leader to recover the partition (KIP-704)</li>
-        <li>Top-level error code field in DescribeLogDirsResponse (KIP-784)</li>
-        <li>kafka-console-producer writes headers and null values (KIP-798 and KIP-810)</li>
-        <li>JoinGroupRequest and LeaveGroupRequest have a reason attached (KIP-800)</li>
-        <li>Static membership protocol lets the leader skip assignment (KIP-814)</li>
-        <li>Rack-aware standby task assignment in Kafka Streams (KIP-708)</li>
-        <li>Interactive Query v2 (KIP-796, KIP-805, and KIP-806)</li>
-        <li>Connect APIs list all connector plugins and retrieve their configuration (KIP-769)</li>
-        <li>TimestampConverter SMT supports different unix time precisions (KIP-808)</li>
-        <li>Connect source tasks handle producer exceptions (KIP-779)</li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.2.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.1.2"></span>
-    <h3 class="download-version">3.1.2<a href="#3.1.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Sept 19, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.1.2/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka-3.1.2-src.tgz">kafka-3.1.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.2/kafka-3.1.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka-3.1.2-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.12-3.1.2.tgz">kafka_2.12-3.1.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.12-3.1.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.12-3.1.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.13-3.1.2.tgz">kafka_2.13-3.1.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.13-3.1.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.13-3.1.2.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.1.2 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 4 other issues since the 3.1.1 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.1.2/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.1.1"></span>
-    <h3 class="download-version">3.1.1<a href="#3.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released May 13, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.1.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka-3.1.1-src.tgz">kafka-3.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.1/kafka-3.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka-3.1.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.12-3.1.1.tgz">kafka_2.12-3.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.12-3.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.12-3.1.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.13-3.1.1.tgz">kafka_2.13-3.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.13-3.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.13-3.1.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.1.1 fixes 29 issues since the 3.1.0 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.1.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.1.0"></span>
-    <h3 class="download-version">3.1.0<a href="#3.1.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released January 24, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.1.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka-3.1.0-src.tgz">kafka-3.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.0/kafka-3.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka-3.1.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.12-3.1.0.tgz">kafka_2.12-3.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.12-3.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.12-3.1.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.13-3.1.0.tgz">kafka_2.13-3.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.13-3.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.13-3.1.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.1.0 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>Apache Kafka supports Java 17</li>
-        <li>The FetchRequest supports Topic IDs (KIP-516)</li>
-        <li>Extend SASL/OAUTHBEARER with support for OIDC (KIP-768)</li>
-        <li>Add broker count metrics (KIP-748)</li>
-        <li>Differentiate consistently metric latency measured in millis and nanos (KIP-773)</li>
-        <li>The eager rebalance protocol is deprecated (KAFKA-13439)</li>
-        <li>Add TaskId field to StreamsException (KIP-783)</li>
-        <li>Custom partitioners in foreign-key joins (KIP-775)</li>
-        <li>Fetch/findSessions queries with open endpoints for SessionStore/WindowStore (KIP-766)</li>
-        <li>Range queries with open endpoints (KIP-763)</li>
-        <li>Add total blocked time metric to Streams (KIP-761)</li>
-        <li>Add additional configuration to control MirrorMaker2 internal topics naming convention (KIP-690)</li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.1.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.0.2"></span>
-    <h3 class="download-version">3.0.2<a href="#3.0.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Sept 19, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.0.2/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka-3.0.2-src.tgz">kafka-3.0.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.2/kafka-3.0.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka-3.0.2-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.12-3.0.2.tgz">kafka_2.12-3.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.12-3.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.12-3.0.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.13-3.0.2.tgz">kafka_2.13-3.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.13-3.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.13-3.0.2.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.0.2 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 10 other issues since the 3.0.1 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.0.2/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.0.1"></span>
-    <h3 class="download-version">3.0.1<a href="#3.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released March 11, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.0.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka-3.0.1-src.tgz">kafka-3.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.1/kafka-3.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka-3.0.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz">kafka_2.12-3.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.13-3.0.1.tgz">kafka_2.13-3.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.13-3.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.13-3.0.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.0.1 fixes 29 issues since the 3.0.0 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.0.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="3.0.0"></span>
-    <h3 class="download-version">3.0.0<a href="#3.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released September 21, 2021
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/3.0.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka-3.0.0-src.tgz">kafka-3.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.0/kafka-3.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka-3.0.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.12-3.0.0.tgz">kafka_2.12-3.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.12-3.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.12-3.0.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.13-3.0.0.tgz">kafka_2.13-3.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.13-3.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.13-3.0.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 3.0.0 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>The deprecation of support for Java 8 and Scala 2.12</li>
-        <li>Kafka Raft support for snapshots of the metadata topic and other improvements in the self-managed quorum</li>
-        <li>Stronger delivery guarantees for the Kafka producer enabled by default</li>
-        <li>Deprecation of message formats v0 and v1</li>
-        <li>Optimizations in OffsetFetch and FindCoordinator requests</li>
-        <li>More flexible Mirror Maker 2 configuration and deprecation of Mirror Maker 1</li>
-        <li>Ability to restart a connector's tasks on a single call in Kafka Connect</li>
-        <li>Connector log contexts and connector client overrides are now enabled by default</li>
-        <li>Enhanced semantics for timestamp synchronization in Kafka Streams</li>
-        <li>Revamped public API for Stream's TaskId</li>
-        <li>Default serde becomes null in Kafka</li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.0.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.8.2"></span>
-    <h3 class="download-version">2.8.2<a href="#2.8.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released September 19, 2022
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.8.2/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka-2.8.2-src.tgz">kafka-2.8.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.2/kafka-2.8.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka-2.8.2-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.12-2.8.2.tgz">kafka_2.12-2.8.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.12-2.8.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.12-2.8.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.13-2.8.2.tgz">kafka_2.13-2.8.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.13-2.8.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.13-2.8.2.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.8.2 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 11 other issues since the 2.8.1 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.8.2/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.8.1"></span>
-    <h3 class="download-version">2.8.1<a href="#2.8.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released September 17, 2021
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.8.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka-2.8.1-src.tgz">kafka-2.8.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.1/kafka-2.8.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka-2.8.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.12-2.8.1.tgz">kafka_2.12-2.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.12-2.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.12-2.8.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.13-2.8.1.tgz">kafka_2.13-2.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.13-2.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.13-2.8.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.8.1 fixes 49 issues since the 2.8.0 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.8.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.8.0"></span>
-    <h3 class="download-version">2.8.0<a href="#2.8.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released April 19, 2021
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.8.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka-2.8.0-src.tgz">kafka-2.8.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.0/kafka-2.8.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka-2.8.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz">kafka_2.12-2.8.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.13-2.8.0.tgz">kafka_2.13-2.8.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.13-2.8.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.13-2.8.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.8.0 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>Early access of replace ZooKeeper with a self-managed quorum</li>
-        <li>Add Describe Cluster API</li>
-        <li>Support mutual TLS authentication on SASL_SSL listeners</li>
-        <li>JSON request/response debug logs</li>
-        <li>Limit broker connection creation rate</li>
-        <li>Topic identifiers</li>
-        <li>Expose task configurations in Connect REST API</li>
-        <li>Update Streams FSM to clarify ERROR state meaning</li>
-        <li>Extend StreamJoined to allow more store configs</li>
-        <li>More convenient TopologyTestDriver construtors</li>
-        <li>Introduce Kafka-Streams-specific uncaught exception handler</li>
-        <li>API to start and shut down Streams threads</li>
-        <li>Improve TimeWindowedDeserializer and TimeWindowedSerde to handle window size</li>
-        <li>Improve timeouts and retries in Kafka Streams</li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.8.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.7.2"></span>
-    <h3 class="download-version">2.7.2<a href="#2.7.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released November 15, 2021
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.7.2/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka-2.7.2-src.tgz">kafka-2.7.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.2/kafka-2.7.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka-2.7.2-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.12-2.7.2.tgz">kafka_2.12-2.7.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.12-2.7.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.12-2.7.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.13-2.7.2.tgz">kafka_2.13-2.7.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.13-2.7.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.13-2.7.2.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.7.2 fixes 26 issues since the 2.7.1 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.7.2/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.7.1"></span>
-    <h3 class="download-version">2.7.1<a href="#2.7.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released May 10, 2021
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.7.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka-2.7.1-src.tgz">kafka-2.7.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.1/kafka-2.7.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka-2.7.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.12-2.7.1.tgz">kafka_2.12-2.7.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.12-2.7.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.12-2.7.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.13-2.7.1.tgz">kafka_2.13-2.7.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.13-2.7.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.13-2.7.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.7.1 fixes 45 issues since the 2.7.0 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.7.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.7.0"></span>
-    <h3 class="download-version">2.7.0<a href="#2.7.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Dec 21, 2020
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka-2.7.0-src.tgz">kafka-2.7.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.0/kafka-2.7.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka-2.7.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.12-2.7.0.tgz">kafka_2.12-2.7.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.12-2.7.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.12-2.7.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.13-2.7.0.tgz">kafka_2.13-2.7.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.13-2.7.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.13-2.7.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.7.0 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>Configurable TCP connection timeout and improve the initial metadata fetch</li>
-        <li>Enforce broker-wide and per-listener connection creation rate (KIP-612, part 1)</li>
-        <li>Throttle Create Topic, Create Partition and Delete Topic Operations</li>
-        <li>Add TRACE-level end-to-end latency metrics to Streams</li>
-        <li>Add Broker-side SCRAM Config API</li>
-        <li>Support PEM format for SSL certificates and private key</li>
-        <li>Add RocksDB Memory Consumption to RocksDB Metrics</li>
-        <li>Add Sliding-Window support for Aggregations</li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.6.3"></span>
-    <h3 class="download-version">2.6.3<a href="#2.6.3"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released November 15, 2021
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.6.3/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka-2.6.3-src.tgz">kafka-2.6.3-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.3/kafka-2.6.3-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka-2.6.3-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.12-2.6.3.tgz">kafka_2.12-2.6.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.12-2.6.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.12-2.6.3.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.13-2.6.3.tgz">kafka_2.13-2.6.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.13-2.6.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.13-2.6.3.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.6.3 fixes 11 issues since the 2.6.2 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.6.3/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.6.2"></span>
-    <h3 class="download-version">2.6.2<a href="#2.6.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released April 20, 2021
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.6.2/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka-2.6.2-src.tgz">kafka-2.6.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.2/kafka-2.6.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka-2.6.2-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.12-2.6.2.tgz">kafka_2.12-2.6.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.12-2.6.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.12-2.6.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.13-2.6.2.tgz">kafka_2.13-2.6.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.13-2.6.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.13-2.6.2.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.6.2 fixes 35 issues since the 2.6.1 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.6.2/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.6.1"></span>
-    <h3 class="download-version">2.6.1<a href="#2.6.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released January 07, 2021
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz">kafka-2.6.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz">kafka_2.12-2.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz">kafka_2.13-2.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.6.1 fixes 41 issues since the 2.6.0 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.6.0"></span>
-    <h3 class="download-version">2.6.0<a href="#2.6.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Aug 3, 2020
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.6.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka-2.6.0-src.tgz">kafka-2.6.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.0/kafka-2.6.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka-2.6.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz">kafka_2.12-2.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.13-2.6.0.tgz">kafka_2.13-2.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.13-2.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.13-2.6.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.6.0 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>TLSv1.3 has been enabled by default for Java 11 or newer</li>
-        <li>Significant performance improvements, especially when the broker has large numbers of partitions</li>
-        <li>Smooth scaling out of Kafka Streams applications</li>
-        <li>Kafka Streams support for emit on change</li>
-        <li>New metrics for better operational insight</li>
-        <li>Kafka Connect can automatically create topics for source connectors when configured to do so</li>
-        <li>Improved error reporting options for sink connectors in Kafka Connect</li>
-        <li>New Filter and conditional SMTs in Kafka Connect</li>
-        <li>The default value for the `client.dns.lookup` configuration is now `use_all_dns_ips`</li>
-        <li>Upgrade Zookeeper to 3.5.8</li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.6.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.5.1"></span>
-    <h3 class="download-version">2.5.1<a href="#2.5.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released August 10, 2020
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.5.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka-2.5.1-src.tgz">kafka-2.5.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.1/kafka-2.5.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka-2.5.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.12-2.5.1.tgz">kafka_2.12-2.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.12-2.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.12-2.5.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.13-2.5.1.tgz">kafka_2.13-2.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.13-2.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.13-2.5.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.5.1 fixes 72 issues since the 2.5.0 release.
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.5.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.5.0"></span>
-    <h3 class="download-version">2.5.0<a href="#2.5.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released April 15, 2020
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.5.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka-2.5.0-src.tgz">kafka-2.5.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.0/kafka-2.5.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka-2.5.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz">kafka_2.12-2.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.13-2.5.0.tgz">kafka_2.13-2.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.13-2.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.13-2.5.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.5.0 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>TLS 1.3 support (1.2 is now the default)</li>
-        <li>Co-groups for Kafka Streams</li>
-        <li>Incremental rebalance for Kafka Consumer</li>
-        <li>New metrics for better operational insight</li>
-        <li>Upgrade Zookeeper to 3.5.7</li>
-        <li>Deprecate support for Scala 2.11</li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.5.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.4.1"></span>
-    <h3 class="download-version">2.4.1<a href="#2.4.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released March 12, 2020
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka-2.4.1-src.tgz">kafka-2.4.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.1/kafka-2.4.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka-2.4.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.11-2.4.1.tgz">kafka_2.11-2.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.11-2.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.11-2.4.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.12-2.4.1.tgz">kafka_2.12-2.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.12-2.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.12-2.4.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.13-2.4.1.tgz">kafka_2.13-2.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.13-2.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.13-2.4.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.4.0"></span>
-    <h3 class="download-version">2.4.0<a href="#2.4.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released December 16, 2019
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz">kafka-2.4.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz">kafka_2.11-2.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz">kafka_2.12-2.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz">kafka_2.13-2.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
-            built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.4.0 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>Allow consumers to fetch from closest replica.</li>
-        <li>Support for incremental cooperative rebalancing to the consumer rebalance protocol.</li>
-        <li>MirrorMaker 2.0 (MM2), a new multi-cluster, cross-datacenter replication engine.</li>
-        <li>New Java authorizer Interface.</li>
-        <li>Support for non-key joining in KTable.</li>
-        <li>Administrative API for replica reassignment.</li>
-    </ul>
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.3.1"></span>
-    <h3 class="download-version">2.3.1<a href="#2.3.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Oct 24, 2019
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.3.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka-2.3.1-src.tgz">kafka-2.3.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.1/kafka-2.3.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka-2.3.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.11-2.3.1.tgz">kafka_2.11-2.3.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.11-2.3.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.11-2.3.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.12-2.3.1.tgz">kafka_2.12-2.3.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.12-2.3.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.12-2.3.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.3.1/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.3.0"></span>
-    <h3 class="download-version">2.3.0<a href="#2.3.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Jun 25, 2019
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.3.0/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz">kafka-2.3.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz">kafka_2.11-2.3.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz">kafka_2.12-2.3.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-        </li>
-    </ul>
-
-    <p>
-        Kafka 2.3.0 includes a number of significant new features. Here is a summary of some notable changes:
-    </p>
-
-    <ul>
-        <li>There have been several improvements to the Kafka Connect REST API.</li>
-        <li>Kafka Connect now supports incremental cooperative rebalancing. </li>
-        <li>Kafka Streams now supports an in-memory session store and window store.</li>
-        <li>The AdminClient now allows users to determine what operations they are authorized to perform on topics.</li>
-        <li>There is a new broker start time metric.</li>
-        <li>JMXTool can now connect to secured RMI ports.</li>
-        <li>An incremental AlterConfigs API has been added.  The old AlterConfigs API has been deprecated.</li>
-        <li>We now track partitions which are under their min ISR count.</li>
-        <li>Consumers can now opt-out of automatic topic creation, even when it is enabled on the broker.</li>
-        <li>Kafka components can now use external configuration stores (KIP-421).</li>
-        <li>We have implemented improved replica fetcher behavior when errors are encountered.</li>
-    </ul>
-    <p>
-        For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.3.0/RELEASE_NOTES.html">Release Notes</a>.
-    </p>
-
-    <span id="2.2.2"></span>
-    <h3 class="download-version">2.2.2<a href="#2.2.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Dec 1, 2019
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.2.2/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka-2.2.2-src.tgz">kafka-2.2.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.2/kafka-2.2.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka-2.2.2-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.11-2.2.2.tgz">kafka_2.11-2.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.11-2.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.11-2.2.2.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.12-2.2.2.tgz">kafka_2.12-2.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.12-2.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.12-2.2.2.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-        </li>
-    </ul>
-
-    <span id="2.2.1"></span>
-    <h3 class="download-version">2.2.1<a href="#2.2.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-    <ul>
-        <li>
-            Released Jun 1, 2019
-        </li>
-        <li>
-            <a href="https://archive.apache.org/dist/kafka/2.2.1/RELEASE_NOTES.html">Release Notes</a>
-        </li>
-        <li>
-            Source download: <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka-2.2.1-src.tgz">kafka-2.2.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.1/kafka-2.2.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka-2.2.1-src.tgz.sha512">sha512</a>)
-        </li>
-        <li>
-            Binary downloads:
-            <ul>
-                <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.11-2.2.1.tgz">kafka_2.11-2.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.11-2.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.11-2.2.1.tgz.sha512">sha512</a>)</li>
-                <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.12-2.2.1.tgz">kafka_2.12-2.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.12-2.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.12-2.2.1.tgz.sha512">sha512</a>)</li>
-            </ul>
-            We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-        </li>
-    </ul>
-
-    <span id="2.2.0"></span>
-    <h3 class="download-version">2.2.0<a href="#2.2.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released Mar 22, 2019
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/2.2.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz">kafka-2.2.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
-                <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz">kafka_2.11-2.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz">kafka_2.12-2.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz.sha512">sha512</a>)</li>
-                </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-            </li>
-        </ul>
-
+        
         <p>
-            Kafka 2.2.0 includes a number of significant new features. Here is a summary of some notable changes:
+            The project goal is to have 3 releases a year, which means a release every 4 months. Bugfix releases are made as needed for supported releases only.
+            It is possible to verify every download by following these <a href="https://www.apache.org/info/verification.html">procedures</a> and using these <a href="https://downloads.apache.org/kafka/KEYS">KEYS</a>.
         </p>
+        
+        <h2>Supported releases</h2>
 
-        <ul>
-          <li>Added SSL support for custom principal name</li>
-          <li>Allow SASL connections to periodically re-authenticate</li>
-          <li>Command line tool <code>bin/kafka-topics.sh</code> adds AdminClient support</li>
-          <li>Improved consumer group management: default <code>group.id</code> is <code>null</code> instead of empty string</li>
-          <li>API improvement:
+            <span id="3.8.0"></span>
+            <h3 class="download-version">3.8.0<a href="#3.8.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
             <ul>
-            <li>Producer: introduce <code>close(Duration)</code></li>
-            <li>AdminClient: introduce <code>close(Duration)</code></li>
-            <li>Kafka Streams: new <code>flatTransform()</code> operator in Streams DSL</li>
-            <li>KafkaStreams (and other classed) now implement <code>AutoClosable</code> to support try-with-resource</li>
-            <li>New Serdes and default method implementations</li>
+                <li>
+                    Released July 29, 2024
+                </li>
+                <li>
+                    <a href="https://downloads.apache.org/kafka/3.8.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.8.0/images/sha256-c9aea96a4813e77e703541b1d8f7d58c9ee05b77353da33684db55c840548791">apache/kafka:3.8.0</a>.
+                </li>
+                <li>
+                    Docker Native image: <a href="https://hub.docker.com/layers/apache/kafka-native/3.8.0/images/sha256-e1b3af1f501bb1d0c2dc11ce4fb04d0132568c9da18232bdd25643b587599ded">apache/kafka-native:3.8.0</a>.
+                </li>
+                <li>
+                    Source download: <a href="https://downloads.apache.org/kafka/3.8.0/kafka-3.8.0-src.tgz">kafka-3.8.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka-3.8.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.8.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz">kafka_2.12-3.8.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz">kafka_2.13-3.8.0.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
             </ul>
-	  </li>
-          <li>Kafka Streams exposed internal <code>client.id</code> via <code>ThreadMetadata</code></li>
-          <li>Metric improvements: All <code>-min</code>, <code>-avg</code> and <code>-max</code> metrics will now output <code>NaN</code> as default value</li>
-        </ul>
-        <p>
-            For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.2.0/RELEASE_NOTES.html">Release Notes</a>.
-        </p>
+    
+            <p>
+                Kafka 3.8.0 includes a significant number of new features and fixes.
+                For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_380_release_announcement" target="_blank">blog post</a>
+                and the detailed <a href="https://downloads.apache.org/kafka/3.8.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
 
-    <span id="2.1.1"></span>
-    <h3 class="download-version">2.1.1<a href="#2.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released Feb 15, 2019
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/2.1.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka-2.1.1-src.tgz">kafka-2.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.1/kafka-2.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka-2.1.1-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+            <span id="3.7.1"></span>
+            <h3 class="download-version">3.7.1<a href="#3.7.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Jun 28, 2024
+                </li>
+                <li>
+                    <a href="https://downloads.apache.org/kafka/3.7.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.7.1/images/sha256-3940ef8e220ead51db7057e9ee0554bfe7c7faac725bb49ac5fcf3b8d0db33b9">apache/kafka:3.7.1</a>.
+                </li>
+                <li>
+                    Source download: <a href="https://downloads.apache.org/kafka/3.7.1/kafka-3.7.1-src.tgz">kafka-3.7.1-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.1/kafka-3.7.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.1/kafka-3.7.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.12-3.7.1.tgz">kafka_2.12-3.7.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.12-3.7.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.12-3.7.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.13-3.7.1.tgz">kafka_2.13-3.7.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.13-3.7.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.1/kafka_2.13-3.7.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+    
+            <p>
+                Kafka 3.7.1 includes a significant number of new features and fixes.
+                For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_371_release_announcement" target="_blank">blog post</a>
+                and the detailed <a href="https://downloads.apache.org/kafka/3.7.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+
+            <span id="3.6.2"></span>
+            <h3 class="download-version">3.6.2<a href="#3.6.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Apr 4, 2024
+                </li>
+                <li>
+                    <a href="https://downloads.apache.org/kafka/3.6.2/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://downloads.apache.org/kafka/3.6.2/kafka-3.6.2-src.tgz">kafka-3.6.2-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.6.2/kafka-3.6.2-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.6.2/kafka-3.6.2-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.12-3.6.2.tgz">kafka_2.12-3.6.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.12-3.6.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.12-3.6.2.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.13-3.6.2.tgz">kafka_2.13-3.6.2.tgz</a> (<a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.13-3.6.2.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.6.2/kafka_2.13-3.6.2.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+    
+            <p>
+                Kafka 3.6.2 fixes 28 issues since the 3.6.1 release.
+                For more information, please read the detailed <a href="https://downloads.apache.org/kafka/3.6.2/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+        <h2>Archived releases</h2>
+
+            <span id="3.7.0"></span>
+            <h3 class="download-version">3.7.0<a href="#3.7.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Feb 27, 2024
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.7.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.7.0/images/sha256-3e324d2bd331570676436b24f625e5dcf1facdfbd62efcffabc6b69b1abc13cc">apache/kafka:3.7.0</a>.
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka-3.7.0-src.tgz">kafka-3.7.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.7.0/kafka-3.7.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka-3.7.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.12-3.7.0.tgz">kafka_2.12-3.7.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.12-3.7.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.12-3.7.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.13-3.7.0.tgz">kafka_2.13-3.7.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.13-3.7.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.7.0/kafka_2.13-3.7.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.7.0 includes a significant number of new features and fixes.
+                For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_370_release_announcement" target="_blank">blog post</a>
+                and the detailed <a href="https://archive.apache.org/dist/kafka/3.7.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.6.1"></span>
+            <h3 class="download-version">3.6.1<a href="#3.6.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Dec 7, 2023
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.6.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka-3.6.1-src.tgz">kafka-3.6.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.1/kafka-3.6.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka-3.6.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.12-3.6.1.tgz">kafka_2.12-3.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.12-3.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.12-3.6.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.13-3.6.1.tgz">kafka_2.13-3.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.13-3.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.1/kafka_2.13-3.6.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.6.1 fixes 30 issues since the 3.6.0 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.6.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.6.0"></span>
+            <h3 class="download-version">3.6.0<a href="#3.6.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Oct 10, 2023
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.6.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka-3.6.0-src.tgz">kafka-3.6.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.0/kafka-3.6.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka-3.6.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.12-3.6.0.tgz">kafka_2.12-3.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.12-3.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.12-3.6.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz">kafka_2.13-3.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.6.0/kafka_2.13-3.6.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.6.0 includes a significant number of new features and fixes.
+                For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_360_release_announcement" target="_blank">blog post</a>
+                and the detailed <a href="https://archive.apache.org/dist/kafka/3.6.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.5.2"></span>
+            <h3 class="download-version">3.5.2<a href="#3.5.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Dec 11, 2023
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz">kafka-3.5.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka-3.5.2-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz">kafka_2.12-3.5.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.12-3.5.2.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz">kafka_2.13-3.5.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.2/kafka_2.13-3.5.2.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.5.2 contains security fixes and bug fixes.
+                For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_352_release_announcement" target="_blank">blog post</a>
+                and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.2/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.5.1"></span>
+            <h3 class="download-version">3.5.1<a href="#3.5.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Jul 21, 2023
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka-3.5.1-src.tgz">kafka-3.5.1-src.tgz</a> (<a href="https://archive.apache.org/dist/3.5.1/kafka-3.5.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka-3.5.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.12-3.5.1.tgz">kafka_2.12-3.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.12-3.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.12-3.5.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz">kafka_2.13-3.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.5.1 is a security patch release. It contains security fixes and regression fixes.
+                For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_351_release_announcement" target="_blank">blog post</a>
+                and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.5.0"></span>
+            <h3 class="download-version">3.5.0<a href="#3.5.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Jun 15, 2023
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.5.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka-3.5.0-src.tgz">kafka-3.5.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.0/kafka-3.5.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka-3.5.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.12-3.5.0.tgz">kafka_2.12-3.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.12-3.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.12-3.5.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz">kafka_2.13-3.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.5.0/kafka_2.13-3.5.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.5.0 includes a significant number of new features and fixes.
+                For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_350_release_announcement" target="_blank">blog post</a>
+                and the detailed <a href="https://archive.apache.org/dist/kafka/3.5.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.4.1"></span>
+            <h3 class="download-version">3.4.1<a href="#3.4.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Jun 6, 2023
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.4.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka-3.4.1-src.tgz">kafka-3.4.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.1/kafka-3.4.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka-3.4.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz">kafka_2.12-3.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.12-3.4.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.13-3.4.1.tgz">kafka_2.13-3.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.13-3.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.1/kafka_2.13-3.4.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.4.1 fixes 58 issues since the 3.4.0 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.4.1/RELEASE_NOTES.html">Release Notes</a>
+            </p>
+        
+            <span id="3.4.0"></span>
+            <h3 class="download-version">3.4.0<a href="#3.4.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Feb 7, 2023
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka-3.4.0-src.tgz">kafka-3.4.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.0/kafka-3.4.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka-3.4.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.12-3.4.0.tgz">kafka_2.12-3.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.12-3.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.12-3.4.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz">kafka_2.13-3.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.4.0/kafka_2.13-3.4.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.4.0 includes a significant number of new features and fixes.
+                For more information, please read our <a href="https://blogs.apache.org/kafka/entry/what-s-new-in-apache9" target="_blank">blog post</a>
+                and the detailed <a href="https://archive.apache.org/dist/kafka/3.4.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.3.2"></span>
+            <h3 class="download-version">3.3.2<a href="#3.3.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Jan 23, 2023
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.3.2/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka-3.3.2-src.tgz">kafka-3.3.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.2/kafka-3.3.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka-3.3.2-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.12-3.3.2.tgz">kafka_2.12-3.3.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.12-3.3.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.12-3.3.2.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.13-3.3.2.tgz">kafka_2.13-3.3.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.13-3.3.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.2/kafka_2.13-3.3.2.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.3.2 fixes 20 issues since the 3.3.1 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.3.2/RELEASE_NOTES.html">Release Notes</a>
+            </p>
+        
+            <span id="3.3.1"></span>
+            <h3 class="download-version">3.3.1<a href="#3.3.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released October 3, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.3.1/RELEASE_NOTES.html">3.3.1</a> and <a href="https://archive.apache.org/dist/kafka/3.3.0/RELEASE_NOTES.html">3.3.0</a> Release Notes
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka-3.3.1-src.tgz">kafka-3.3.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.1/kafka-3.3.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka-3.3.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.12-3.3.1.tgz">kafka_2.12-3.3.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.12-3.3.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.12-3.3.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz">kafka_2.13-3.3.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.3.1/kafka_2.13-3.3.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.3.1 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>KIP-833: Mark KRaft as Production Ready</li>
+                <li>KIP-778: KRaft to KRaft upgrades</li>
+                <li>KIP-835: Monitor KRaft Controller Quorum health</li>
+                <li>KIP-794: Strictly Uniform Sticky Partitioner</li>
+                <li>KIP-834: Pause/resume KafkaStreams topologies</li>
+                <li>KIP-618: Exactly-Once support for source connectors</li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.3.1/RELEASE_NOTES.html">3.3.1</a> and <a href="https://archive.apache.org/dist/kafka/3.3.0/RELEASE_NOTES.html">3.3.0</a> Release Notes.
+            </p>
+        
+            <span id="3.3.0"></span>
+            <h3 class="download-version">3.3.0<a href="#3.3.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <p>A significant bug was found in the 3.3.0 release after artifacts were pushed to Apache and Maven central but prior to the release announcement. As a result, the decision was made to not announce 3.3.0 and instead release 3.3.1 with the fix. It is recommended that 3.3.0 not be used.</p>
+        
+            <span id="3.2.3"></span>
+            <h3 class="download-version">3.2.3<a href="#3.2.3"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Sept 19, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.2.3/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka-3.2.3-src.tgz">kafka-3.2.3-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.3/kafka-3.2.3-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka-3.2.3-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.12-3.2.3.tgz">kafka_2.12-3.2.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.12-3.2.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.12-3.2.3.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.13-3.2.3.tgz">kafka_2.13-3.2.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.13-3.2.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.3/kafka_2.13-3.2.3.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.2.3 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 7 other issues since the 3.2.1 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.2.3/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.2.2"></span>
+            <h3 class="download-version">3.2.2<a href="#3.2.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <p>A significant bug was found in the 3.2.2 release after artifacts were pushed to Maven central but prior to the release announcement. 
+            As a result the decision was taken to not announce 3.2.2 and release 3.2.3 with the fix. 
+            It is recommended that 3.2.2 not be used.</p>
+        
+            <span id="3.2.1"></span>
+            <h3 class="download-version">3.2.1<a href="#3.2.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Jul 29, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.2.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka-3.2.1-src.tgz">kafka-3.2.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.1/kafka-3.2.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka-3.2.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.12-3.2.1.tgz">kafka_2.12-3.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.12-3.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.12-3.2.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.13-3.2.1.tgz">kafka_2.13-3.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.13-3.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.1/kafka_2.13-3.2.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.2.1 fixes 13 issues since the 3.2.0 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.2.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.2.0"></span>
+            <h3 class="download-version">3.2.0<a href="#3.2.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released May 17, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.2.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka-3.2.0-src.tgz">kafka-3.2.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.0/kafka-3.2.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka-3.2.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.12-3.2.0.tgz">kafka_2.12-3.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.12-3.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.12-3.2.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.13-3.2.0.tgz">kafka_2.13-3.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.13-3.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.2.0/kafka_2.13-3.2.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.2.0 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>log4j 1.x is replaced with reload4j</li>
+                <li>StandardAuthorizer for KRaft (KIP-801)</li>
+                <li>Send a hint to the partition leader to recover the partition (KIP-704)</li>
+                <li>Top-level error code field in DescribeLogDirsResponse (KIP-784)</li>
+                <li>kafka-console-producer writes headers and null values (KIP-798 and KIP-810)</li>
+                <li>JoinGroupRequest and LeaveGroupRequest have a reason attached (KIP-800)</li>
+                <li>Static membership protocol lets the leader skip assignment (KIP-814)</li>
+                <li>Rack-aware standby task assignment in Kafka Streams (KIP-708)</li>
+                <li>Interactive Query v2 (KIP-796, KIP-805, and KIP-806)</li>
+                <li>Connect APIs list all connector plugins and retrieve their configuration (KIP-769)</li>
+                <li>TimestampConverter SMT supports different unix time precisions (KIP-808)</li>
+                <li>Connect source tasks handle producer exceptions (KIP-779)</li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.2.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.1.2"></span>
+            <h3 class="download-version">3.1.2<a href="#3.1.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Sept 19, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.1.2/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka-3.1.2-src.tgz">kafka-3.1.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.2/kafka-3.1.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka-3.1.2-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.12-3.1.2.tgz">kafka_2.12-3.1.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.12-3.1.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.12-3.1.2.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.13-3.1.2.tgz">kafka_2.13-3.1.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.13-3.1.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.2/kafka_2.13-3.1.2.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.1.2 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 4 other issues since the 3.1.1 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.1.2/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.1.1"></span>
+            <h3 class="download-version">3.1.1<a href="#3.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released May 13, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.1.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka-3.1.1-src.tgz">kafka-3.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.1/kafka-3.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka-3.1.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.12-3.1.1.tgz">kafka_2.12-3.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.12-3.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.12-3.1.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.13-3.1.1.tgz">kafka_2.13-3.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.13-3.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.1/kafka_2.13-3.1.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.1.1 fixes 29 issues since the 3.1.0 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.1.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.1.0"></span>
+            <h3 class="download-version">3.1.0<a href="#3.1.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released January 24, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.1.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka-3.1.0-src.tgz">kafka-3.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.0/kafka-3.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka-3.1.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.12-3.1.0.tgz">kafka_2.12-3.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.12-3.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.12-3.1.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.13-3.1.0.tgz">kafka_2.13-3.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.13-3.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.1.0/kafka_2.13-3.1.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.1.0 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>Apache Kafka supports Java 17</li>
+                <li>The FetchRequest supports Topic IDs (KIP-516)</li>
+                <li>Extend SASL/OAUTHBEARER with support for OIDC (KIP-768)</li>
+                <li>Add broker count metrics (KIP-748)</li>
+                <li>Differentiate consistently metric latency measured in millis and nanos (KIP-773)</li>
+                <li>The eager rebalance protocol is deprecated (KAFKA-13439)</li>
+                <li>Add TaskId field to StreamsException (KIP-783)</li>
+                <li>Custom partitioners in foreign-key joins (KIP-775)</li>
+                <li>Fetch/findSessions queries with open endpoints for SessionStore/WindowStore (KIP-766)</li>
+                <li>Range queries with open endpoints (KIP-763)</li>
+                <li>Add total blocked time metric to Streams (KIP-761)</li>
+                <li>Add additional configuration to control MirrorMaker2 internal topics naming convention (KIP-690)</li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.1.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.0.2"></span>
+            <h3 class="download-version">3.0.2<a href="#3.0.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Sept 19, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.0.2/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka-3.0.2-src.tgz">kafka-3.0.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.2/kafka-3.0.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka-3.0.2-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.12-3.0.2.tgz">kafka_2.12-3.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.12-3.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.12-3.0.2.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.13-3.0.2.tgz">kafka_2.13-3.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.13-3.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.2/kafka_2.13-3.0.2.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.0.2 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 10 other issues since the 3.0.1 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.0.2/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.0.1"></span>
+            <h3 class="download-version">3.0.1<a href="#3.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released March 11, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.0.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka-3.0.1-src.tgz">kafka-3.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.1/kafka-3.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka-3.0.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz">kafka_2.12-3.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.12-3.0.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.13-3.0.1.tgz">kafka_2.13-3.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.13-3.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.1/kafka_2.13-3.0.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.0.1 fixes 29 issues since the 3.0.0 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.0.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="3.0.0"></span>
+            <h3 class="download-version">3.0.0<a href="#3.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released September 21, 2021
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/3.0.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka-3.0.0-src.tgz">kafka-3.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.0/kafka-3.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka-3.0.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.12-3.0.0.tgz">kafka_2.12-3.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.12-3.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.12-3.0.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.13-3.0.0.tgz">kafka_2.13-3.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.13-3.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/3.0.0/kafka_2.13-3.0.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 3.0.0 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>The deprecation of support for Java 8 and Scala 2.12</li>
+                <li>Kafka Raft support for snapshots of the metadata topic and other improvements in the self-managed quorum</li>
+                <li>Stronger delivery guarantees for the Kafka producer enabled by default</li>
+                <li>Deprecation of message formats v0 and v1</li>
+                <li>Optimizations in OffsetFetch and FindCoordinator requests</li>
+                <li>More flexible Mirror Maker 2 configuration and deprecation of Mirror Maker 1</li>
+                <li>Ability to restart a connector's tasks on a single call in Kafka Connect</li>
+                <li>Connector log contexts and connector client overrides are now enabled by default</li>
+                <li>Enhanced semantics for timestamp synchronization in Kafka Streams</li>
+                <li>Revamped public API for Stream's TaskId</li>
+                <li>Default serde becomes null in Kafka</li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/3.0.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.8.2"></span>
+            <h3 class="download-version">2.8.2<a href="#2.8.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released September 19, 2022
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.8.2/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka-2.8.2-src.tgz">kafka-2.8.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.2/kafka-2.8.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka-2.8.2-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.12-2.8.2.tgz">kafka_2.12-2.8.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.12-2.8.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.12-2.8.2.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.13-2.8.2.tgz">kafka_2.13-2.8.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.13-2.8.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.2/kafka_2.13-2.8.2.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.8.2 fixes <a href="cve-list#CVE-2022-34917">CVE-2022-34917</a> and 11 other issues since the 2.8.1 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.8.2/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.8.1"></span>
+            <h3 class="download-version">2.8.1<a href="#2.8.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released September 17, 2021
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.8.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka-2.8.1-src.tgz">kafka-2.8.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.1/kafka-2.8.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka-2.8.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.12-2.8.1.tgz">kafka_2.12-2.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.12-2.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.12-2.8.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.13-2.8.1.tgz">kafka_2.13-2.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.13-2.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.1/kafka_2.13-2.8.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.8.1 fixes 49 issues since the 2.8.0 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.8.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.8.0"></span>
+            <h3 class="download-version">2.8.0<a href="#2.8.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released April 19, 2021
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.8.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka-2.8.0-src.tgz">kafka-2.8.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.0/kafka-2.8.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka-2.8.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz">kafka_2.12-2.8.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.12-2.8.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.13-2.8.0.tgz">kafka_2.13-2.8.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.13-2.8.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.8.0/kafka_2.13-2.8.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.8.0 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>Early access of replace ZooKeeper with a self-managed quorum</li>
+                <li>Add Describe Cluster API</li>
+                <li>Support mutual TLS authentication on SASL_SSL listeners</li>
+                <li>JSON request/response debug logs</li>
+                <li>Limit broker connection creation rate</li>
+                <li>Topic identifiers</li>
+                <li>Expose task configurations in Connect REST API</li>
+                <li>Update Streams FSM to clarify ERROR state meaning</li>
+                <li>Extend StreamJoined to allow more store configs</li>
+                <li>More convenient TopologyTestDriver construtors</li>
+                <li>Introduce Kafka-Streams-specific uncaught exception handler</li>
+                <li>API to start and shut down Streams threads</li>
+                <li>Improve TimeWindowedDeserializer and TimeWindowedSerde to handle window size</li>
+                <li>Improve timeouts and retries in Kafka Streams</li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.8.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.7.2"></span>
+            <h3 class="download-version">2.7.2<a href="#2.7.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released November 15, 2021
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.7.2/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka-2.7.2-src.tgz">kafka-2.7.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.2/kafka-2.7.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka-2.7.2-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.12-2.7.2.tgz">kafka_2.12-2.7.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.12-2.7.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.12-2.7.2.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.13-2.7.2.tgz">kafka_2.13-2.7.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.13-2.7.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.2/kafka_2.13-2.7.2.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.7.2 fixes 26 issues since the 2.7.1 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.7.2/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.7.1"></span>
+            <h3 class="download-version">2.7.1<a href="#2.7.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released May 10, 2021
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.7.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka-2.7.1-src.tgz">kafka-2.7.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.1/kafka-2.7.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka-2.7.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.12-2.7.1.tgz">kafka_2.12-2.7.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.12-2.7.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.12-2.7.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.13-2.7.1.tgz">kafka_2.13-2.7.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.13-2.7.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.1/kafka_2.13-2.7.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.7.1 fixes 45 issues since the 2.7.0 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.7.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.7.0"></span>
+            <h3 class="download-version">2.7.0<a href="#2.7.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Dec 21, 2020
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka-2.7.0-src.tgz">kafka-2.7.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.0/kafka-2.7.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka-2.7.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.12-2.7.0.tgz">kafka_2.12-2.7.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.12-2.7.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.12-2.7.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.13-2.7.0.tgz">kafka_2.13-2.7.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.13-2.7.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.7.0/kafka_2.13-2.7.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.7.0 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>Configurable TCP connection timeout and improve the initial metadata fetch</li>
+                <li>Enforce broker-wide and per-listener connection creation rate (KIP-612, part 1)</li>
+                <li>Throttle Create Topic, Create Partition and Delete Topic Operations</li>
+                <li>Add TRACE-level end-to-end latency metrics to Streams</li>
+                <li>Add Broker-side SCRAM Config API</li>
+                <li>Support PEM format for SSL certificates and private key</li>
+                <li>Add RocksDB Memory Consumption to RocksDB Metrics</li>
+                <li>Add Sliding-Window support for Aggregations</li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.6.3"></span>
+            <h3 class="download-version">2.6.3<a href="#2.6.3"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released November 15, 2021
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.6.3/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka-2.6.3-src.tgz">kafka-2.6.3-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.3/kafka-2.6.3-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka-2.6.3-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.12-2.6.3.tgz">kafka_2.12-2.6.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.12-2.6.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.12-2.6.3.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.13-2.6.3.tgz">kafka_2.13-2.6.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.13-2.6.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.3/kafka_2.13-2.6.3.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.6.3 fixes 11 issues since the 2.6.2 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.6.3/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.6.2"></span>
+            <h3 class="download-version">2.6.2<a href="#2.6.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released April 20, 2021
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.6.2/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka-2.6.2-src.tgz">kafka-2.6.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.2/kafka-2.6.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka-2.6.2-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.12-2.6.2.tgz">kafka_2.12-2.6.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.12-2.6.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.12-2.6.2.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.13-2.6.2.tgz">kafka_2.13-2.6.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.13-2.6.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.2/kafka_2.13-2.6.2.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.6.2 fixes 35 issues since the 2.6.1 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.6.2/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.6.1"></span>
+            <h3 class="download-version">2.6.1<a href="#2.6.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released January 07, 2021
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz">kafka-2.6.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka-2.6.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz">kafka_2.12-2.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.12-2.6.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz">kafka_2.13-2.6.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.1/kafka_2.13-2.6.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.6.1 fixes 41 issues since the 2.6.0 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.6.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.6.0"></span>
+            <h3 class="download-version">2.6.0<a href="#2.6.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Aug 3, 2020
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.6.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka-2.6.0-src.tgz">kafka-2.6.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.0/kafka-2.6.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka-2.6.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz">kafka_2.12-2.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.12-2.6.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.13-2.6.0.tgz">kafka_2.13-2.6.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.13-2.6.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.6.0/kafka_2.13-2.6.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.13 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.6.0 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>TLSv1.3 has been enabled by default for Java 11 or newer</li>
+                <li>Significant performance improvements, especially when the broker has large numbers of partitions</li>
+                <li>Smooth scaling out of Kafka Streams applications</li>
+                <li>Kafka Streams support for emit on change</li>
+                <li>New metrics for better operational insight</li>
+                <li>Kafka Connect can automatically create topics for source connectors when configured to do so</li>
+                <li>Improved error reporting options for sink connectors in Kafka Connect</li>
+                <li>New Filter and conditional SMTs in Kafka Connect</li>
+                <li>The default value for the `client.dns.lookup` configuration is now `use_all_dns_ips`</li>
+                <li>Upgrade Zookeeper to 3.5.8</li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.6.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.5.1"></span>
+            <h3 class="download-version">2.5.1<a href="#2.5.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released August 10, 2020
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.5.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka-2.5.1-src.tgz">kafka-2.5.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.1/kafka-2.5.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka-2.5.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.12-2.5.1.tgz">kafka_2.12-2.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.12-2.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.12-2.5.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.13-2.5.1.tgz">kafka_2.13-2.5.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.13-2.5.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.1/kafka_2.13-2.5.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.5.1 fixes 72 issues since the 2.5.0 release.
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.5.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.5.0"></span>
+            <h3 class="download-version">2.5.0<a href="#2.5.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released April 15, 2020
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.5.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka-2.5.0-src.tgz">kafka-2.5.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.0/kafka-2.5.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka-2.5.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz">kafka_2.12-2.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.12-2.5.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.13-2.5.0.tgz">kafka_2.13-2.5.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.13-2.5.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.5.0/kafka_2.13-2.5.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.5.0 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>TLS 1.3 support (1.2 is now the default)</li>
+                <li>Co-groups for Kafka Streams</li>
+                <li>Incremental rebalance for Kafka Consumer</li>
+                <li>New metrics for better operational insight</li>
+                <li>Upgrade Zookeeper to 3.5.7</li>
+                <li>Deprecate support for Scala 2.11</li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.5.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.4.1"></span>
+            <h3 class="download-version">2.4.1<a href="#2.4.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released March 12, 2020
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka-2.4.1-src.tgz">kafka-2.4.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.1/kafka-2.4.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka-2.4.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.11-2.4.1.tgz">kafka_2.11-2.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.11-2.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.11-2.4.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.12-2.4.1.tgz">kafka_2.12-2.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.12-2.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.12-2.4.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.13-2.4.1.tgz">kafka_2.13-2.4.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.13-2.4.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.1/kafka_2.13-2.4.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.4.0"></span>
+            <h3 class="download-version">2.4.0<a href="#2.4.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released December 16, 2019
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz">kafka-2.4.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka-2.4.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz">kafka_2.11-2.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.11-2.4.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz">kafka_2.12-2.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.12-2.4.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz">kafka_2.13-2.4.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.4.0/kafka_2.13-2.4.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.4.0 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>Allow consumers to fetch from closest replica.</li>
+                <li>Support for incremental cooperative rebalancing to the consumer rebalance protocol.</li>
+                <li>MirrorMaker 2.0 (MM2), a new multi-cluster, cross-datacenter replication engine.</li>
+                <li>New Java authorizer Interface.</li>
+                <li>Support for non-key joining in KTable.</li>
+                <li>Administrative API for replica reassignment.</li>
+            </ul>
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.3.1"></span>
+            <h3 class="download-version">2.3.1<a href="#2.3.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Oct 24, 2019
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.3.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka-2.3.1-src.tgz">kafka-2.3.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.1/kafka-2.3.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka-2.3.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.11-2.3.1.tgz">kafka_2.11-2.3.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.11-2.3.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.11-2.3.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.12-2.3.1.tgz">kafka_2.12-2.3.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.12-2.3.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.1/kafka_2.12-2.3.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.3.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.3.0"></span>
+            <h3 class="download-version">2.3.0<a href="#2.3.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Jun 25, 2019
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.3.0/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz">kafka-2.3.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka-2.3.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz">kafka_2.11-2.3.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.11-2.3.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz">kafka_2.12-2.3.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.3.0/kafka_2.12-2.3.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                </li>
+            </ul>
+        
+            <p>
+                Kafka 2.3.0 includes a number of significant new features. Here is a summary of some notable changes:
+            </p>
+        
+            <ul>
+                <li>There have been several improvements to the Kafka Connect REST API.</li>
+                <li>Kafka Connect now supports incremental cooperative rebalancing. </li>
+                <li>Kafka Streams now supports an in-memory session store and window store.</li>
+                <li>The AdminClient now allows users to determine what operations they are authorized to perform on topics.</li>
+                <li>There is a new broker start time metric.</li>
+                <li>JMXTool can now connect to secured RMI ports.</li>
+                <li>An incremental AlterConfigs API has been added.  The old AlterConfigs API has been deprecated.</li>
+                <li>We now track partitions which are under their min ISR count.</li>
+                <li>Consumers can now opt-out of automatic topic creation, even when it is enabled on the broker.</li>
+                <li>Kafka components can now use external configuration stores (KIP-421).</li>
+                <li>We have implemented improved replica fetcher behavior when errors are encountered.</li>
+            </ul>
+            <p>
+                For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.3.0/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+        
+            <span id="2.2.2"></span>
+            <h3 class="download-version">2.2.2<a href="#2.2.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Dec 1, 2019
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.2.2/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka-2.2.2-src.tgz">kafka-2.2.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.2/kafka-2.2.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka-2.2.2-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.11-2.2.2.tgz">kafka_2.11-2.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.11-2.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.11-2.2.2.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.12-2.2.2.tgz">kafka_2.12-2.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.12-2.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.2/kafka_2.12-2.2.2.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                </li>
+            </ul>
+        
+            <span id="2.2.1"></span>
+            <h3 class="download-version">2.2.1<a href="#2.2.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released Jun 1, 2019
+                </li>
+                <li>
+                    <a href="https://archive.apache.org/dist/kafka/2.2.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Source download: <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka-2.2.1-src.tgz">kafka-2.2.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.1/kafka-2.2.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka-2.2.1-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.11-2.2.1.tgz">kafka_2.11-2.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.11-2.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.11-2.2.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.12-2.2.1.tgz">kafka_2.12-2.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.12-2.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.1/kafka_2.12-2.2.1.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                </li>
+            </ul>
+        
+            <span id="2.2.0"></span>
+            <h3 class="download-version">2.2.0<a href="#2.2.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.11-2.1.1.tgz">kafka_2.11-2.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.11-2.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.11-2.1.1.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.12-2.1.1.tgz">kafka_2.12-2.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.12-2.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.12-2.1.1.tgz.sha512">sha512</a>)</li>
+                    <li>
+                        Released Mar 22, 2019
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/2.2.0/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz">kafka-2.2.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka-2.2.0-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz">kafka_2.11-2.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.11-2.2.0.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz">kafka_2.12-2.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.2.0/kafka_2.12-2.2.0.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                    </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-            </li>
-        </ul>
-
-    <span id="2.1.0"></span>
-    <h3 class="download-version">2.1.0<a href="#2.1.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released Nov 20, 2018
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz">kafka-2.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+                <p>
+                    Kafka 2.2.0 includes a number of significant new features. Here is a summary of some notable changes:
+                </p>
+        
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz">kafka_2.11-2.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz">kafka_2.12-2.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz.sha512">sha512</a>)</li>
+                  <li>Added SSL support for custom principal name</li>
+                  <li>Allow SASL connections to periodically re-authenticate</li>
+                  <li>Command line tool <code>bin/kafka-topics.sh</code> adds AdminClient support</li>
+                  <li>Improved consumer group management: default <code>group.id</code> is <code>null</code> instead of empty string</li>
+                  <li>API improvement:
+                    <ul>
+                    <li>Producer: introduce <code>close(Duration)</code></li>
+                    <li>AdminClient: introduce <code>close(Duration)</code></li>
+                    <li>Kafka Streams: new <code>flatTransform()</code> operator in Streams DSL</li>
+                    <li>KafkaStreams (and other classed) now implement <code>AutoClosable</code> to support try-with-resource</li>
+                    <li>New Serdes and default method implementations</li>
+                    </ul>
+              </li>
+                  <li>Kafka Streams exposed internal <code>client.id</code> via <code>ThreadMetadata</code></li>
+                  <li>Metric improvements: All <code>-min</code>, <code>-avg</code> and <code>-max</code> metrics will now output <code>NaN</code> as default value</li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-            </li>
-        </ul>
-
-        <p>
-            Kafka 2.1.0 includes a number of significant new features. Here is a summary of some notable changes:
-        </p>
-
-        <ul>
-          <li>Java 11 support</li>
-          <li>Support for Zstandard, which achieves compression comparable to gzip with higher compression and especially decompression speeds (KIP-110)</li>
-          <li>Avoid expiring committed offsets for active consumer group (KIP-211)</li>
-          <li>Provide Intuitive User Timeouts in The Producer (KIP-91)</li>
-          <li>Kafka's replication protocol now supports improved fencing of zombies. Previously, under certain rare conditions, if a broker became partitioned
-              from Zookeeper but not the rest of the cluster, then the logs of replicated partitions could diverge and cause data loss in the worst case (KIP-320).</li>
-          <li>Streams API improvements (KIP-319, KIP-321, KIP-330, KIP-353, KIP-356)</li>
-          <li>Admin script and admin client API improvements to simplify admin operation (KIP-231, KIP-308, KIP-322, KIP-324, KIP-338, KIP-340)</li>
-          <li>DNS handling improvements (KIP-235, KIP-302)</li>
-        </ul>
-        <p>
-            For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html">Release Notes</a>.
-        </p>
-
-    <span id="2.0.1"></span>
-    <h3 class="download-version">2.0.1<a href="#2.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released November 9, 2018
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/2.0.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz">kafka-2.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+                <p>
+                    For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.2.0/RELEASE_NOTES.html">Release Notes</a>.
+                </p>
+        
+            <span id="2.1.1"></span>
+            <h3 class="download-version">2.1.1<a href="#2.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz">kafka_2.11-2.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz">kafka_2.12-2.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz.sha512">sha512</a>)</li>
+                    <li>
+                        Released Feb 15, 2019
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/2.1.1/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka-2.1.1-src.tgz">kafka-2.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.1/kafka-2.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka-2.1.1-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.11-2.1.1.tgz">kafka_2.11-2.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.11-2.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.11-2.1.1.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.12-2.1.1.tgz">kafka_2.12-2.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.12-2.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.1/kafka_2.12-2.1.1.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                    </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
-            </li>
-
-        </ul>
-
-    <span id="2.0.0"></span>
-    <h3 class="download-version">2.0.0<a href="#2.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released July 30, 2018
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/2.0.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka-2.0.0-src.tgz">kafka-2.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.0/kafka-2.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka-2.0.0-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="2.1.0"></span>
+            <h3 class="download-version">2.1.0<a href="#2.1.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.11-2.0.0.tgz">kafka_2.11-2.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.11-2.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.11-2.0.0.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.12-2.0.0.tgz">kafka_2.12-2.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.12-2.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.12-2.0.0.tgz.sha512">sha512</a>)</li>
+                    <li>
+                        Released Nov 20, 2018
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz">kafka-2.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka-2.1.0-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz">kafka_2.11-2.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.11-2.1.0.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz">kafka_2.12-2.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.1.0/kafka_2.12-2.1.0.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                    </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-        <p>
-            Kafka 2.0.0 includes a number of significant new features. Here is a summary of some notable changes:
-        </p>
-
-        <ul>
-          <li>KIP-290 adds support for prefixed ACLs, simplifying access control management in large secure deployments.
-              Bulk access to topics, consumer groups or transactional ids with a prefix can now be granted using a single rule.
-              Access control for topic creation has also been improved to enable access to be granted to create specific topics or topics
-              with a prefix.</li>
-          <li>KIP-255 adds a framework for authenticating to Kafka brokers using OAuth2 bearer tokens. The SASL/OAUTHBEARER implementation
-              is customizable using callbacks for token retrieval and validation.</li>
-          <li>Host name verification is now enabled by default for SSL connections to ensure that the default SSL configuration is not
-              susceptible to man-in-the-middle attacks. You can disable this verification if required.</li>
-          <li>You can now dynamically update SSL truststores without broker restart. You can also configure security for broker listeners
-              in ZooKeeper before starting brokers, including SSL keystore and truststore passwords and JAAS configuration for SASL.
-              With this new feature, you can store sensitive password configs in encrypted form in ZooKeeper rather than in cleartext
-              in the broker properties file.</li>
-          <li>The replication protocol has been improved to avoid log divergence between leader and follower during fast leader failover.
-              We have also improved resilience of brokers by reducing the memory footprint of message down-conversions. By using message
-              chunking, both memory usage and memory reference time have been reduced to avoid OutOfMemory errors in brokers.</li>
-          <li>Kafka clients are now notified of throttling before any throttling is applied when quotas are enabled. This enables clients to
-              distinguish between network errors and large throttle times when quotas are exceeded.</li>
-          <li>We have added a configuration option for Kafka consumer to avoid indefinite blocking in the consumer.</li>
-          <li>We have dropped support for Java 7 and removed the previously deprecated Scala producer and consumer.</li>
-          <li>Kafka Connect includes a number of improvements and features. KIP-298 enables you to control how errors in connectors,
-              transformations and converters are handled by enabling automatic retries and controlling the number of errors that are tolerated
-              before the connector is stopped.  More contextual information can be included in the logs to help diagnose problems and
-              problematic messages consumed by sink connectors can be sent to a dead letter queue rather than forcing the connector to stop.</li>
-          <li>KIP-297 adds a new extension point to move secrets out of connector configurations and integrate with any external
-              key management system. The placeholders in connector configurations are only resolved before sending the configuration
-              to the connector, ensuring that secrets are stored and managed securely in your preferred key management system and
-              not exposed over the REST APIs or in log files.</li>
-          <li>We have added a thin Scala wrapper API for our Kafka Streams DSL, which provides better type inference and better type safety
-              during compile time. Scala users can have less boilerplate in their code, notably regarding Serdes with new implicit Serdes.</li>
-          <li>Message headers are now supported in the Kafka Streams Processor API, allowing users to add and manipulate headers read
-              from the source topics and propagate them to the sink topics.</li>
-          <li>Windowed aggregations performance in Kafka Streams has been largely improved (sometimes by an order of magnitude) thanks to
-              the new single-key-fetch API.</li>
-          <li>We have further improved unit testibility of Kafka Streams with the kafka-streams-testutil artifact.</li>
-        </ul>
-        <p>
-            For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.0.0/RELEASE_NOTES.html">Release Notes</a>.
-        </p>
-
-    <span id="1.1.1"></span>
-    <h3 class="download-version">1.1.1<a href="#1.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released July 19, 2018
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/1.1.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz">kafka-1.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+                <p>
+                    Kafka 2.1.0 includes a number of significant new features. Here is a summary of some notable changes:
+                </p>
+        
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz">kafka_2.11-1.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz">kafka_2.12-1.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz.sha512">sha512</a>)</li>
+                  <li>Java 11 support</li>
+                  <li>Support for Zstandard, which achieves compression comparable to gzip with higher compression and especially decompression speeds (KIP-110)</li>
+                  <li>Avoid expiring committed offsets for active consumer group (KIP-211)</li>
+                  <li>Provide Intuitive User Timeouts in The Producer (KIP-91)</li>
+                  <li>Kafka's replication protocol now supports improved fencing of zombies. Previously, under certain rare conditions, if a broker became partitioned
+                      from Zookeeper but not the rest of the cluster, then the logs of replicated partitions could diverge and cause data loss in the worst case (KIP-320).</li>
+                  <li>Streams API improvements (KIP-319, KIP-321, KIP-330, KIP-353, KIP-356)</li>
+                  <li>Admin script and admin client API improvements to simplify admin operation (KIP-231, KIP-308, KIP-322, KIP-324, KIP-338, KIP-340)</li>
+                  <li>DNS handling improvements (KIP-235, KIP-302)</li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-
-        </ul>
-
-    <span id="1.1.0"></span>
-    <h3 class="download-version">1.1.0<a href="#1.1.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released March 28, 2018
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/1.1.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka-1.1.0-src.tgz">kafka-1.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.0/kafka-1.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka-1.1.0-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+                <p>
+                    For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html">Release Notes</a>.
+                </p>
+        
+            <span id="2.0.1"></span>
+            <h3 class="download-version">2.0.1<a href="#2.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz">kafka_2.11-1.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.12-1.1.0.tgz">kafka_2.12-1.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.12-1.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.12-1.1.0.tgz.sha512">sha512</a>)</li>
+                    <li>
+                        Released November 9, 2018
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/2.0.1/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz">kafka-2.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka-2.0.1-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz">kafka_2.11-2.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.11-2.0.1.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz">kafka_2.12-2.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.1/kafka_2.12-2.0.1.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.12 is recommended).
+                    </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-        <p>
-            Kafka 1.1.0 includes a number of significant new features. Here is a summary of some notable changes:
-        </p>
-
-        <ul>
-            <li> Kafka 1.1.0 includes significant improvements to the Kafka Controller that speed up controlled shutdown. ZooKeeper session expiration edge cases have also been fixed as part of this effort.</li>
-            <li>Controller improvements also enable more partitions to be supported on a single cluster.  KIP-227 introduced incremental fetch requests, providing more efficient replication when the number of partitions is large.</li>
-            <li>KIP-113 added support for replica movement between log directories to enable data balancing with JBOD.</li>
-            <li>Some of the broker configuration options like SSL keystores can now be updated dynamically without restarting the broker. See KIP-226 for details and the full list of dynamic configs.</li>
-            <li>Delegation token based authentication (KIP-48) has been added to Kafka brokers to support large number of clients without overloading Kerberos KDCs or other authentication servers.</li>
-            <li>Several new features have been added to Kafka Connect, including header support (KIP-145), SSL and Kafka cluster identifiers in the Connect REST interface (KIP-208 and KIP-238), validation of connector names (KIP-212) and support for topic regex in sink connectors (KIP-215). Additionally, the default maximum heap size for Connect workers was increased to 2GB.</li>
-            <li>Several improvements have been added to the Kafka Streams API, including reducing repartition topic partitions footprint, customizable error handling for produce failures and enhanced resilience to broker unavailability. See KIPs 205, 210, 220, 224 and 239 for details.</li>
-        </ul>
-        <p>
-            For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/1.1.0/RELEASE_NOTES.html">Release Notes</a>.
-        </p>
-
-
-    <span id="1.0.2"></span>
-    <h3 class="download-version">1.0.2<a href="#1.0.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released July 8th, 2018
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/1.0.2/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka-1.0.2-src.tgz">kafka-1.0.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.2/kafka-1.0.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka-1.0.2-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="2.0.0"></span>
+            <h3 class="download-version">2.0.0<a href="#2.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.11-1.0.2.tgz">kafka_2.11-1.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.11-1.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.11-1.0.2.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.12-1.0.2.tgz">kafka_2.12-1.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.12-1.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.12-1.0.2.tgz.sha512">sha512</a>)</li>
+                    <li>
+                        Released July 30, 2018
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/2.0.0/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka-2.0.0-src.tgz">kafka-2.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.0/kafka-2.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka-2.0.0-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.11-2.0.0.tgz">kafka_2.11-2.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.11-2.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.11-2.0.0.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.12-2.0.0.tgz">kafka_2.12-2.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.12-2.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/2.0.0/kafka_2.12-2.0.0.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
+                    </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="1.0.1"></span>
-    <h3 class="download-version">1.0.1<a href="#1.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released March 5, 2018
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/1.0.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka-1.0.1-src.tgz">kafka-1.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.1/kafka-1.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka-1.0.1-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+                <p>
+                    Kafka 2.0.0 includes a number of significant new features. Here is a summary of some notable changes:
+                </p>
+        
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.11-1.0.1.tgz">kafka_2.11-1.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.11-1.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.11-1.0.1.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.12-1.0.1.tgz">kafka_2.12-1.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.12-1.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.12-1.0.1.tgz.sha512">sha512</a>)</li>
+                  <li>KIP-290 adds support for prefixed ACLs, simplifying access control management in large secure deployments.
+                      Bulk access to topics, consumer groups or transactional ids with a prefix can now be granted using a single rule.
+                      Access control for topic creation has also been improved to enable access to be granted to create specific topics or topics
+                      with a prefix.</li>
+                  <li>KIP-255 adds a framework for authenticating to Kafka brokers using OAuth2 bearer tokens. The SASL/OAUTHBEARER implementation
+                      is customizable using callbacks for token retrieval and validation.</li>
+                  <li>Host name verification is now enabled by default for SSL connections to ensure that the default SSL configuration is not
+                      susceptible to man-in-the-middle attacks. You can disable this verification if required.</li>
+                  <li>You can now dynamically update SSL truststores without broker restart. You can also configure security for broker listeners
+                      in ZooKeeper before starting brokers, including SSL keystore and truststore passwords and JAAS configuration for SASL.
+                      With this new feature, you can store sensitive password configs in encrypted form in ZooKeeper rather than in cleartext
+                      in the broker properties file.</li>
+                  <li>The replication protocol has been improved to avoid log divergence between leader and follower during fast leader failover.
+                      We have also improved resilience of brokers by reducing the memory footprint of message down-conversions. By using message
+                      chunking, both memory usage and memory reference time have been reduced to avoid OutOfMemory errors in brokers.</li>
+                  <li>Kafka clients are now notified of throttling before any throttling is applied when quotas are enabled. This enables clients to
+                      distinguish between network errors and large throttle times when quotas are exceeded.</li>
+                  <li>We have added a configuration option for Kafka consumer to avoid indefinite blocking in the consumer.</li>
+                  <li>We have dropped support for Java 7 and removed the previously deprecated Scala producer and consumer.</li>
+                  <li>Kafka Connect includes a number of improvements and features. KIP-298 enables you to control how errors in connectors,
+                      transformations and converters are handled by enabling automatic retries and controlling the number of errors that are tolerated
+                      before the connector is stopped.  More contextual information can be included in the logs to help diagnose problems and
+                      problematic messages consumed by sink connectors can be sent to a dead letter queue rather than forcing the connector to stop.</li>
+                  <li>KIP-297 adds a new extension point to move secrets out of connector configurations and integrate with any external
+                      key management system. The placeholders in connector configurations are only resolved before sending the configuration
+                      to the connector, ensuring that secrets are stored and managed securely in your preferred key management system and
+                      not exposed over the REST APIs or in log files.</li>
+                  <li>We have added a thin Scala wrapper API for our Kafka Streams DSL, which provides better type inference and better type safety
+                      during compile time. Scala users can have less boilerplate in their code, notably regarding Serdes with new implicit Serdes.</li>
+                  <li>Message headers are now supported in the Kafka Streams Processor API, allowing users to add and manipulate headers read
+                      from the source topics and propagate them to the sink topics.</li>
+                  <li>Windowed aggregations performance in Kafka Streams has been largely improved (sometimes by an order of magnitude) thanks to
+                      the new single-key-fetch API.</li>
+                  <li>We have further improved unit testibility of Kafka Streams with the kafka-streams-testutil artifact.</li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="1.0.0"></span>
-    <h3 class="download-version">1.0.0<a href="#1.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released November 1, 2017
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka-1.0.0-src.tgz">kafka-1.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.0/kafka-1.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka-1.0.0-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+                <p>
+                    For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/2.0.0/RELEASE_NOTES.html">Release Notes</a>.
+                </p>
+        
+            <span id="1.1.1"></span>
+            <h3 class="download-version">1.1.1<a href="#1.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.11-1.0.0.tgz">kafka_2.11-1.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.11-1.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.11-1.0.0.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.12-1.0.0.tgz">kafka_2.12-1.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.12-1.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.12-1.0.0.tgz.sha512">sha512</a>)</li>
+                    <li>
+                        Released July 19, 2018
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/1.1.1/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz">kafka-1.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka-1.1.1-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz">kafka_2.11-1.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.11-1.1.1.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz">kafka_2.12-1.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.1/kafka_2.12-1.1.1.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
+                    </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-        <p>
-            Kafka 1.0.0 is no mere bump of the version number. The Apache Kafka Project Management Committee has packed a number of valuable enhancements into the release. Here is a summary of a few of them:
-        </p>
-
-        <ul>
-            <li>
-                Since its introduction in version 0.10, the Streams API has become hugely popular among Kafka users, including the likes of Pinterest, Rabobank, Zalando, and The New York Times. In 1.0, the the API continues to evolve at a healthy pace. To begin with, the builder API has been improved (KIP-120). A new API has been added to expose the state of active tasks at runtime (KIP-130). The new cogroup API makes it much easier to deal with partitioned aggregates with fewer StateStores and fewer moving parts in your code (KIP-150). Debuggability gets easier with enhancements to the print() and writeAsText() methods (KIP-160). And if that’s not enough, check out KIP-138 and KIP-161 too. For more on streams, check out the <a href="/documentation/streams/">Apache Kafka Streams</a> documentation, including some helpful new tutorial videos.
-            </li>
-            <li>
-                Operating Kafka at scale requires that the system remain observable, and to make that easier, we’ve made a number of improvements to metrics. These are too many to summarize without becoming tedious, but Connect metrics have been significantly improved (KIP-196), a litany of new health check metrics are now exposed (KIP-188), and we now have a global topic and partition count (KIP-168). Check out KIP-164 and KIP-187 for even more.
-            </li>
-            <li>
-                We now support Java 9, leading, among other things, to significantly faster TLS and CRC32C implementations. Over-the-wire encryption will be faster now, which will keep Kafka fast and compute costs low when encryption is enabled.
-            </li>
-            <li>
-                In keeping with the security theme, KIP-152 cleans up the error handling on Simple Authentication Security Layer (SASL) authentication attempts. Previously, some authentication error conditions were indistinguishable from broker failures and were not logged in a clear way. This is cleaner now.
-            </li>
-            <li>
-                Kafka can now tolerate disk failures better. Historically, JBOD storage configurations have not been recommended, but the architecture has nevertheless been tempting: after all, why not rely on Kafka’s own replication mechanism to protect against storage failure rather than using RAID? With KIP-112, Kafka now handles disk failure more gracefully. A single disk failure in a JBOD broker will not bring the entire broker down; rather, the broker will continue serving any log files that remain on functioning disks.
-            </li>
-            <li>
-                Since release 0.11.0, the idempotent producer (which is the producer used in the presence of a transaction, which of course is the producer we use for exactly-once processing) required max.in.flight.requests.per.connection to be equal to one. As anyone who has written or tested a wire protocol can attest, this put an upper bound on throughput. Thanks to KAFKA-5949, this can now be as large as five, relaxing the throughput constraint quite a bit.
-            </li>
-        </ul>
-
-        <p>
-            For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/1.0.0/RELEASE_NOTES.html">Release Notes</a>.
-        </p>
-
-
-    <span id="0.11.0.3"></span>
-    <h3 class="download-version">0.11.0.3<a href="#0.11.0.3"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released July 2ed, 2018
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.11.0.3/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka-0.11.0.3-src.tgz">kafka-0.11.0.3-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka-0.11.0.3-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka-0.11.0.3-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="1.1.0"></span>
+            <h3 class="download-version">1.1.0<a href="#1.1.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.11-0.11.0.3.tgz">kafka_2.11-0.11.0.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.11-0.11.0.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.11-0.11.0.3.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.12-0.11.0.3.tgz">kafka_2.12-0.11.0.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.12-0.11.0.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.12-0.11.0.3.tgz.sha512">sha512</a>)</li>
+                    <li>
+                        Released March 28, 2018
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/1.1.0/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka-1.1.0-src.tgz">kafka-1.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.0/kafka-1.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka-1.1.0-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz">kafka_2.11-1.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.11-1.1.0.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.12-1.1.0.tgz">kafka_2.12-1.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.12-1.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.1.0/kafka_2.12-1.1.0.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
+                    </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.11.0.2"></span>
-    <h3 class="download-version">0.11.0.2<a href="#0.11.0.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released November 17, 2017
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.11.0.2/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka-0.11.0.2-src.tgz">kafka-0.11.0.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka-0.11.0.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka-0.11.0.2-src.tgz.sha512">sha512</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+                <p>
+                    Kafka 1.1.0 includes a number of significant new features. Here is a summary of some notable changes:
+                </p>
+        
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.11-0.11.0.2.tgz">kafka_2.11-0.11.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.11-0.11.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.11-0.11.0.2.tgz.sha512">sha512</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.12-0.11.0.2.tgz">kafka_2.12-0.11.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.12-0.11.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.12-0.11.0.2.tgz.sha512">sha512</a>)</li>
+                    <li> Kafka 1.1.0 includes significant improvements to the Kafka Controller that speed up controlled shutdown. ZooKeeper session expiration edge cases have also been fixed as part of this effort.</li>
+                    <li>Controller improvements also enable more partitions to be supported on a single cluster.  KIP-227 introduced incremental fetch requests, providing more efficient replication when the number of partitions is large.</li>
+                    <li>KIP-113 added support for replica movement between log directories to enable data balancing with JBOD.</li>
+                    <li>Some of the broker configuration options like SSL keystores can now be updated dynamically without restarting the broker. See KIP-226 for details and the full list of dynamic configs.</li>
+                    <li>Delegation token based authentication (KIP-48) has been added to Kafka brokers to support large number of clients without overloading Kerberos KDCs or other authentication servers.</li>
+                    <li>Several new features have been added to Kafka Connect, including header support (KIP-145), SSL and Kafka cluster identifiers in the Connect REST interface (KIP-208 and KIP-238), validation of connector names (KIP-212) and support for topic regex in sink connectors (KIP-215). Additionally, the default maximum heap size for Connect workers was increased to 2GB.</li>
+                    <li>Several improvements have been added to the Kafka Streams API, including reducing repartition topic partitions footprint, customizable error handling for produce failures and enhanced resilience to broker unavailability. See KIPs 205, 210, 220, 224 and 239 for details.</li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-    <span id="0.11.0.1"></span>
-    <h3 class="download-version">0.11.0.1<a href="#0.11.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released September 13, 2017
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.11.0.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka-0.11.0.1-src.tgz">kafka-0.11.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka-0.11.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka-0.11.0.1-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+                <p>
+                    For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/1.1.0/RELEASE_NOTES.html">Release Notes</a>.
+                </p>
+        
+            <span id="1.0.2"></span>
+            <h3 class="download-version">1.0.2<a href="#1.0.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.11-0.11.0.1.tgz">kafka_2.11-0.11.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.11-0.11.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.11-0.11.0.1.tgz.md5">md5</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.12-0.11.0.1.tgz">kafka_2.12-0.11.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.12-0.11.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.12-0.11.0.1.tgz.md5">md5</a>)</li>
+                    <li>
+                        Released July 8th, 2018
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/1.0.2/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka-1.0.2-src.tgz">kafka-1.0.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.2/kafka-1.0.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka-1.0.2-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.11-1.0.2.tgz">kafka_2.11-1.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.11-1.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.11-1.0.2.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.12-1.0.2.tgz">kafka_2.12-1.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.12-1.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.2/kafka_2.12-1.0.2.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
+                    </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.11.0.0"></span>
-    <h3 class="download-version">0.11.0.0<a href="#0.11.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released June 28, 2017
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.11.0.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka-0.11.0.0-src.tgz">kafka-0.11.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka-0.11.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka-0.11.0.0-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="1.0.1"></span>
+            <h3 class="download-version">1.0.1<a href="#1.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.11-0.11.0.0.tgz">kafka_2.11-0.11.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.11-0.11.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.11-0.11.0.0.tgz.md5">md5</a>)</li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.12-0.11.0.0.tgz">kafka_2.12-0.11.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.12-0.11.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.12-0.11.0.0.tgz.md5">md5</a>)</li>
+                    <li>
+                        Released March 5, 2018
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/1.0.1/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka-1.0.1-src.tgz">kafka-1.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.1/kafka-1.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka-1.0.1-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.11-1.0.1.tgz">kafka_2.11-1.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.11-1.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.11-1.0.1.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.12-1.0.1.tgz">kafka_2.12-1.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.12-1.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.1/kafka_2.12-1.0.1.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
+                    </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.10.2.2"></span>
-    <h3 class="download-version">0.10.2.2<a href="#0.10.2.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released July 2nd, 2018
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.10.2.2/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz">kafka-0.10.2.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="1.0.0"></span>
+            <h3 class="download-version">1.0.0<a href="#1.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz">kafka_2.10-0.10.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz.md5">md5</a>)
+                    <li>
+                        Released November 1, 2017
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz">kafka_2.11-0.10.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz.md5">md5</a>)
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka-1.0.0-src.tgz">kafka-1.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.0/kafka-1.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka-1.0.0-src.tgz.sha512">sha512</a>)
                     </li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz">kafka_2.12-0.10.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz.md5">md5</a>)
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.11-1.0.0.tgz">kafka_2.11-1.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.11-1.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.11-1.0.0.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.12-1.0.0.tgz">kafka_2.12-1.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.12-1.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/1.0.0/kafka_2.12-1.0.0.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We add 2.12 to the supported Scala version. These different versions only matter if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.10.2.1"></span>
-    <h3 class="download-version">0.10.2.1<a href="#0.10.2.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released April 26, 2017
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.10.2.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka-0.10.2.1-src.tgz">kafka-0.10.2.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka-0.10.2.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka-0.10.2.1-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+                <p>
+                    Kafka 1.0.0 is no mere bump of the version number. The Apache Kafka Project Management Committee has packed a number of valuable enhancements into the release. Here is a summary of a few of them:
+                </p>
+        
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.10-0.10.2.1.tgz">kafka_2.10-0.10.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.10-0.10.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.10-0.10.2.1.tgz.md5">md5</a>)
+                    <li>
+                        Since its introduction in version 0.10, the Streams API has become hugely popular among Kafka users, including the likes of Pinterest, Rabobank, Zalando, and The New York Times. In 1.0, the the API continues to evolve at a healthy pace. To begin with, the builder API has been improved (KIP-120). A new API has been added to expose the state of active tasks at runtime (KIP-130). The new cogroup API makes it much easier to deal with partitioned aggregates with fewer StateStores and fewer moving parts in your code (KIP-150). Debuggability gets easier with enhancements to the print() and writeAsText() methods (KIP-160). And if that’s not enough, check out KIP-138 and KIP-161 too. For more on streams, check out the <a href="/documentation/streams/">Apache Kafka Streams</a> documentation, including some helpful new tutorial videos.
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz">kafka_2.11-0.10.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz.md5">md5</a>)
+                    <li>
+                        Operating Kafka at scale requires that the system remain observable, and to make that easier, we’ve made a number of improvements to metrics. These are too many to summarize without becoming tedious, but Connect metrics have been significantly improved (KIP-196), a litany of new health check metrics are now exposed (KIP-188), and we now have a global topic and partition count (KIP-168). Check out KIP-164 and KIP-187 for even more.
                     </li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.12-0.10.2.1.tgz">kafka_2.12-0.10.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.12-0.10.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.12-0.10.2.1.tgz.md5">md5</a>)
+                    <li>
+                        We now support Java 9, leading, among other things, to significantly faster TLS and CRC32C implementations. Over-the-wire encryption will be faster now, which will keep Kafka fast and compute costs low when encryption is enabled.
+                    </li>
+                    <li>
+                        In keeping with the security theme, KIP-152 cleans up the error handling on Simple Authentication Security Layer (SASL) authentication attempts. Previously, some authentication error conditions were indistinguishable from broker failures and were not logged in a clear way. This is cleaner now.
+                    </li>
+                    <li>
+                        Kafka can now tolerate disk failures better. Historically, JBOD storage configurations have not been recommended, but the architecture has nevertheless been tempting: after all, why not rely on Kafka’s own replication mechanism to protect against storage failure rather than using RAID? With KIP-112, Kafka now handles disk failure more gracefully. A single disk failure in a JBOD broker will not bring the entire broker down; rather, the broker will continue serving any log files that remain on functioning disks.
+                    </li>
+                    <li>
+                        Since release 0.11.0, the idempotent producer (which is the producer used in the presence of a transaction, which of course is the producer we use for exactly-once processing) required max.in.flight.requests.per.connection to be equal to one. As anyone who has written or tested a wire protocol can attest, this put an upper bound on throughput. Thanks to KAFKA-5949, this can now be as large as five, relaxing the throughput constraint quite a bit.
                     </li>
                 </ul>
-                We add 2.12 to the supported Scala version. These different versions only matter if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.10.2.0"></span>
-    <h3 class="download-version">0.10.2.0<a href="#0.10.2.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released February 21, 2017
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.10.2.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka-0.10.2.0-src.tgz">kafka-0.10.2.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka-0.10.2.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka-0.10.2.0-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+                <p>
+                    For more information, please read the detailed <a href="https://archive.apache.org/dist/kafka/1.0.0/RELEASE_NOTES.html">Release Notes</a>.
+                </p>
+        
+            <span id="0.11.0.3"></span>
+            <h3 class="download-version">0.11.0.3<a href="#0.11.0.3"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.10-0.10.2.0.tgz">kafka_2.10-0.10.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.10-0.10.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.10-0.10.2.0.tgz.md5">md5</a>)
+                    <li>
+                        Released July 2ed, 2018
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.11-0.10.2.0.tgz">kafka_2.11-0.10.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.11-0.10.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.11-0.10.2.0.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.11.0.3/RELEASE_NOTES.html">Release Notes</a>
                     </li>
-                    <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.12-0.10.2.0.tgz">kafka_2.12-0.10.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.12-0.10.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.12-0.10.2.0.tgz.md5">md5</a>)
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka-0.11.0.3-src.tgz">kafka-0.11.0.3-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka-0.11.0.3-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka-0.11.0.3-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.11-0.11.0.3.tgz">kafka_2.11-0.11.0.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.11-0.11.0.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.11-0.11.0.3.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.12-0.11.0.3.tgz">kafka_2.12-0.11.0.3.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.12-0.11.0.3.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.3/kafka_2.12-0.11.0.3.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We add 2.12 to the supported Scala version. These different versions only matter if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.10.1.1"></span>
-    <h3 class="download-version">0.10.1.1<a href="#0.10.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released December 20, 2016
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.10.1.1/RELEASE_NOTES.html.">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka-0.10.1.1-src.tgz">kafka-0.10.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka-0.10.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka-0.10.1.1-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.11.0.2"></span>
+            <h3 class="download-version">0.11.0.2<a href="#0.11.0.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.10-0.10.1.1.tgz">kafka_2.10-0.10.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.10-0.10.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.10-0.10.1.1.tgz.md5">md5</a>)
+                    <li>
+                        Released November 17, 2017
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz">kafka_2.11-0.10.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.11.0.2/RELEASE_NOTES.html">Release Notes</a>
                     </li>
-                    <li>Scala 2.12 (pre-alpha) &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.12-0.10.1.1.tgz">kafka_2.12-0.10.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.12-0.10.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.12-0.10.1.1.tgz.md5">md5</a>)
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka-0.11.0.2-src.tgz">kafka-0.11.0.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka-0.11.0.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka-0.11.0.2-src.tgz.sha512">sha512</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.11-0.11.0.2.tgz">kafka_2.11-0.11.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.11-0.11.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.11-0.11.0.2.tgz.sha512">sha512</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.12-0.11.0.2.tgz">kafka_2.12-0.11.0.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.12-0.11.0.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.2/kafka_2.12-0.11.0.2.tgz.sha512">sha512</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala, and include 2.12 as a pre-alpha before the next major release. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.10.1.0"></span>
-    <h3 class="download-version">0.10.1.0<a href="#0.10.1.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released October 20, 2016
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.10.1.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka-0.10.1.0-src.tgz">kafka-0.10.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka-0.10.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka-0.10.1.0-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.11.0.1"></span>
+            <h3 class="download-version">0.11.0.1<a href="#0.11.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.10-0.10.1.0.tgz">kafka_2.10-0.10.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.10-0.10.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.10-0.10.1.0.tgz.md5">md5</a>)
+                    <li>
+                        Released September 13, 2017
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz">kafka_2.11-0.10.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.11.0.1/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka-0.11.0.1-src.tgz">kafka-0.11.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka-0.11.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka-0.11.0.1-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.11-0.11.0.1.tgz">kafka_2.11-0.11.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.11-0.11.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.11-0.11.0.1.tgz.md5">md5</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.12-0.11.0.1.tgz">kafka_2.12-0.11.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.12-0.11.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.1/kafka_2.12-0.11.0.1.tgz.md5">md5</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.10.0.1"></span>
-    <h3 class="download-version">0.10.0.1<a href="#0.10.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released August 10, 2016
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.10.0.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka-0.10.0.1-src.tgz">kafka-0.10.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka-0.10.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka-0.10.0.1-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.11.0.0"></span>
+            <h3 class="download-version">0.11.0.0<a href="#0.11.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz">kafka_2.10-0.10.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz.md5">md5</a>)
+                    <li>
+                        Released June 28, 2017
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.11-0.10.0.1.tgz">kafka_2.11-0.10.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.11-0.10.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.11-0.10.0.1.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.11.0.0/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka-0.11.0.0-src.tgz">kafka-0.11.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka-0.11.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka-0.11.0.0-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.11-0.11.0.0.tgz">kafka_2.11-0.11.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.11-0.11.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.11-0.11.0.0.tgz.md5">md5</a>)</li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.12-0.11.0.0.tgz">kafka_2.12-0.11.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.12-0.11.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.11.0.0/kafka_2.12-0.11.0.0.tgz.md5">md5</a>)</li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.10.0.0"></span>
-    <h3 class="download-version">0.10.0.0<a href="#0.10.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released May 22, 2016
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.10.0.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka-0.10.0.0-src.tgz">kafka-0.10.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka-0.10.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka-0.10.0.0-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.10.2.2"></span>
+            <h3 class="download-version">0.10.2.2<a href="#0.10.2.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.10-0.10.0.0.tgz">kafka_2.10-0.10.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.10-0.10.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.10-0.10.0.0.tgz.md5">md5</a>)
+                    <li>
+                        Released July 2nd, 2018
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.11-0.10.0.0.tgz">kafka_2.11-0.10.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.11-0.10.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.11-0.10.0.0.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.10.2.2/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz">kafka-0.10.2.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka-0.10.2.2-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz">kafka_2.10-0.10.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.10-0.10.2.2.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz">kafka_2.11-0.10.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.11-0.10.2.2.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz">kafka_2.12-0.10.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We add 2.12 to the supported Scala version. These different versions only matter if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.9.0.1"></span>
-    <h3 class="download-version">0.9.0.1<a href="#0.9.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released February 19, 2016
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.9.0.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka-0.9.0.1-src.tgz">kafka-0.9.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka-0.9.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka-0.9.0.1-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.10.2.1"></span>
+            <h3 class="download-version">0.10.2.1<a href="#0.10.2.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.10-0.9.0.1.tgz">kafka_2.10-0.9.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.10-0.9.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.10-0.9.0.1.tgz.md5">md5</a>)
+                    <li>
+                        Released April 26, 2017
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz">kafka_2.11-0.9.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.10.2.1/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka-0.10.2.1-src.tgz">kafka-0.10.2.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka-0.10.2.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka-0.10.2.1-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.10-0.10.2.1.tgz">kafka_2.10-0.10.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.10-0.10.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.10-0.10.2.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz">kafka_2.11-0.10.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.11-0.10.2.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.12-0.10.2.1.tgz">kafka_2.12-0.10.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.12-0.10.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.1/kafka_2.12-0.10.2.1.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We add 2.12 to the supported Scala version. These different versions only matter if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.9.0.0"></span>
-    <h3 class="download-version">0.9.0.0<a href="#0.9.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released November 23, 2015
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.9.0.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka-0.9.0.0-src.tgz">kafka-0.9.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka-0.9.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka-0.9.0.0-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.10.2.0"></span>
+            <h3 class="download-version">0.10.2.0<a href="#0.10.2.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.10-0.9.0.0.tgz">kafka_2.10-0.9.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.10-0.9.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.10-0.9.0.0.tgz.md5">md5</a>)
+                    <li>
+                        Released February 21, 2017
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.11-0.9.0.0.tgz">kafka_2.11-0.9.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.11-0.9.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.11-0.9.0.0.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.10.2.0/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka-0.10.2.0-src.tgz">kafka-0.10.2.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka-0.10.2.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka-0.10.2.0-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.10-0.10.2.0.tgz">kafka_2.10-0.10.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.10-0.10.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.10-0.10.2.0.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.11-0.10.2.0.tgz">kafka_2.11-0.10.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.11-0.10.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.11-0.10.2.0.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.12 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.12-0.10.2.0.tgz">kafka_2.12-0.10.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.12-0.10.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.2.0/kafka_2.12-0.10.2.0.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We add 2.12 to the supported Scala version. These different versions only matter if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.8.2.2"></span>
-    <h3 class="download-version">0.8.2.2<a href="#0.8.2.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released October 2, 2015
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.8.2.2/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka-0.8.2.2-src.tgz">kafka-0.8.2.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka-0.8.2.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka-0.8.2.2-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.10.1.1"></span>
+            <h3 class="download-version">0.10.1.1<a href="#0.10.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.1-0.8.2.2.tgz">kafka_2.9.1-0.8.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.1-0.8.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.1-0.8.2.2.tgz.md5">md5</a>)
+                    <li>
+                        Released December 20, 2016
                     </li>
-                    <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.2-0.8.2.2.tgz">kafka_2.9.2-0.8.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.2-0.8.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.2-0.8.2.2.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.10.1.1/RELEASE_NOTES.html.">Release Notes</a>
                     </li>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz">kafka_2.10-0.8.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz.md5">md5</a>)
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka-0.10.1.1-src.tgz">kafka-0.10.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka-0.10.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka-0.10.1.1-src.tgz.md5">md5</a>)
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz">kafka_2.11-0.8.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz.md5">md5</a>)
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.10-0.10.1.1.tgz">kafka_2.10-0.10.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.10-0.10.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.10-0.10.1.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz">kafka_2.11-0.10.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.11-0.10.1.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.12 (pre-alpha) &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.12-0.10.1.1.tgz">kafka_2.12-0.10.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.12-0.10.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.1/kafka_2.12-0.10.1.1.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala, and include 2.12 as a pre-alpha before the next major release. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.10 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.8.2.1"></span>
-    <h3 class="download-version">0.8.2.1<a href="#0.8.2.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released March 11, 2015
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.8.2.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka-0.8.2.1-src.tgz">kafka-0.8.2.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka-0.8.2.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka-0.8.2.1-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.10.1.0"></span>
+            <h3 class="download-version">0.10.1.0<a href="#0.10.1.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.1-0.8.2.1.tgz">kafka_2.9.1-0.8.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.1-0.8.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.1-0.8.2.1.tgz.md5">md5</a>)
+                    <li>
+                        Released October 20, 2016
                     </li>
-                    <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.2-0.8.2.1.tgz">kafka_2.9.2-0.8.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.2-0.8.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.2-0.8.2.1.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.10.1.0/RELEASE_NOTES.html">Release Notes</a>
                     </li>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz">kafka_2.10-0.8.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz.md5">md5</a>)
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka-0.10.1.0-src.tgz">kafka-0.10.1.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka-0.10.1.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka-0.10.1.0-src.tgz.md5">md5</a>)
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.11-0.8.2.1.tgz">kafka_2.11-0.8.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.11-0.8.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.11-0.8.2.1.tgz.md5">md5</a>)
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.10-0.10.1.0.tgz">kafka_2.10-0.10.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.10-0.10.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.10-0.10.1.0.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz">kafka_2.11-0.10.1.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.1.0/kafka_2.11-0.10.1.0.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.10 is recommended).
-            </li>
-        </ul>
-       
-
-    <span id="0.8.2.0"></span>
-    <h3 class="download-version">0.8.2.0<a href="#0.8.2.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released February 2, 2015
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.8.2.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka-0.8.2.0-src.tgz">kafka-0.8.2.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka-0.8.2.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka-0.8.2.0-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.10.0.1"></span>
+            <h3 class="download-version">0.10.0.1<a href="#0.10.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.1-0.8.2.0.tgz">kafka_2.9.1-0.8.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.1-0.8.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.1-0.8.2.0.tgz.md5">md5</a>)
+                    <li>
+                        Released August 10, 2016
                     </li>
-                    <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.2-0.8.2.0.tgz">kafka_2.9.2-0.8.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.2-0.8.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.2-0.8.2.0.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.10.0.1/RELEASE_NOTES.html">Release Notes</a>
                     </li>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.10-0.8.2.0.tgz">kafka_2.10-0.8.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.10-0.8.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.10-0.8.2.0.tgz.md5">md5</a>)
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka-0.10.0.1-src.tgz">kafka-0.10.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka-0.10.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka-0.10.0.1-src.tgz.md5">md5</a>)
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.11-0.8.2.0.tgz">kafka_2.11-0.8.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.11-0.8.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.11-0.8.2.0.tgz.md5">md5</a>)
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz">kafka_2.10-0.10.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.10-0.10.0.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.11-0.10.0.1.tgz">kafka_2.11-0.10.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.11-0.10.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.1/kafka_2.11-0.10.0.1.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.10 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.8.2-beta"></span>
-    <h3 class="download-version">0.8.2-beta<a href="#0.8.2-beta"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released October 28, 2014
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka-0.8.2-beta-src.tgz">kafka-0.8.2-beta-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka-0.8.2-beta-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka-0.8.2-beta-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.10.0.0"></span>
+            <h3 class="download-version">0.10.0.0<a href="#0.10.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.1-0.8.2-beta.tgz">kafka_2.9.1-0.8.2-beta.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.1-0.8.2-beta.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.1-0.8.2-beta.tgz.md5">md5</a>)
+                    <li>
+                        Released May 22, 2016
                     </li>
-                    <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.2-0.8.2-beta.tgz">kafka_2.9.2-0.8.2-beta.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.2-0.8.2-beta.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.2-0.8.2-beta.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.10.0.0/RELEASE_NOTES.html">Release Notes</a>
                     </li>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.10-0.8.2-beta.tgz">kafka_2.10-0.8.2-beta.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.10-0.8.2-beta.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.10-0.8.2-beta.tgz.md5">md5</a>)
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka-0.10.0.0-src.tgz">kafka-0.10.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka-0.10.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka-0.10.0.0-src.tgz.md5">md5</a>)
                     </li>
-                    <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.11-0.8.2-beta.tgz">kafka_2.11-0.8.2-beta.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.11-0.8.2-beta.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.11-0.8.2-beta.tgz.md5">md5</a>)
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.10-0.10.0.0.tgz">kafka_2.10-0.10.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.10-0.10.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.10-0.10.0.0.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.11-0.10.0.0.tgz">kafka_2.11-0.10.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.11-0.10.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.10.0.0/kafka_2.11-0.10.0.0.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.10 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.8.1.1"></span>
-    <h3 class="download-version">0.8.1.1 Release<a href="#0.8.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released April 29, 2014
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.8.1.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka-0.8.1.1-src.tgz">kafka-0.8.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka-0.8.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka-0.8.1.1-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.9.0.1"></span>
+            <h3 class="download-version">0.9.0.1<a href="#0.9.0.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.8.0 - <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.8.0-0.8.1.1.tgz">kafka_2.8.0-0.8.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.8.0-0.8.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.8.0-0.8.1.1.tgz.md5">md5</a>)
+                    <li>
+                        Released February 19, 2016
                     </li>
-                    <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.1-0.8.1.1.tgz">kafka_2.9.1-0.8.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.1-0.8.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.1-0.8.1.1.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.9.0.1/RELEASE_NOTES.html">Release Notes</a>
                     </li>
-                    <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.2-0.8.1.1.tgz">kafka_2.9.2-0.8.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.2-0.8.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.2-0.8.1.1.tgz.md5">md5</a>)
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka-0.9.0.1-src.tgz">kafka-0.9.0.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka-0.9.0.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka-0.9.0.1-src.tgz.md5">md5</a>)
                     </li>
-                    <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.10-0.8.1.1.tgz">kafka_2.10-0.8.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.10-0.8.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.10-0.8.1.1.tgz.md5">md5</a>)
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.10-0.9.0.1.tgz">kafka_2.10-0.9.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.10-0.9.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.10-0.9.0.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz">kafka_2.11-0.9.0.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.9.2 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.8.1"></span>
-    <h3 class="download-version">0.8.1 Release<a href="#0.8.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released March 12, 2014
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.8.1/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka-0.8.1-src.tgz">kafka-0.8.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka-0.8.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka-0.8.1-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary downloads:
+        
+            <span id="0.9.0.0"></span>
+            <h3 class="download-version">0.9.0.0<a href="#0.9.0.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
                 <ul>
-                    <li>Scala 2.8.0 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.0-0.8.1.tgz">kafka_2.8.0-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.0-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.0-0.8.1.tgz.md5">md5</a>)
+                    <li>
+                        Released November 23, 2015
                     </li>
-                    <li>Scala 2.8.2 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.2-0.8.1.tgz">kafka_2.8.2-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.2-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.2-0.8.1.tgz.md5">md5</a>)
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.9.0.0/RELEASE_NOTES.html">Release Notes</a>
                     </li>
-                    <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.1-0.8.1.tgz">kafka_2.9.1-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.1-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.1-0.8.1.tgz.md5">md5</a>)
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka-0.9.0.0-src.tgz">kafka-0.9.0.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka-0.9.0.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka-0.9.0.0-src.tgz.md5">md5</a>)
                     </li>
-                    <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.2-0.8.1.tgz">kafka_2.9.2-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.2-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.2-0.8.1.tgz.md5">md5</a>)
-                    </li>
-                    <li>Scala 2.10 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.10-0.8.1.tgz">kafka_2.10-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.10-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.10-0.8.1.tgz.md5">md5</a>)
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.10-0.9.0.0.tgz">kafka_2.10-0.9.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.10-0.9.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.10-0.9.0.0.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.11-0.9.0.0.tgz">kafka_2.11-0.9.0.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.11-0.9.0.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.9.0.0/kafka_2.11-0.9.0.0.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.11 is recommended).
                     </li>
                 </ul>
-                We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.9.2 is recommended).
-            </li>
-        </ul>
-
-
-    <span id="0.8.0"></span>
-    <h3 class="download-version">0.8.0 Release<a href="#0.11.0.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released December 3, 2013
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/0.8.0/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/0.8.0/kafka-0.8.0-src.tgz">kafka-0.8.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.0/kafka-0.8.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.0/0.8.0/kafka-0.8.0-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary download: <a href="https://archive.apache.org/dist/kafka/0.8.0/kafka_2.8.0-0.8.0.tar.gz">kafka_2.8.0-0.8.0.tar.gz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.0/kafka_2.8.0-0.8.0.tar.gz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.0/kafka_2.8.0-0.8.0.tar.gz.md5">md5</a>)
-            </li>
-        </ul>
-
-
-    <span id="0.8.0-Beta1"></span>
-    <h3 class="download-version">0.8.0 Beta1 Release<a href="#0.8.0-Beta1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released June 28, 2013
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/RELEASE_NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Source download: <a href="https://archive.apache.org/dist/kafka/kafka-0.8.0-beta1-src.tgz">kafka-0.8.0-beta1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/kafka-0.8.0-beta1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/kafka-0.8.0-beta1-src.tgz.md5">md5</a>)
-            </li>
-            <li>
-                Binary download: <a href="https://archive.apache.org/dist/kafka/kafka_2.8.0-0.8.0-beta1.tgz">kafka_2.8.0-0.8.0-beta1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/kafka_2.8.0-0.8.0-beta1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/kafka_2.8.0-0.8.0-beta1.tgz.md5">md5</a>)
-            </li>
-        </ul>
-
-
-    <span id="0.7.2"></span>
-    <h3 class="download-version">0.7.2 Release<a href="#0.7.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released October 10, 2012
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.2-incubating/RELEASE-NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Download: <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.2-incubating/kafka-0.7.2-incubating-src.tgz">kafka-0.7.2-incubating-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.2-incubating/kafka-0.7.2-incubating-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.2-incubating/kafka-0.7.2-incubating-src.tgz.md5">md5</a>)
-            </li>
-        </ul>
-
-
-    <span id="0.7.1"></span>
-    <h3 class="download-version">0.7.1 Release<a href="#0.7.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released June 27, 2012
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.1-incubating/RELEASE-NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Download: <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.1-incubating/kafka-0.7.1-incubating-src.tgz">kafka-0.7.1-incubating-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.1-incubating/kafka-0.7.1-incubating-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.1-incubating/kafka-0.7.1-incubating-src.tgz.md5">md5</a>)
-            </li>
-        </ul>
-
-
-    <span id="0.7.0"></span>
-    <h3 class="download-version">0.7.0 Release<a href="#0.7.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
-        <ul>
-            <li>
-                Released January 4, 2012
-            </li>
-            <li>
-                <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/RELEASE-NOTES.html">Release Notes</a>
-            </li>
-            <li>
-                Download: <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz">kafka-0.7.0-incubating-src.tar.gz</a> (<a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz.md5">md5</a>)
-            </li>
-        </ul>
-
-        <p>
-            You can download releases previous to 0.7.0-incubating <a href="http://sna-projects.com/kafka/downloads.php">here</a>.
-        </p>
-
-
+        
+            <span id="0.8.2.2"></span>
+            <h3 class="download-version">0.8.2.2<a href="#0.8.2.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released October 2, 2015
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.8.2.2/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka-0.8.2.2-src.tgz">kafka-0.8.2.2-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka-0.8.2.2-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka-0.8.2.2-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.1-0.8.2.2.tgz">kafka_2.9.1-0.8.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.1-0.8.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.1-0.8.2.2.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.2-0.8.2.2.tgz">kafka_2.9.2-0.8.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.2-0.8.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.9.2-0.8.2.2.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz">kafka_2.10-0.8.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz">kafka_2.11-0.8.2.2.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.10 is recommended).
+                    </li>
+                </ul>
+        
+            <span id="0.8.2.1"></span>
+            <h3 class="download-version">0.8.2.1<a href="#0.8.2.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released March 11, 2015
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.8.2.1/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka-0.8.2.1-src.tgz">kafka-0.8.2.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka-0.8.2.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka-0.8.2.1-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.1-0.8.2.1.tgz">kafka_2.9.1-0.8.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.1-0.8.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.1-0.8.2.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.2-0.8.2.1.tgz">kafka_2.9.2-0.8.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.2-0.8.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.9.2-0.8.2.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz">kafka_2.10-0.8.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.11-0.8.2.1.tgz">kafka_2.11-0.8.2.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.11-0.8.2.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.11-0.8.2.1.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.10 is recommended).
+                    </li>
+                </ul>
+        
+            <span id="0.8.2.0"></span>
+            <h3 class="download-version">0.8.2.0<a href="#0.8.2.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released February 2, 2015
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.8.2.0/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka-0.8.2.0-src.tgz">kafka-0.8.2.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka-0.8.2.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka-0.8.2.0-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.1-0.8.2.0.tgz">kafka_2.9.1-0.8.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.1-0.8.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.1-0.8.2.0.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.2-0.8.2.0.tgz">kafka_2.9.2-0.8.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.2-0.8.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.9.2-0.8.2.0.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.10-0.8.2.0.tgz">kafka_2.10-0.8.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.10-0.8.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.10-0.8.2.0.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.11-0.8.2.0.tgz">kafka_2.11-0.8.2.0.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.11-0.8.2.0.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2.0/kafka_2.11-0.8.2.0.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.10 is recommended).
+                    </li>
+                </ul>
+        
+            <span id="0.8.2-beta"></span>
+            <h3 class="download-version">0.8.2-beta<a href="#0.8.2-beta"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released October 28, 2014
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka-0.8.2-beta-src.tgz">kafka-0.8.2-beta-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka-0.8.2-beta-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka-0.8.2-beta-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.1-0.8.2-beta.tgz">kafka_2.9.1-0.8.2-beta.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.1-0.8.2-beta.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.1-0.8.2-beta.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.2-0.8.2-beta.tgz">kafka_2.9.2-0.8.2-beta.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.2-0.8.2-beta.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.9.2-0.8.2-beta.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.10-0.8.2-beta.tgz">kafka_2.10-0.8.2-beta.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.10-0.8.2-beta.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.10-0.8.2-beta.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.11 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.11-0.8.2-beta.tgz">kafka_2.11-0.8.2-beta.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.11-0.8.2-beta.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.2-beta/kafka_2.11-0.8.2-beta.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.10 is recommended).
+                    </li>
+                </ul>
+        
+            <span id="0.8.1.1"></span>
+            <h3 class="download-version">0.8.1.1 Release<a href="#0.8.1.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released April 29, 2014
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.8.1.1/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka-0.8.1.1-src.tgz">kafka-0.8.1.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka-0.8.1.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka-0.8.1.1-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.8.0 - <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.8.0-0.8.1.1.tgz">kafka_2.8.0-0.8.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.8.0-0.8.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.8.0-0.8.1.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.1-0.8.1.1.tgz">kafka_2.9.1-0.8.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.1-0.8.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.1-0.8.1.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.2-0.8.1.1.tgz">kafka_2.9.2-0.8.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.2-0.8.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.9.2-0.8.1.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.10 &nbsp;- <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.10-0.8.1.1.tgz">kafka_2.10-0.8.1.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.10-0.8.1.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1.1/kafka_2.10-0.8.1.1.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.9.2 is recommended).
+                    </li>
+                </ul>
+        
+            <span id="0.8.1"></span>
+            <h3 class="download-version">0.8.1 Release<a href="#0.8.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released March 12, 2014
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.8.1/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka-0.8.1-src.tgz">kafka-0.8.1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka-0.8.1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka-0.8.1-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary downloads:
+                        <ul>
+                            <li>Scala 2.8.0 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.0-0.8.1.tgz">kafka_2.8.0-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.0-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.0-0.8.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.8.2 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.2-0.8.1.tgz">kafka_2.8.2-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.2-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.8.2-0.8.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.9.1 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.1-0.8.1.tgz">kafka_2.9.1-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.1-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.1-0.8.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.9.2 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.2-0.8.1.tgz">kafka_2.9.2-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.2-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.9.2-0.8.1.tgz.md5">md5</a>)
+                            </li>
+                            <li>Scala 2.10 - <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.10-0.8.1.tgz">kafka_2.10-0.8.1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.10-0.8.1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.1/kafka_2.10-0.8.1.tgz.md5">md5</a>)
+                            </li>
+                        </ul>
+                        We build for multiple versions of Scala. This only matters if you are using Scala and you want a version built for the same Scala version you use. Otherwise any version should work (2.9.2 is recommended).
+                    </li>
+                </ul>
+        
+            <span id="0.8.0"></span>
+            <h3 class="download-version">0.8.0 Release<a href="#0.11.0.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released December 3, 2013
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/0.8.0/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/0.8.0/kafka-0.8.0-src.tgz">kafka-0.8.0-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.0/kafka-0.8.0-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.0/0.8.0/kafka-0.8.0-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary download: <a href="https://archive.apache.org/dist/kafka/0.8.0/kafka_2.8.0-0.8.0.tar.gz">kafka_2.8.0-0.8.0.tar.gz</a> (<a href="https://archive.apache.org/dist/kafka/0.8.0/kafka_2.8.0-0.8.0.tar.gz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/0.8.0/kafka_2.8.0-0.8.0.tar.gz.md5">md5</a>)
+                    </li>
+                </ul>
+        
+            <span id="0.8.0-Beta1"></span>
+            <h3 class="download-version">0.8.0 Beta1 Release<a href="#0.8.0-Beta1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released June 28, 2013
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/RELEASE_NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Source download: <a href="https://archive.apache.org/dist/kafka/kafka-0.8.0-beta1-src.tgz">kafka-0.8.0-beta1-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/kafka-0.8.0-beta1-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/kafka-0.8.0-beta1-src.tgz.md5">md5</a>)
+                    </li>
+                    <li>
+                        Binary download: <a href="https://archive.apache.org/dist/kafka/kafka_2.8.0-0.8.0-beta1.tgz">kafka_2.8.0-0.8.0-beta1.tgz</a> (<a href="https://archive.apache.org/dist/kafka/kafka_2.8.0-0.8.0-beta1.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/kafka_2.8.0-0.8.0-beta1.tgz.md5">md5</a>)
+                    </li>
+                </ul>
+        
+            <span id="0.7.2"></span>
+            <h3 class="download-version">0.7.2 Release<a href="#0.7.2"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released October 10, 2012
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.2-incubating/RELEASE-NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Download: <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.2-incubating/kafka-0.7.2-incubating-src.tgz">kafka-0.7.2-incubating-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.2-incubating/kafka-0.7.2-incubating-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.2-incubating/kafka-0.7.2-incubating-src.tgz.md5">md5</a>)
+                    </li>
+                </ul>
+                
+            <span id="0.7.1"></span>
+            <h3 class="download-version">0.7.1 Release<a href="#0.7.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released June 27, 2012
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.1-incubating/RELEASE-NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Download: <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.1-incubating/kafka-0.7.1-incubating-src.tgz">kafka-0.7.1-incubating-src.tgz</a> (<a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.1-incubating/kafka-0.7.1-incubating-src.tgz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.1-incubating/kafka-0.7.1-incubating-src.tgz.md5">md5</a>)
+                    </li>
+                </ul>
+        
+            <span id="0.7.0"></span>
+            <h3 class="download-version">0.7.0 Release<a href="#0.7.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+                <ul>
+                    <li>
+                        Released January 4, 2012
+                    </li>
+                    <li>
+                        <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/RELEASE-NOTES.html">Release Notes</a>
+                    </li>
+                    <li>
+                        Download: <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz">kafka-0.7.0-incubating-src.tar.gz</a> (<a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz.asc">asc</a>, <a href="https://archive.apache.org/dist/kafka/old_releases/kafka-0.7.0-incubating/kafka-0.7.0-incubating-src.tar.gz.md5">md5</a>)
+                    </li>
+                </ul>
+        
+                <p>
+                    You can download releases previous to 0.7.0-incubating <a href="http://sna-projects.com/kafka/downloads.php">here</a>.
+                </p>
+        
 <!--#include virtual="includes/_footer.htm" -->


### PR DESCRIPTION
We should have the supported releases at the top clearly identified and list archived releases below. According to the project's EOL policy we support the last 3 releases.