### PR TITLE
MINOR: add a space for kafka.metrics.polling.interval.secs description

### DIFF
--- a/38/generated/kafka_config.html
+++ b/38/generated/kafka_config.html
@@ -2729,7 +2729,7 @@
 </li>
 <li>
 <h4><a id="kafka.metrics.polling.interval.secs"></a><a id="brokerconfigs_kafka.metrics.polling.interval.secs" href="#brokerconfigs_kafka.metrics.polling.interval.secs">kafka.metrics.polling.interval.secs</a></h4>
-<p>The metrics polling interval (in seconds) which can be used inkafka.metrics.reporters implementations.</p>
+<p>The metrics polling interval (in seconds) which can be used in kafka.metrics.reporters implementations.</p>
 <table><tbody>
 <tr><th>Type:</th><td>int</td></tr>
 <tr><th>Default:</th><td>10</td></tr>


### PR DESCRIPTION
As title, there should be a space between in and kafka.metrics.reporters words.
![CleanShot 2024-09-24 at 02 16 41](https://github.com/user-attachments/assets/ea36b483-bdb3-42ea-983a-17faa7c9fecc)
