### PR TITLE
[Docs] Update site for 3.8.1

### DIFF
--- a/38/generated/connect_rest.yaml
+++ b/38/generated/connect_rest.yaml
@@ -8,7 +8,7 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
   title: Kafka Connect REST API
-  version: 3.8.0-SNAPSHOT
+  version: 3.8.1-SNAPSHOT
 paths:
   /:
     get:

--- a/38/js/templateData.js
+++ b/38/js/templateData.js
@@ -19,6 +19,6 @@ limitations under the License.
 var context={
     "version": "38",
     "dotVersion": "3.8",
-    "fullDotVersion": "3.8.0",
+    "fullDotVersion": "3.8.1-SNAPSHOT",
     "scalaVersion": "2.13"
 };

--- a/38/js/templateData.js
+++ b/38/js/templateData.js
@@ -19,6 +19,6 @@ limitations under the License.
 var context={
     "version": "38",
     "dotVersion": "3.8",
-    "fullDotVersion": "3.8.1-SNAPSHOT",
+    "fullDotVersion": "3.8.1",
     "scalaVersion": "2.13"
 };

--- a/38/ops.html
+++ b/38/ops.html
@@ -3990,7 +3990,8 @@ controller.listener.names=CONTROLLER</code></pre>
     To migrate the brokers to KRaft, they simply need to be reconfigured as KRaft brokers and restarted. Using the above
     broker configuration as an example, we would replace the <code>broker.id</code> with <code>node.id</code> and add
     <code>process.roles=broker</code>. It is important that the broker maintain the same Broker/Node ID when it is restarted.
-    The zookeeper configurations should be removed at this point.
+    The zookeeper configurations should be removed at this point. Finally, if you have set
+    <code>control.plane.listener.name</code>. please remove it before restarting in KRaft mode.
   </p>
 
   <p>

--- a/38/ops.html
+++ b/38/ops.html
@@ -3834,6 +3834,7 @@ foo
   <p>The following features are not fully implemented in KRaft mode:</p>
 
   <ul>
+    <li>Supporting JBOD configurations with multiple storage directories. Note that an Early Access release is supported in 3.7 as per <a href="https://cwiki.apache.org/confluence/display/KAFKA/KIP-858%3A+Handle+JBOD+broker+disk+failure+in+KRaft">KIP-858</a>. Note that it is not yet recommended for use in production environments. Please refer to the <a href="https://cwiki.apache.org/confluence/display/KAFKA/Kafka+JBOD+in+KRaft+Early+Access+Release+Notes">release notes</a> to help us test it and provide feedback at <a href="https://issues.apache.org/jira/browse/KAFKA-16061">KAFKA-16061</a>.</li>
     <li>Modifying certain dynamic configurations on the standalone KRaft controller</li>
   </ul>
 

--- a/38/upgrade.html
+++ b/38/upgrade.html
@@ -19,9 +19,9 @@
 
 <script id="upgrade-template" type="text/x-handlebars-template">
 
-<h4><a id="upgrade_3_8_0" href="#upgrade_3_8_0">Upgrading to 3.8.0 from any version 0.8.x through 3.7.x</a></h4>
+<h4><a id="upgrade_3_8_1" href="#upgrade_3_8_1">Upgrading to 3.8.1 from any version 0.8.x through 3.7.x</a></h4>
 
-    <h5><a id="upgrade_380_zk" href="#upgrade_380_zk">Upgrading ZooKeeper-based clusters</a></h5>
+<h5><a id="upgrade_381_zk" href="#upgrade_381_zk">Upgrading ZooKeeper-based clusters</a></h5>
     <p><b>If you are upgrading from a version prior to 2.1.x, please see the note in step 5 below about the change to the schema used to store consumer offsets.
         Once you have changed the inter.broker.protocol.version to the latest version, it will not be possible to downgrade to a version prior to 2.1.</b></p>
 
@@ -81,6 +81,19 @@
             after 3.2.x has a boolean parameter that indicates if there are metadata changes (i.e. <code>IBP_3_3_IV3(7, "3.3", "IV3", true)</code> means this version has metadata changes).
             Given your current and target versions, a downgrade is only possible if there are no metadata changes in the versions between.</li>
     </ol>
+
+    <h5><a id="upgrade_381_notable" href="#upgrade_381_notable">Notable changes in 3.8.1</a></h5>
+    <ul>
+        <li>In case you run your Kafka clusters with no execution permission for the <code>/tmp</code> partition, Kafka will not work properly. It might either refuse to start or fail
+            when producing and consuming messages. This is due to the compression libraries <code>zstd-jni</code> and <code>snappy</code>.
+            To remediate this problem you need to pass the following JVM flags to Kafka <code>ZstdTempFolder</code> and <code>org.xerial.snappy.tempdir</code> pointing to a directory with execution permissions.
+            For example, this could be done via the <code>KAFKA_OPTS</code> environment variable like follows: <code>export KAFKA_OPTS="-DZstdTempFolder=/opt/kafka/tmp -Dorg.xerial.snappy.tempdir=/opt/kafka/tmp"</code>.
+            This is a known issue for version 3.8.0.
+        </li>
+        <li>In 3.8.0 the <code>kafka.utils.Thottler</code> metric was accidentally renamed to <code>org.apache.kafka.storage.internals.utils.Throttler</code>.
+            This change has been reverted and the metric is now named <code>kafka.utils.Thottler</code> again.
+        </li>
+    </ul>
 
     <h5><a id="upgrade_380_notable" href="#upgrade_380_notable">Notable changes in 3.8.0</a></h5>
     <ul>

--- a/blog.html
+++ b/blog.html
@@ -24,6 +24,19 @@
             <h1 class="content-title">Blog</h1>
             <article>
                 <h2 class="bullet">
+                    <a id="apache_kafka_381_release_announcement"></a>
+                    <a href="#apache_kafka_381_release_announcement">Apache Kafka 3.8.1 Release Announcement</a>
+                </h2>
+                29 October 2024 - Josep Prat (<a href="https://twitter.com/jlprat">@jlprat</a>)
+                <p>We are proud to announce the release of Apache Kafka 3.8.1. This is a bugfix release. For a full list of changes, be sure to check the <a href="https://archive.apache.org/dist/kafka/3.8.1/RELEASE_NOTES.html">release notes</a>.</p>
+                <p>See the <a href="https://kafka.apache.org/38/documentation.html#upgrade_3_8_1">Upgrading to 3.8.1 from any version 0.8.x through 3.7.x</a> section in the documentation for the list of notable changes and detailed upgrade steps.</p>
+                <h3>Summary</h3>
+                <p>This was a community effort, so thank you to everyone who contributed to this release:</br>
+                    Andrew Schofield, Apoorv Mittal, Bill Bejeck, Bruno Cadonna, Chia-Ping Tsai, Chris Egerton, Colin P. McCabe, David Arthur, Guillaume Mallet, Igor Soarez, Josep Prat, Justine Olshan, Ken Huang, Kondrat Bertalan, Kuan-Po Tseng, Luke Chen, Manikumar Reddy, Matthias J. Sax, Mickael Maison, PoAn Yang, Rohan, TengYao Chi, Vikas Singh
+                </p>
+            </article>
+            <article>
+                <h2 class="bullet">
                     <a id="apache_kafka_380_release_announcement"></a>
                     <a href="#apache_kafka_380_release_announcement">Apache Kafka 3.8.0 Release Announcement</a>
                 </h2>

--- a/downloads.html
+++ b/downloads.html
@@ -13,6 +13,41 @@
         
         <h2>Supported releases</h2>
 
+            <span id="3.8.1"></span>
+            <h3 class="download-version">3.8.1<a href="#3.8.1"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
+            <ul>
+                <li>
+                    Released October 29, 2024
+                </li>
+                <li>
+                    <a href="https://downloads.apache.org/kafka/3.8.1/RELEASE_NOTES.html">Release Notes</a>
+                </li>
+                <li>
+                    Docker image: <a href="https://hub.docker.com/layers/apache/kafka/3.8.1/images/sha256-be37a49a4466f6620e2b67614dc2185e35d0e02e5cdc04ad5735ddd368a76b3e">apache/kafka:3.8.1</a>.
+                </li>
+                <li>
+                    Docker Native image: <a href="https://hub.docker.com/layers/apache/kafka-native/3.8.1/images/sha256-ecf23c833391b00803876332b8642e261e675237e133cba8bc6a59ab8292a4a6">apache/kafka-native:3.8.1</a>.
+                </li>
+                <li>
+                    Source download: <a href="https://downloads.apache.org/kafka/3.8.1/kafka-3.8.1-src.tgz">kafka-3.8.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka-3.8.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.8.0-src.tgz.sha512">sha512</a>)
+                </li>
+                <li>
+                    Binary downloads:
+                    <ul>
+                        <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.12-3.8.1.tgz">kafka_2.12-3.8.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.13-3.8.1.tgz">kafka_2.13-3.8.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz.sha512">sha512</a>)</li>
+                    </ul>
+                    We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
+                    built for the same Scala version you use. Otherwise, any version should work (2.13 is recommended).
+                </li>
+            </ul>
+
+            <p>
+                Kafka 3.8.1 includes a significant number of new features and fixes.
+                For more information, please read our <a href="https://kafka.apache.org/blog#apache_kafka_381_release_announcement" target="_blank">blog post</a>
+                and the detailed <a href="https://downloads.apache.org/kafka/3.8.1/RELEASE_NOTES.html">Release Notes</a>.
+            </p>
+
             <span id="3.8.0"></span>
             <h3 class="download-version">3.8.0<a href="#3.8.0"><i class="fas fa-link " style="color:#053ce2"></i></a></h3>
             <ul>


### PR DESCRIPTION
Updating the site for 3.8.1.
As https://home.apache.org is now gone, we can't have a real preview of the site for patch versions as all changes would be visible directly.