### PR TITLE
MINOR: fix links pointing to wrong version

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -29,13 +29,13 @@
                     Docker Native image: <a href="https://hub.docker.com/layers/apache/kafka-native/3.8.1/images/sha256-ecf23c833391b00803876332b8642e261e675237e133cba8bc6a59ab8292a4a6">apache/kafka-native:3.8.1</a>.
                 </li>
                 <li>
-                    Source download: <a href="https://downloads.apache.org/kafka/3.8.1/kafka-3.8.1-src.tgz">kafka-3.8.0-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka-3.8.0-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.8.0-src.tgz.sha512">sha512</a>)
+                    Source download: <a href="https://downloads.apache.org/kafka/3.8.1/kafka-3.8.1-src.tgz">kafka-3.8.1-src.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.1/kafka-3.8.1-src.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.7.0/kafka-3.8.1-src.tgz.sha512">sha512</a>)
                 </li>
                 <li>
                     Binary downloads:
                     <ul>
-                        <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.12-3.8.1.tgz">kafka_2.12-3.8.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.12-3.8.0.tgz.sha512">sha512</a>)</li>
-                        <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.13-3.8.1.tgz">kafka_2.13-3.8.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.0/kafka_2.13-3.8.0.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.12 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.12-3.8.1.tgz">kafka_2.12-3.8.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.12-3.8.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.12-3.8.1.tgz.sha512">sha512</a>)</li>
+                        <li>Scala 2.13 &nbsp;- <a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.13-3.8.1.tgz">kafka_2.13-3.8.1.tgz</a> (<a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.13-3.8.1.tgz.asc">asc</a>, <a href="https://downloads.apache.org/kafka/3.8.1/kafka_2.13-3.8.1.tgz.sha512">sha512</a>)</li>
                     </ul>
                     We build for multiple versions of Scala. This only matters if you are using Scala and you want a version
                     built for the same Scala version you use. Otherwise, any version should work (2.13 is recommended).


### PR DESCRIPTION
I didn't properly search-and-replace. Now it should be good.