### PR TITLE
MINOR: Fix the leak "unknown" group.coordinator.rebalance.protocols on document

### DIFF
--- a/37/generated/kafka_config.html
+++ b/37/generated/kafka_config.html
@@ -1266,7 +1266,7 @@
 </li>
 <li>
 <h4><a id="group.coordinator.rebalance.protocols"></a><a id="brokerconfigs_group.coordinator.rebalance.protocols" href="#brokerconfigs_group.coordinator.rebalance.protocols">group.coordinator.rebalance.protocols</a></h4>
-<p>The list of enabled rebalance protocols. Supported protocols: consumer,classic. The consumer rebalance protocol is in early access and therefore must not be used in production.</p>
+<p>The list of enabled rebalance protocols. The consumer rebalance protocol is in early access and therefore must not be used in production.</p>
 <table><tbody>
 <tr><th>Type:</th><td>list</td></tr>
 <tr><th>Default:</th><td>classic</td></tr>

--- a/38/generated/kafka_config.html
+++ b/38/generated/kafka_config.html
@@ -1321,11 +1321,11 @@
 </li>
 <li>
 <h4><a id="group.coordinator.rebalance.protocols"></a><a id="brokerconfigs_group.coordinator.rebalance.protocols" href="#brokerconfigs_group.coordinator.rebalance.protocols">group.coordinator.rebalance.protocols</a></h4>
-<p>The list of enabled rebalance protocols. Supported protocols: consumer,classic,unknown. The consumer rebalance protocol is in early access and therefore must not be used in production.</p>
+<p>The list of enabled rebalance protocols. The consumer rebalance protocol is in early access and therefore must not be used in production.</p>
 <table><tbody>
 <tr><th>Type:</th><td>list</td></tr>
 <tr><th>Default:</th><td>classic</td></tr>
-<tr><th>Valid Values:</th><td>[consumer, classic, unknown]</td></tr>
+<tr><th>Valid Values:</th><td>[consumer, classic]</td></tr>
 <tr><th>Importance:</th><td>medium</td></tr>
 <tr><th>Update Mode:</th><td>read-only</td></tr>
 </tbody></table>

--- a/39/generated/kafka_config.html
+++ b/39/generated/kafka_config.html
@@ -1321,11 +1321,11 @@
 </li>
 <li>
 <h4><a id="group.coordinator.rebalance.protocols"></a><a id="brokerconfigs_group.coordinator.rebalance.protocols" href="#brokerconfigs_group.coordinator.rebalance.protocols">group.coordinator.rebalance.protocols</a></h4>
-<p>The list of enabled rebalance protocols. Supported protocols: consumer,classic,share,unknown. The consumer rebalance protocol is in early access and therefore must not be used in production.</p>
+<p>The list of enabled rebalance protocols. The consumer rebalance protocol is in early access and therefore must not be used in production.</p>
 <table><tbody>
 <tr><th>Type:</th><td>list</td></tr>
 <tr><th>Default:</th><td>classic</td></tr>
-<tr><th>Valid Values:</th><td>[consumer, classic, share, unknown]</td></tr>
+<tr><th>Valid Values:</th><td>[consumer, classic, share]</td></tr>
 <tr><th>Importance:</th><td>medium</td></tr>
 <tr><th>Update Mode:</th><td>read-only</td></tr>
 </tbody></table>

--- a/39/generated/kafka_config.html
+++ b/39/generated/kafka_config.html
@@ -1321,7 +1321,7 @@
 </li>
 <li>
 <h4><a id="group.coordinator.rebalance.protocols"></a><a id="brokerconfigs_group.coordinator.rebalance.protocols" href="#brokerconfigs_group.coordinator.rebalance.protocols">group.coordinator.rebalance.protocols</a></h4>
-<p>The list of enabled rebalance protocols. The consumer rebalance protocol is in early access and therefore must not be used in production.</p>
+<p>The list of enabled rebalance protocols. The consumer and share rebalance protocol is in early access and therefore must not be used in production.</p>
 <table><tbody>
 <tr><th>Type:</th><td>list</td></tr>
 <tr><th>Default:</th><td>classic</td></tr>

--- a/39/generated/kafka_config.html
+++ b/39/generated/kafka_config.html
@@ -1321,7 +1321,7 @@
 </li>
 <li>
 <h4><a id="group.coordinator.rebalance.protocols"></a><a id="brokerconfigs_group.coordinator.rebalance.protocols" href="#brokerconfigs_group.coordinator.rebalance.protocols">group.coordinator.rebalance.protocols</a></h4>
-<p>The list of enabled rebalance protocols. The consumer and share rebalance protocol is in early access and therefore must not be used in production.</p>
+<p>The list of enabled rebalance protocols. The consumer and share rebalance protocol are in early access and therefore must not be used in production.</p>
 <table><tbody>
 <tr><th>Type:</th><td>list</td></tr>
 <tr><th>Default:</th><td>classic</td></tr>


### PR DESCRIPTION
Although "unknown" group.coordinator.rebalance.protocols type is a valid string in internal kafka system, but the common user should not config this "unknown" type, so we should remove it from the document.
