### PR TITLE
MINOR: fix 3.9 dynamic quorum with unknow `controller_static.properties`

### DIFF
--- a/39/ops.html
+++ b/39/ops.html
@@ -3878,7 +3878,7 @@ Feature: metadata.version       SupportedMinVersion: 3.0-IV1    SupportedMaxVers
   this flag when formatting brokers -- only when formatting controllers.)<p>
 
 <pre><code class="language-bash">
-  $ bin/kafka-storage.sh format -t KAFKA_CLUSTER_ID --feature kraft.version=1 -c controller_static.properties
+  $ bin/kafka-storage.sh format -t KAFKA_CLUSTER_ID --feature kraft.version=1 -c controller.properties
   Cannot set kraft.version to 1 unless KIP-853 configuration is present. Try removing the --feature flag for kraft.version.
 </code></pre><p>
 


### PR DESCRIPTION
`controller_static.properties` this properties is only appear in this command, users will not know this properties means, we should change it to `controller.properties` which use in previous command.