### PR TITLE
MINOR Fix the URL for matomo

### DIFF
--- a/includes/_header.htm
+++ b/includes/_header.htm
@@ -68,7 +68,7 @@
 			_paq.push(['trackPageView']);
 			_paq.push(['enableLinkTracking']);
 			(function() {
-				var u="//matomo.privacy.apache.org/";
+				var u="//analytics.apache.org/";
 				_paq.push(['setTrackerUrl', u+'matomo.php']);
 				_paq.push(['setSiteId', '26']);
 				var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];


### PR DESCRIPTION
This has been broken for a long time. We should be seeing data in https://analytics.apache.org, but we don't.