### PR TITLE
MINOR: Fix a minor issue and improve ops doc for 3.9 version

### DIFF
--- a/39/ops.html
+++ b/39/ops.html
@@ -3801,7 +3801,7 @@ controller.listener.names=CONTROLLER</code></pre>
   <h5 class="anchor-heading"><a id="kraft_storage_standalone" class="anchor-link"></a><a href="#kraft_storage_standalone">Bootstrap a Standalone Controller</a></h5>
   The recommended method for creating a new KRaft controller cluster is to bootstrap it with one voter and dynamically <a href="#kraft_reconfig_add">add the rest of the controllers</a>. Bootstrapping the first controller can be done with the following CLI command:
 
-  <pre><code class="language-bash">$ bin/kafka-storage format --cluster-id &lt;cluster-id&gt; --standalone --config controller.properties</code></pre>
+  <pre><code class="language-bash">$ bin/kafka-storage.sh format --cluster-id &lt;cluster-id&gt; --standalone --config controller.properties</code></pre>
 
   This command will 1) create a meta.properties file in metadata.log.dir with a randomly generated directory.id, 2) create a snapshot at 00000000000000000000-0000000000.checkpoint with the necessary control records (KRaftVersionRecord and VotersRecord) to make this Kafka node the only voter for the quorum.
 
@@ -4070,7 +4070,13 @@ inter.broker.listener.name=PLAINTEXT
 
 # Other configs ...</code></pre>
 
-  <p>The new standalone controller in the example configuration above should be formatted using the <code>kafka-storage format --standalone</code>command.</p>
+
+  <p>
+    Follow these steps to format and start a new standalone controller:
+  </p>
+  <pre><code class="language-bash"># Save the previously retrieved cluster ID from ZooKeeper
+$ bin/kafka-storage.sh format --standalone -t &lt;zk-cluster-id&gt; -c config/kraft/controller.properties
+$ bin/kafka-server-start.sh config/kraft/controller.properties</code></pre>
 
   <p><em>Note: The KRaft cluster <code>node.id</code> values must be different from any existing ZK broker <code>broker.id</code>.
   In KRaft-mode, the brokers and controllers share the same Node ID namespace.</em></p>

--- a/39/ops.html
+++ b/39/ops.html
@@ -3801,22 +3801,22 @@ controller.listener.names=CONTROLLER</code></pre>
   <h5 class="anchor-heading"><a id="kraft_storage_standalone" class="anchor-link"></a><a href="#kraft_storage_standalone">Bootstrap a Standalone Controller</a></h5>
   The recommended method for creating a new KRaft controller cluster is to bootstrap it with one voter and dynamically <a href="#kraft_reconfig_add">add the rest of the controllers</a>. Bootstrapping the first controller can be done with the following CLI command:
 
-  <pre><code class="language-bash">$ bin/kafka-storage.sh format --cluster-id &lt;cluster-id&gt; --standalone --config controller.properties</code></pre>
+  <pre><code class="language-bash">$ bin/kafka-storage.sh format --cluster-id &lt;cluster-id&gt; --standalone --config ./config/kraft/controller.properties</code></pre>
 
   This command will 1) create a meta.properties file in metadata.log.dir with a randomly generated directory.id, 2) create a snapshot at 00000000000000000000-0000000000.checkpoint with the necessary control records (KRaftVersionRecord and VotersRecord) to make this Kafka node the only voter for the quorum.
 
   <h5 class="anchor-heading"><a id="kraft_storage_voters" class="anchor-link"></a><a href="#kraft_storage_voters">Bootstrap with Multiple Controllers</a></h5>
   The KRaft cluster metadata partition can also be bootstrapped with more than one voter. This can be done by using the --initial-controllers flag:
 
-  <pre><code class="language-bash">cluster-id=$(kafka-storage random-uuid)
-controller-0-uuid=$(kafka-storage random-uuid)
-controller-1-uuid=$(kafka-storage random-uuid)
-controller-2-uuid=$(kafka-storage random-uuid)
+  <pre><code class="language-bash">cluster-id=$(bin/kafka-storage.sh random-uuid)
+controller-0-uuid=$(bin/kafka-storage.sh random-uuid)
+controller-1-uuid=$(bin/kafka-storage.sh random-uuid)
+controller-2-uuid=$(bin/kafka-storage.sh random-uuid)
 
 # In each controller execute
-kafka-storage format --cluster-id ${cluster-id} \
+bin/kafka-storage.sh format --cluster-id ${cluster-id} \
                      --initial-controllers "0@controller-0:1234:${controller-0-uuid},1@controller-1:1234:${controller-1-uuid},2@controller-2:1234:${controller-2-uuid}" \
-                     --config controller.properties</code></pre>
+                     --config config/kraft/controller.properties</code></pre>
 
 This command is similar to the standalone version but the snapshot at 00000000000000000000-0000000000.checkpoint will instead contain a VotersRecord that includes information for all of the controllers specified in --initial-controllers. It is important that the value of this flag is the same in all of the controllers with the same cluster id.
 
@@ -3825,7 +3825,7 @@ In the replica description 0@controller-0:1234:3Db5QLSqSZieL3rJBUUegA, 0 is the 
   <h5 class="anchor-heading"><a id="kraft_storage_observers" class="anchor-link"></a><a href="#kraft_storage_observers">Formatting Brokers and New Controllers</a></h5>
   When provisioning new broker and controller nodes that we want to add to an existing Kafka cluster, use the <code>kafka-storage.sh format</code> command with the --no-initial-controllers flag.
 
-  <pre><code class="language-bash">$ bin/kafka-storage.sh format --cluster-id &lt;cluster-id&gt; --config server.properties --no-initial-controllers</code></pre>
+  <pre><code class="language-bash">$ bin/kafka-storage.sh format --cluster-id &lt;cluster-id&gt; --config config/kraft/server.properties --no-initial-controllers</code></pre>
 
   <h4 class="anchor-heading"><a id="kraft_reconfig" class="anchor-link"></a><a href="#kraft_reconfig">Controller membership changes</a></h4>
 
@@ -3878,7 +3878,7 @@ Feature: metadata.version       SupportedMinVersion: 3.0-IV1    SupportedMaxVers
   this flag when formatting brokers -- only when formatting controllers.)<p>
 
 <pre><code class="language-bash">
-  $ bin/kafka-storage.sh format -t KAFKA_CLUSTER_ID --feature kraft.version=1 -c controller.properties
+  $ bin/kafka-storage.sh format -t KAFKA_CLUSTER_ID --feature kraft.version=1 -c config/kraft/controller.properties
   Cannot set kraft.version to 1 unless KIP-853 configuration is present. Try removing the --feature flag for kraft.version.
 </code></pre><p>
 
@@ -3891,10 +3891,10 @@ Feature: metadata.version       SupportedMinVersion: 3.0-IV1    SupportedMaxVers
   After starting the controller, the replication to the new controller can be monitored using the <code>kafka-metadata-quorum describe --replication</code> command. Once the new controller has caught up to the active controller, it can be added to the cluster using the <code>kafka-metadata-quorum add-controller</code> command.
 
   When using broker endpoints use the --bootstrap-server flag:
-  <pre><code class="language-bash">$ bin/kafka-metadata-quorum --command-config controller.properties --bootstrap-server localhost:9092 add-controller</code></pre>
+  <pre><code class="language-bash">$ bin/kafka-metadata-quorum.sh --command-config config/kraft/controller.properties --bootstrap-server localhost:9092 add-controller</code></pre>
 
   When using controller endpoints use the --bootstrap-controller flag:
-  <pre><code class="language-bash">$ bin/kafka-metadata-quorum --command-config controller.properties --bootstrap-controller localhost:9092 add-controller</code></pre>
+  <pre><code class="language-bash">$ bin/kafka-metadata-quorum.sh --command-config config/kraft/controller.properties --bootstrap-controller localhost:9092 add-controller</code></pre>
 
   <h5 class="anchor-heading"><a id="kraft_reconfig_remove" class="anchor-link"></a><a href="#kraft_reconfig_remove">Remove Controller</a></h5>
   If the dynamic controller cluster already exists, it can be shrunk using the <code>bin/kafka-metadata-quorum.sh remove-controller</code> command. Until KIP-996: Pre-vote has been implemented and released, it is recommended to shutdown the controller that will be removed before running the remove-controller command.
@@ -4074,7 +4074,7 @@ inter.broker.listener.name=PLAINTEXT
   <p>
     Follow these steps to format and start a new standalone controller:
   </p>
-  <pre><code class="language-bash"># Save the previously retrieved cluster ID from ZooKeeper
+  <pre><code class="language-bash"># Save the previously retrieved cluster ID from ZooKeeper in a variable called zk-cluster-id
 $ bin/kafka-storage.sh format --standalone -t &lt;zk-cluster-id&gt; -c config/kraft/controller.properties
 $ bin/kafka-server-start.sh config/kraft/controller.properties</code></pre>
 


### PR DESCRIPTION
This PR adds the command related to starting the Kraft controller into the Provisioning the Kraft Controller quorum section. I think it's better to include it there instead of switching back and forth between sections, as it's a small command and keeps the flow more consistent.