### PR TITLE
MINOR: add footer for `compatibility-summary`

### DIFF
--- a/includes/_footer.htm
+++ b/includes/_footer.htm
@@ -43,6 +43,7 @@
 					'upgrade',
 					'content',
 					'zk2kraft-summary',
+					'compatibility-summary',
 					'docker'
 				];
 


### PR DESCRIPTION
After merge https://github.com/apache/kafka/pull/18091, we need to add footer for `compatibility-summary` 