### PR TITLE
MINOR: Update default docs to point to the 4.0 release docs

### DIFF
--- a/documentation.html
+++ b/documentation.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="39/documentation.html" -->
+<!--#include virtual="40/documentation.html" -->

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../39/documentation.html" -->
+<!--#include virtual="../40/documentation.html" -->

--- a/documentation/streams/architecture.html
+++ b/documentation/streams/architecture.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../39/streams/architecture.html" -->
+<!--#include virtual="../../40/streams/architecture.html" -->

--- a/documentation/streams/core-concepts.html
+++ b/documentation/streams/core-concepts.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../3r/streams/core-concepts.html" -->
+<!--#include virtual="../../40/streams/core-concepts.html" -->

--- a/documentation/streams/developer-guide/app-reset-tool.html
+++ b/documentation/streams/developer-guide/app-reset-tool.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/app-reset-tool.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/app-reset-tool.html" -->

--- a/documentation/streams/developer-guide/config-streams.html
+++ b/documentation/streams/developer-guide/config-streams.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/config-streams.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/config-streams.html" -->

--- a/documentation/streams/developer-guide/datatypes.html
+++ b/documentation/streams/developer-guide/datatypes.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/datatypes.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/datatypes.html" -->

--- a/documentation/streams/developer-guide/dsl-api.html
+++ b/documentation/streams/developer-guide/dsl-api.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/dsl-api.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/dsl-api.html" -->

--- a/documentation/streams/developer-guide/dsl-topology-naming.html
+++ b/documentation/streams/developer-guide/dsl-topology-naming.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/dsl-topology-naming.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/dsl-topology-naming.html" -->

--- a/documentation/streams/developer-guide/index.html
+++ b/documentation/streams/developer-guide/index.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/index.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/index.html" -->

--- a/documentation/streams/developer-guide/interactive-queries.html
+++ b/documentation/streams/developer-guide/interactive-queries.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/interactive-queries.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/interactive-queries.html" -->

--- a/documentation/streams/developer-guide/manage-topics.html
+++ b/documentation/streams/developer-guide/manage-topics.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/manage-topics.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/manage-topics.html" -->

--- a/documentation/streams/developer-guide/memory-mgmt.html
+++ b/documentation/streams/developer-guide/memory-mgmt.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/memory-mgmt.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/memory-mgmt.html" -->

--- a/documentation/streams/developer-guide/processor-api.html
+++ b/documentation/streams/developer-guide/processor-api.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/processor-api.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/processor-api.html" -->

--- a/documentation/streams/developer-guide/running-app.html
+++ b/documentation/streams/developer-guide/running-app.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/running-app.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/running-app.html" -->

--- a/documentation/streams/developer-guide/security.html
+++ b/documentation/streams/developer-guide/security.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/security.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/security.html" -->

--- a/documentation/streams/developer-guide/testing.html
+++ b/documentation/streams/developer-guide/testing.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/testing.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/testing.html" -->

--- a/documentation/streams/developer-guide/write-streams.html
+++ b/documentation/streams/developer-guide/write-streams.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../../39/streams/developer-guide/write-streams.html" -->
+<!--#include virtual="../../../40/streams/developer-guide/write-streams.html" -->

--- a/documentation/streams/index.html
+++ b/documentation/streams/index.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../39/streams/index.html" -->
+<!--#include virtual="../../40/streams/index.html" -->

--- a/documentation/streams/quickstart.html
+++ b/documentation/streams/quickstart.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../39/streams/quickstart.html" -->
+<!--#include virtual="../../40/streams/quickstart.html" -->

--- a/documentation/streams/upgrade-guide.html
+++ b/documentation/streams/upgrade-guide.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="../../39/streams/upgrade-guide.html" -->
+<!--#include virtual="../../40/streams/upgrade-guide.html" -->

--- a/intro.html
+++ b/intro.html
@@ -29,7 +29,7 @@
         </div>
     </div>
 <!-- should always link the latest release's documentation -->
-    <!--#include virtual="/39/introduction.html" -->
+    <!--#include virtual="/40/introduction.html" -->
 
 <!--#include virtual="includes/_footer.htm" -->
 

--- a/protocol.html
+++ b/protocol.html
@@ -1,2 +1,2 @@
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="39/protocol.html" -->
+<!--#include virtual="40/protocol.html" -->

--- a/quickstart.html
+++ b/quickstart.html
@@ -30,7 +30,7 @@
     </div>
 
 <!-- should always link the latest release's documentation -->
-    <!--#include virtual="39/quickstart.html" -->
+    <!--#include virtual="40/quickstart.html" -->
 <!--#include virtual="includes/_footer.htm" -->
 <script>
 // Show selected style on nav item

--- a/uses.html
+++ b/uses.html
@@ -7,7 +7,7 @@
 		<h1 class="content-title">Use cases</h1>
 
 <!-- should always link the latest release's documentation -->
-<!--#include virtual="39/uses.html" -->
+<!--#include virtual="40/uses.html" -->
 
 <!--#include virtual="includes/_footer.htm" -->
 


### PR DESCRIPTION
Update: There are lots of default docs still linked to 3.9
This patch is to update all of them.


Note: due to the `htaccess` rule, I have to manually add `.html` to add the end of the URL to access the quickstart.
It should be fine in production.

Preview:
![image](https://github.com/user-attachments/assets/5f333735-068f-4ba7-8e90-3ee34c68fcbf)
