### PR TITLE
KAFKA-18993: Remove confusing notable change section from upgrade.html

### DIFF
--- a/40/upgrade.html
+++ b/40/upgrade.html
@@ -32,12 +32,6 @@
         or <a href="https://cwiki.apache.org/confluence/x/y4kgF">KIP-1124</a>.</li>
 </ol>
 
-<h6><a id="upgrade_clients_400_notable" href="#upgrade_clients_400_notable">Notable changes in 4.0.0</a></h6>
-
-<ul>
-    <li>Please see notable changes in the server section.</li>
-</ul>
-
 <h5><a id="upgrade_servers_4_0_0" href="#upgrade_servers_4_0_0">Upgrading Servers to 4.0.0 from any version 3.3.x through 3.9.x</a></h5>
 
 <p>Note: Apache Kafka 4.0 only supports KRaft mode - ZooKeeper mode has been removed. As such, <b>broker upgrades to 4.0.0 (and higher) require KRaft mode and


### PR DESCRIPTION
JIRA: KAFKA-18993
Currently, the "Notable changes in 4.0.0" for the client is very confusing.
We should remove it.