### PR TITLE
MINOR: Show Committer pictures on small screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1680,6 +1680,10 @@ nav .btn {
     h4 {
         font-size: 1.6rem;
     }
+    td {
+        padding: 0.5rem;
+        width: 5rem;
+    }
     .logo {
         width: 21.667rem;
         height: auto;


### PR DESCRIPTION
Before the change:
![Screen Shot 2025-03-20 at 17 21 01](https://github.com/user-attachments/assets/c6c7d724-26f3-4ac0-af1b-47ac3c8c2dd1)
After the change:
![Screen Shot 2025-03-20 at 17 21 19](https://github.com/user-attachments/assets/35e5e746-e919-48af-b35d-d2570e62b0ec)

It's not perfect, but with the space given and not making a full fledged change on the table format, it's the best I could do with minimal effort.