### PR TITLE
Added missing `/migration` znode deletion on rollback KRaft migration

### DIFF
--- a/39/ops.html
+++ b/39/ops.html
@@ -4292,7 +4292,10 @@ listeners=CONTROLLER://:9093
             </li>
             <li>
               Using <code>zookeeper-shell.sh</code>, run <code>delete /controller</code> so that one
-              of the brokers can become the new old-style controller.
+              of the brokers can become the new old-style controller. Additionally, run
+              <code>get /migration</code> followed by <code>delete /migration</code> to clear the
+              migration state from ZooKeeper. This will allow you to re-attempt the migration
+              in the future. The data read from "/migration" can be useful for debugging.
             </li>
             <li>
               On each broker, remove the <code>zookeeper.metadata.migration.enable</code>,


### PR DESCRIPTION
The table provided in the section "Reverting to ZooKeeper mode During the Migration" of the KRaft migration guide is written in a way that each line is self-consistent (or this is my understanding).
It means that given the phase you are (so looking at the column "Final Migration Section Completed"), you refer to one line of the table and follow the instruction showed in the "Directions for Reverting" column (+ "Notes" one).
When in "Migrating brokers to KRaft" phase, the steps are missing the deletion of the `/migration` znode and this is fixed by this PR.
