### PR TITLE
KAFKA-19026: add note in ZK to KRaft migration

### DIFF
--- a/39/ops.html
+++ b/39/ops.html
@@ -4009,6 +4009,11 @@ foo
     </li>
     <li><a href="#kraft_missing">As noted above</a>, some features are not fully implemented in KRaft mode. If you are
       using one of those features, you will not be able to migrate to KRaft yet.</li>
+    <li>
+      There is a known inconsistency between ZK and KRaft modes in the arguments passed to an <code>AlterConfigPolicy</code>,
+      when an <code>OpType.SUBTRACT</code> is processed.
+      For further details refer to <a href="https://issues.apache.org/jira/browse/KAFKA-19026">KAFKA-19026</a>.
+    </li>
   </ul>
 
   <h3>Preparing for migration</h3>


### PR DESCRIPTION
Add a brief note pointing to the issue in the 3.9 migration guide