### PR TITLE
KAFKA-19209: Clarify index.interval.bytes impact on offset and time index

### DIFF
--- a/40/generated/topic_config.html
+++ b/40/generated/topic_config.html
@@ -111,7 +111,12 @@
 </li>
 <li>
 <h4><a id="index.interval.bytes"></a><a id="topicconfigs_index.interval.bytes" href="#topicconfigs_index.interval.bytes">index.interval.bytes</a></h4>
-<p>This setting controls how frequently Kafka adds an index entry to its offset index. The default setting ensures that we index a message roughly every 4096 bytes. More indexing allows reads to jump closer to the exact position in the log but makes the index larger. You probably don't need to change this.</p>
+<p>This setting controls how frequently Kafka adds entries to its offset index and, conditionally, to its time index. After appending a batch of messages, if the total bytes written since the last index entry exceed this value, Kafka will:</p>
+<ul>
+<li>Add an entry to the offset index for the batch's last offset.</li>
+<li>Attempt to add an entry to the time index if the batch's maximum timestamp is greater than the last indexed timestamp.</li>
+</ul>
+<p>The default setting ensures that we index a message roughly every 4096 bytes. More frequent indexing allows reads to jump closer to the exact position in the log but results in larger index files. You probably don't need to change this.</p>
 <table><tbody>
 <tr><th>Type:</th><td>int</td></tr>
 <tr><th>Default:</th><td>4096 (4 kibibytes)</td></tr>

--- a/40/generated/topic_config.html
+++ b/40/generated/topic_config.html
@@ -111,12 +111,7 @@
 </li>
 <li>
 <h4><a id="index.interval.bytes"></a><a id="topicconfigs_index.interval.bytes" href="#topicconfigs_index.interval.bytes">index.interval.bytes</a></h4>
-<p>This setting controls how frequently Kafka adds entries to its offset index and, conditionally, to its time index. After appending a batch of messages, if the total bytes written since the last index entry exceed this value, Kafka will:</p>
-<ul>
-<li>Add an entry to the offset index for the batch's last offset.</li>
-<li>Attempt to add an entry to the time index if the batch's maximum timestamp is greater than the last indexed timestamp.</li>
-</ul>
-<p>The default setting ensures that we index a message roughly every 4096 bytes. More frequent indexing allows reads to jump closer to the exact position in the log but results in larger index files. You probably don't need to change this.</p>
+<p>This setting controls how frequently Kafka adds entries to its offset index and, conditionally, to its time index. The default setting ensures that we index a message roughly every 4096 bytes. More frequent indexing allows reads to jump closer to the exact position in the log but results in larger index files. You probably don't need to change this.<p> Note: the time index will be inserted only when the timestamp is greater than the last indexed timestamp.</p></p>
 <table><tbody>
 <tr><th>Type:</th><td>int</td></tr>
 <tr><th>Default:</th><td>4096 (4 kibibytes)</td></tr>


### PR DESCRIPTION
Update docs to note index.interval.bytes sets entry frequency for offset index and, conditionally, time index.