### PR TITLE
MINOR: Update the definition of Average Poll Idle Ratio in KRaft monitoring metrics.

### DIFF
--- a/35/ops.html
+++ b/35/ops.html
@@ -1899,7 +1899,7 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
   </tr>
   <tr>
     <td>Average Poll Idle Ratio</td>
-    <td>The average fraction of time the client's poll() is idle as opposed to waiting for the user code to process records.</td>
+    <td>The ratio of time the Raft IO thread is idle as opposed to doing work (e.g. handling requests or replicating from the leader)</td>
     <td>kafka.server:type=raft-metrics,name=poll-idle-ratio-avg</td>
   </tr>
   </tbody>

--- a/36/ops.html
+++ b/36/ops.html
@@ -1987,7 +1987,7 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
   </tr>
   <tr>
     <td>Average Poll Idle Ratio</td>
-    <td>The average fraction of time the client's poll() is idle as opposed to waiting for the user code to process records.</td>
+    <td>The ratio of time the Raft IO thread is idle as opposed to doing work (e.g. handling requests or replicating from the leader)</td>
     <td>kafka.server:type=raft-metrics,name=poll-idle-ratio-avg</td>
   </tr>
   <tr>

--- a/37/ops.html
+++ b/37/ops.html
@@ -2053,7 +2053,7 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
   </tr>
   <tr>
     <td>Average Poll Idle Ratio</td>
-    <td>The average fraction of time the client's poll() is idle as opposed to waiting for the user code to process records.</td>
+    <td>The ratio of time the Raft IO thread is idle as opposed to doing work (e.g. handling requests or replicating from the leader)</td>
     <td>kafka.server:type=raft-metrics,name=poll-idle-ratio-avg</td>
   </tr>
   <tr>

--- a/38/ops.html
+++ b/38/ops.html
@@ -2011,7 +2011,7 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
   </tr>
   <tr>
     <td>Average Poll Idle Ratio</td>
-    <td>The average fraction of time the client's poll() is idle as opposed to waiting for the user code to process records.</td>
+    <td>The ratio of time the Raft IO thread is idle as opposed to doing work (e.g. handling requests or replicating from the leader)</td>
     <td>kafka.server:type=raft-metrics,name=poll-idle-ratio-avg</td>
   </tr>
   <tr>

--- a/39/ops.html
+++ b/39/ops.html
@@ -2035,7 +2035,7 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
   </tr>
   <tr>
     <td>Average Poll Idle Ratio</td>
-    <td>The average fraction of time the client's poll() is idle as opposed to waiting for the user code to process records.</td>
+    <td>The ratio of time the Raft IO thread is idle as opposed to doing work (e.g. handling requests or replicating from the leader)</td>
     <td>kafka.server:type=raft-metrics,name=poll-idle-ratio-avg</td>
   </tr>
   <tr>

--- a/40/ops.html
+++ b/40/ops.html
@@ -2118,7 +2118,7 @@ These metrics are reported on both Controllers and Brokers in a KRaft Cluster
   </tr>
   <tr>
     <td>Average Poll Idle Ratio</td>
-    <td>The average fraction of time the client's poll() is idle as opposed to waiting for the user code to process records.</td>
+    <td>The ratio of time the Raft IO thread is idle as opposed to doing work (e.g. handling requests or replicating from the leader)</td>
     <td>kafka.server:type=raft-metrics</td>
   </tr>
   <tr>


### PR DESCRIPTION
The definition of the average poll idle ratio was changed in [KAFKA-14664](https://github.com/apache/kafka/pull/13207), but the doc has not yet been updated to reflect the new [definition](https://kafka.apache.org/documentation/#kraft_monitoring). 


<img width="651" height="110" alt="Screenshot 2025-07-23 at 10 14 47 AM" src="https://github.com/user-attachments/assets/6d354905-6f87-4d05-a35c-f1dceeb798bc" />
