### PR TITLE
Updated the documentation to align with broker changes.

### DIFF
--- a/39/generated/kafka_config.html
+++ b/39/generated/kafka_config.html
@@ -1325,7 +1325,7 @@
 <table><tbody>
 <tr><th>Type:</th><td>list</td></tr>
 <tr><th>Default:</th><td>classic</td></tr>
-<tr><th>Valid Values:</th><td>[consumer, classic, share]</td></tr>
+<tr><th>Valid Values:</th><td>[consumer, classic]</td></tr>
 <tr><th>Importance:</th><td>medium</td></tr>
 <tr><th>Update Mode:</th><td>read-only</td></tr>
 </tbody></table>

--- a/40/generated/kafka_config.html
+++ b/40/generated/kafka_config.html
@@ -1292,7 +1292,7 @@
 <table><tbody>
 <tr><th>Type:</th><td>list</td></tr>
 <tr><th>Default:</th><td>classic,consumer</td></tr>
-<tr><th>Valid Values:</th><td>[consumer, classic, share]</td></tr>
+<tr><th>Valid Values:</th><td>[consumer, classic]</td></tr>
 <tr><th>Importance:</th><td>medium</td></tr>
 <tr><th>Update Mode:</th><td>read-only</td></tr>
 </tbody></table>

--- a/41/generated/kafka_config.html
+++ b/41/generated/kafka_config.html
@@ -1292,7 +1292,7 @@
 <table><tbody>
 <tr><th>Type:</th><td>list</td></tr>
 <tr><th>Default:</th><td>classic,consumer,streams</td></tr>
-<tr><th>Valid Values:</th><td>[consumer, classic, share, streams]</td></tr>
+<tr><th>Valid Values:</th><td>[consumer, classic, streams]</td></tr>
 <tr><th>Importance:</th><td>medium</td></tr>
 <tr><th>Update Mode:</th><td>read-only</td></tr>
 </tbody></table>


### PR DESCRIPTION
Updated the documentation to align with broker changes. The config group.coordinator.rebalance.protocols no longer accepts share as a valid value. Share Groups should instead be enabled through the share.version
Kafka related PR: https://github.com/apache/kafka/pull/20466
Reviewers: Christo Lolov[christololov@gmail.com](mailto:christololov@gmail.com)