### PR TITLE
KAFKA-19748: Add a note in docs about memory leak in Kafka Streams 4.1.0

### DIFF
--- a/41/streams/upgrade-guide.html
+++ b/41/streams/upgrade-guide.html
@@ -141,6 +141,8 @@
 
     <h3><a id="streams_api_changes_410" href="#streams_api_changes_410">Streams API changes in 4.1.0</a></h3>
 
+    <p><b>Note:</b> Kafka Streams 4.1.0 contains a critical memory leak bug (<a href="https://issues.apache.org/jira/browse/KAFKA-19748">KAFKA-19748</a>) that affects users of range scans and certain DSL operators (session windows, sliding windows, stream-stream joins, foreign-key joins). Users running Kafka Streams should consider upgrading directly to 4.1.1 when available.</p>
+
     <h4>Early Access of the Streams Rebalance Protocol</h4>
 
     <p>

--- a/41/upgrade.html
+++ b/41/upgrade.html
@@ -21,6 +21,8 @@
 
 <h4><a id="upgrade_4_1_0" href="#upgrade_4_1_0">Upgrading to 4.1.0</a></h4>
 
+<p><b>Note:</b> Kafka Streams 4.1.0 contains a critical memory leak bug (<a href="https://issues.apache.org/jira/browse/KAFKA-19748">KAFKA-19748</a>) that affects users of range scans and certain DSL operators (session windows, sliding windows, stream-stream joins, foreign-key joins). Users running Kafka Streams should consider upgrading directly to 4.1.1 when available.</p>
+
 <h5><a id="upgrade_4_1_0_from" href="#upgrade_4_1_0_from">Upgrading Servers to 4.1.0 from any version 3.3.x through 4.0.x</a></h5>
     <h5><a id="upgrade_410_notable" href="#upgrade_410_notable">Notable changes in 4.1.0</a></h5>
         <ul>


### PR DESCRIPTION
Added a note regarding the memory leak bug in the documentation.

### Preview of `/41/documentation/streams/upgrade-guide`

<img width="1452" height="830" alt="upgrade-guide" src="https://github.com/user-attachments/assets/fcb52d08-1351-4f03-ad89-baf1b9e8eac0" />

### Preview of `/41/documentation/#upgrade`

<img width="1452" height="830" alt="upgrade" src="https://github.com/user-attachments/assets/1114d3f1-f6ca-4a00-885f-f677d18d4095" />
