### PR TITLE
KAFKA-19835: The Content-Security-Policy header must not be overridden

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,4 +10,6 @@ RewriteRule ^/?(\d+)/javadoc - [S=2]
 RewriteRule ^/?(\d+)/images/ - [S=1]
 RewriteCond $2 !=protocol
 RewriteRule ^/?(\d+)/([a-z]+)(\.html)? /$1/documentation#$2 [R=302,L,NE]
-Header set Content-Security-Policy "frame-src https://youtube.com https://www.youtube.com"
+
+# Adding YouTube for embedded videos to CSP header, more details please check https://infra.apache.org/tools/csp.html
+SetEnv CSP_PROJECT_DOMAINS "https://youtube.com https://www.youtube.com"

--- a/.htaccess
+++ b/.htaccess
@@ -11,5 +11,7 @@ RewriteRule ^/?(\d+)/images/ - [S=1]
 RewriteCond $2 !=protocol
 RewriteRule ^/?(\d+)/([a-z]+)(\.html)? /$1/documentation#$2 [R=302,L,NE]
 
-# Adding YouTube for embedded videos to CSP header, more details please check https://infra.apache.org/tools/csp.html
+# Kafka website embeds YouTube tutorial videos in many documentation pages e.g. QuickStart, Kafka Streams which using <iframe> tags.
+# Without adding YouTube domains to the CSP (Content-Security-Policy), browsers will block these iframes and videos won't display.
+# More details please check https://infra.apache.org/tools/csp.html.
 SetEnv CSP_PROJECT_DOMAINS "https://youtube.com https://www.youtube.com"


### PR DESCRIPTION
The Content-Security-Policy header must not be overridden.
There is now a standard way to add local exceptions to the CSP:
https://infra.apache.org/tools/csp.html
