### PR TITLE
KAFKA-19751: KAFKA-19751: add Java 21, 23 to 3.9 supported version

### DIFF
--- a/39/ops.html
+++ b/39/ops.html
@@ -1249,10 +1249,10 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Java 8, Java 11, and Java 17 are supported.
+  Java 8, Java 11, Java 17, Java 21 and Java 23 are supported.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
-  has been deprecated since Apache Kafka 3.7. Both will be removed in Apache Kafka 4.0.
+  has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.
   <p>
   Java 11 and later versions perform significantly better if TLS is enabled, so they are highly recommended (they also include a number of other
   performance improvements: G1GC, CRC32C, Compact Strings, Thread-Local Handshakes and more).


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-19751

reviewers: Chia-Ping Tsai <chia7712@gmail.com>