### PR TITLE
KAFKA-19897 Document support for testing with java 25

### DIFF
--- a/39/ops.html
+++ b/39/ops.html
@@ -1249,7 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Build and test Apache Kafka with Java 8, 11, 17 and 21. Set the release parameter in javac and scalac
+  Build and test Apache Kafka with Java 8, 11, 17, 21, and 23. Set the release parameter in javac and scalac
 to 8 to ensure the generated binaries are compatible with Java 8 or higher (independently of the Java version
 used for compilation).
   <p>

--- a/39/ops.html
+++ b/39/ops.html
@@ -1249,7 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Java 8, Java 11, Java 17, Java 21 and Java 23 are supported.
+  Java 8, Java 11, Java 17, and Java 21 are supported. Java 23 is used in CI pipelines to verify compatibility, but it's not officially supported because it's non-LTS version.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.

--- a/39/ops.html
+++ b/39/ops.html
@@ -1249,7 +1249,9 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Java 8, Java 11, Java 17, and Java 21 are supported. Java 23 is used in CI pipelines to verify compatibility, but it's not officially supported because it's non-LTS version.
+  Build and test Apache Kafka with Java 8, 11, 17 and 21. Set the release parameter in javac and scalac
+to 8 to ensure the generated binaries are compatible with Java 8 or higher (independently of the Java version
+used for compilation).
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.

--- a/39/ops.html
+++ b/39/ops.html
@@ -1249,7 +1249,9 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Build and test Apache Kafka with Java 8, 11, 17, 21, and 25.
+  Java 8, 11, 17, 21, and 23 are fully supported while Java 25 is supported for unit and integration tests only.
+  Support for versions newer than the most recent LTS version are best-effort and the project typically only tests with the
+  most recent non LTS version.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.

--- a/39/ops.html
+++ b/39/ops.html
@@ -1249,9 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Java 8, 11, 17, 21, and 23 are fully supported while Java 25 is supported for unit and integration tests only.
-  Support for versions newer than the most recent LTS version are best-effort and the project typically only tests with the
-  most recent non LTS version.
+  Java 8, 11, 17, and 21 are fully supported while Java 25 has received limited validation and support is best-effort.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.

--- a/39/ops.html
+++ b/39/ops.html
@@ -1249,9 +1249,7 @@ queued.max.requests=[number of concurrent requests]</code></pre>
 
   <h3 class="anchor-heading"><a id="java" class="anchor-link"></a><a href="#java">6.6 Java Version</a></h3>
 
-  Build and test Apache Kafka with Java 8, 11, 17, 21, and 23. Set the release parameter in javac and scalac
-to 8 to ensure the generated binaries are compatible with Java 8 or higher (independently of the Java version
-used for compilation).
+  Build and test Apache Kafka with Java 8, 11, 17, 21, and 25.
   <p>
   Note that Java 8 support project-wide has been deprecated since Apache Kafka 3.0 and Java 11 support for the broker and tools
   has been deprecated since Apache Kafka 3.7. Both have been removed in Apache Kafka 4.0.


### PR DESCRIPTION
Updates the Apache Kafka operations guide documentation to include limited support for testing with Java 25 and clarifies the project's best-effort support policy for newer Java versions.

Reviewers: Ismael Juma <ismael@juma.me.uk>, Stig Døssing <stigdoessing@gmail.com>, Greg Harris <gharris1727@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>