### PR TITLE
KAFKA-19988: change example kafka-storage command in the migration section

### DIFF
--- a/39/ops.html
+++ b/39/ops.html
@@ -4080,7 +4080,7 @@ inter.broker.listener.name=PLAINTEXT
     Follow these steps to format and start a new standalone controller:
   </p>
   <pre><code class="language-bash"># Save the previously retrieved cluster ID from ZooKeeper in a variable called zk-cluster-id
-$ bin/kafka-storage.sh format --standalone -t &lt;zk-cluster-id&gt; -c config/kraft/controller.properties
+$ bin/kafka-storage.sh format --standalone --cluster-id=&lt;zk-cluster-id&gt; -c config/kraft/controller.properties
 $ bin/kafka-server-start.sh config/kraft/controller.properties</code></pre>
 
   <p>Note: The migration can stall if the <a href="#zk_authz_migration">ZooKeeper Security Migration Tool</a> was previously executed (see <a href="https://issues.apache.org/jira/browse/KAFKA-19480">KAFKA-19480</a> for more details). As a workaround, the malformed "/migration" node can be removed from ZooKeeper by running <code>delete /migration</code> with the <code>zookeeper-shell.sh</code> CLI tool.</p>


### PR DESCRIPTION
When preparing for the migration, there is a small chance that the retrieved cluster id from ZooKeeper contains a leading dash. Currently the 3.9 documentation specifies the following during the step "Provisioning the KRaft controller quorum":
```
# Save the previously retrieved cluster ID from ZooKeeper in a variable called zk-cluster-id
$ bin/kafka-storage.sh format --standalone -t <zk-cluster-id> -c config/kraft/controller.properties
```
However the above command will fail with a less fortunate cluster id like `-Yh6XyBIQ9CeAlMwJ8f7Hg`, eg.:
```
bin/kafka-storage.sh format --standalone -t -Yh6XyBIQ9CeAlMwJ8f7Hg -c config/server.properties

25/12/12 09:24:54 INFO  utils.Log4jControllerRegistration$: [main]: Registered `kafka:type=kafka.Log4jController` MBean
usage: kafka-storage format [-h] --config CONFIG --cluster-id CLUSTER_ID [--add-scram ADD_SCRAM] [--ignore-formatted] [--release-version RELEASE_VERSION] [--feature FEATURE] [--standalone |
                     --no-initial-controllers | --initial-controllers INITIAL_CONTROLLERS]
kafka-storage: error: argument --cluster-id/-t: expected one argument
```

A similar problem came up with KRaft which was addressed in [KAFKA-13741](https://issues.apache.org/jira/browse/KAFKA-13741). In our case the cluster id is already specified, there is no way to change it. I was able to come up with a simple solution by using the full name of the argument like `--cluster-id=<zk-cluster-id>` instead of the shorthand `-t <zk-cluster-id>`. Full example:
```
bin/kafka-storage.sh format --cluster-id=-Yh6XyBIQ9CeAlMwJ8f7Hg -c config/kraft/controller.properties
```
I would propose to change the documentation based on my findings so we will be able to cover also ZooKeeper based cluster ids with a leading dash.