### PR TITLE
MINOR: fix heading of Errant Record Reporter

### DIFF
--- a/content/en/26/kafka-connect/connector-development-guide.md
+++ b/content/en/26/kafka-connect/connector-development-guide.md
@@ -181,7 +181,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     

--- a/content/en/27/kafka-connect/connector-development-guide.md
+++ b/content/en/27/kafka-connect/connector-development-guide.md
@@ -188,7 +188,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     

--- a/content/en/28/kafka-connect/connector-development-guide.md
+++ b/content/en/28/kafka-connect/connector-development-guide.md
@@ -188,7 +188,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     

--- a/content/en/30/kafka-connect/connector-development-guide.md
+++ b/content/en/30/kafka-connect/connector-development-guide.md
@@ -188,7 +188,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     

--- a/content/en/31/kafka-connect/connector-development-guide.md
+++ b/content/en/31/kafka-connect/connector-development-guide.md
@@ -188,7 +188,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     

--- a/content/en/32/kafka-connect/connector-development-guide.md
+++ b/content/en/32/kafka-connect/connector-development-guide.md
@@ -181,7 +181,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     

--- a/content/en/35/kafka-connect/connector-development-guide.md
+++ b/content/en/35/kafka-connect/connector-development-guide.md
@@ -188,7 +188,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     

--- a/content/en/36/kafka-connect/connector-development-guide.md
+++ b/content/en/36/kafka-connect/connector-development-guide.md
@@ -195,7 +195,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     

--- a/content/en/37/kafka-connect/connector-development-guide.md
+++ b/content/en/37/kafka-connect/connector-development-guide.md
@@ -195,7 +195,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     

--- a/content/en/38/kafka-connect/connector-development-guide.md
+++ b/content/en/38/kafka-connect/connector-development-guide.md
@@ -197,7 +197,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
 

--- a/content/en/39/kafka-connect/connector-development-guide.md
+++ b/content/en/39/kafka-connect/connector-development-guide.md
@@ -197,7 +197,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
 

--- a/content/en/40/kafka-connect/connector-development-guide.md
+++ b/content/en/40/kafka-connect/connector-development-guide.md
@@ -197,7 +197,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
 

--- a/content/en/41/kafka-connect/connector-development-guide.md
+++ b/content/en/41/kafka-connect/connector-development-guide.md
@@ -197,7 +197,7 @@ The `SinkTask` documentation contains full details, but this interface is nearly
 
 The `flush()` method is used during the offset commit process, which allows tasks to recover from failures and resume from a safe point such that no events will be missed. The method should push any outstanding data to the destination system and then block until the write has been acknowledged. The `offsets` parameter can often be ignored, but is useful in some cases where implementations want to store offset information in the destination store to provide exactly-once delivery. For example, an HDFS connector could do this and use atomic move operations to make sure the `flush()` operation atomically commits the data and offsets to a final location in HDFS.
 
-### [Errant Record Reporter](connect_errantrecordreporter)
+### Errant Record Reporter
 
 When error reporting is enabled for a connector, the connector can use an `ErrantRecordReporter` to report problems with individual records sent to a sink connector. The following example shows how a connector's `SinkTask` subclass might obtain and use the `ErrantRecordReporter`, safely handling a null reporter when the DLQ is not enabled or when the connector is installed in an older Connect runtime that doesn't have this reporter feature:
     


### PR DESCRIPTION
Remove the wrong anchor of Errant Record Reporter in `kafka-connect/connector-development-guide.md`.

Before
<img width="600" height="480" alt="before_1" src="https://github.com/user-attachments/assets/b19869cf-c4a2-47b5-9f8d-f97b6c64537a" />
<img width="600" height="480" alt="before_2" src="https://github.com/user-attachments/assets/b208090b-bf96-44d7-ab41-5f689fcf4560" />

After
<img width="600" height="480" alt="after_1" src="https://github.com/user-attachments/assets/5aab6037-fe9f-461f-89f1-3b47e1fc138f" />
<img width="600" height="480" alt="after_2" src="https://github.com/user-attachments/assets/e5323c9a-9cfa-47b8-bffa-ee24ff769d37" />

Follow up to https://github.com/apache/kafka/pull/20313