### PR TITLE
KAFKA-20039: Fix Docker mount permission errors on SELinux-enabled systems

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Build Hugo site
       run: |
         # Build the site using the multi-platform Hugo image
-        docker run --rm -v $(pwd):/src hvishwanath/hugo:v0.123.7-ext-multiplatform \
+        docker run --rm -v $(pwd):/src:z hvishwanath/hugo:v0.123.7-ext-multiplatform \
           --minify \
           --destination output
     

--- a/Makefile
+++ b/Makefile
@@ -29,14 +29,14 @@ hugo-base-multi-platform: buildx-setup
 # Build the static site using Docker
 build: 
 	docker pull $(DOCKER_IMAGE)
-	docker run --rm -v $(PWD):/src $(DOCKER_IMAGE) \
+	docker run --rm -v $(PWD):/src:z $(DOCKER_IMAGE) \
 		--minify \
 		--destination $(OUTPUT_DIR)
 
 # Serve the site locally using Docker (development)
 serve: 
 	docker pull $(DOCKER_IMAGE)
-	docker run --rm -it -v $(PWD):/src -p 1313:1313 $(DOCKER_IMAGE) \
+	docker run --rm -it -v $(PWD):/src:z -p 1313:1313 $(DOCKER_IMAGE) \
 		server \
 		--bind 0.0.0.0 \
 		--destination $(OUTPUT_DIR) \


### PR DESCRIPTION
### Description
This PR fixes Docker mount permission errors on SELinux-enabled systems by appending the `:z` suffix to volume mounts.

- Modified `Makefile` (build and serve targets)
- Modified `.github/workflows/build-docker-image.yml`

The `:z` flag instructs Docker to relabel the volume content with the correct SELinux context. On non-SELinux systems, this flag is ignored by Docker, ensuring backward compatibility.

### JIRA
https://issues.apache.org/jira/browse/KAFKA-20039

### Testing & Verification
I have verified this change locally to ensure no regression on non-SELinux environments.

**Environment:**
- OS: macOS 14.1.2
- Docker Version: 28.5.2
- SELinux: Disabled/Not present

**Steps Performed:**
1. Ran `make build`: Verified that the static site generates successfully without errors.
2. Ran `make serve`: Verified that the local server starts at http://localhost:1313 without permission errors.

**Result:**
The build passed and the site is accessible, confirming that the `:z` flag is safely ignored on non-SELinux systems.

**Screenshots:**
<img width="1024" height="720" alt="image" src="https://github.com/user-attachments/assets/b51b6675-5321-43a7-8605-f5454b5d9d92" />
<img width="1023" height="899" alt="image" src="https://github.com/user-attachments/assets/9f7da505-c25e-436b-95c7-7618ad948e27" />

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>