### PR TITLE
Handling `/KEYS` redirect - Implement Front Matter Support for External Redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,8 +193,25 @@ Detailed information about the Front Matter fields used in this site:
 - `type`: Used to specify the layout type (e.g., `type: docs` for documentation pages).
 - `aliases`: (Optional) List of old URLs that should redirect to this page.
 - `url`: (Optional) Overrides the default URL path constructed from the filename.
+- `redirect_to`: (Optional) Sets up a client-side meta-refresh redirect to an external URL.
 
 For more details, see the [Hugo Front Matter Documentation](https://gohugo.io/content-management/front-matter/).
+
+### Managing Redirects
+
+To create a client-side redirect to an external URL, use the `redirect_to` Front Matter field.
+
+1. Create a markdown file at the desired path (e.g., `content/en/KEYS.md` for `/KEYS`).
+2. Add the `redirect_to` field in the Front Matter.
+
+```yaml
+---
+title: KEYS Redirect
+redirect_to: https://downloads.apache.org/kafka/KEYS
+---
+```
+
+This generates a standard HTML meta-refresh redirect. Note that this is a client-side redirect; command-line tools like `curl` will not follow it automatically unless they parse the HTML.
 
 ### Dynamic Version Linking
 

--- a/content/en/KEYS.md
+++ b/content/en/KEYS.md
@@ -1,0 +1,4 @@
+---
+title: KEYS Redirect
+redirect_to: https://downloads.apache.org/kafka/KEYS
+---

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -7,3 +7,8 @@
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
+
+{{ if .Params.redirect_to }}
+<meta http-equiv="refresh" content="0; url={{ .Params.redirect_to }}" />
+<link rel="canonical" href="{{ .Params.redirect_to }}" />
+{{ end }}


### PR DESCRIPTION
This PR introduces a redirect_to front matter parameter, allowing any content page to easily set up an external client-side redirect. We use this new capability to redirect `/KEYS` to `https://downloads.apache.org/kafka/KEYS`.

- Updated `layouts/partials/hooks/head-end.html` to check for the redirect_to parameter. If present, it injects the standard `<meta http-equiv="refresh" ... />` tag and a canonical link.
- Created `content/en/KEYS.md` utilizing this new parameter.

This implements the standard "Meta Refresh" method for redirects, similar to [Hugo's internal Aliases](https://gohugo.io/content-management/urls/#aliases). It utilizes [Hugo Partial Hooks](https://github.com/google/docsy/blob/master/layouts/partials/hooks/head-end.html) to inject the logic into the `<head>` of the page without overriding the entire theme layout.

cc @mumrah 

> Note: This generates a standard HTML meta-refresh redirect. Note that this is a client-side redirect; command-line tools like `curl` will not follow it automatically unless they parse the HTML.

