### PR TITLE
KAFKA-20051: Avoid npm engine warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
   "optionalDependencies": {
     "npm-check-updates": "^19.3.1"
   },
+  "overrides": {
+    "read-package-up": "11.0.0",
+    "read-pkg": "9.0.1"
+  },
   "private": true,
   "prettier": {
     "proseWrap": "always",


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/KAFKA-20051

Summary:
- add npm overrides to keep read-package-up/read-pkg on Node 20.13-compatible versions
- avoid pulling normalize-package-data@8/hosted-git-info@9 which require Node >=20.17

Motivation:
- current hugo-extended dependency chain emits EBADENGINE warnings with Node 20.13.x

Validation:
- npm install --ignore-scripts