### PR TITLE
Fix typos in KRaft Documentation

### DIFF
--- a/content/en/33/operations/kraft.md
+++ b/content/en/33/operations/kraft.md
@@ -92,7 +92,7 @@ The `kafka-dump-log` tool can be used to debug the log segments and snapshots fo
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000000.log
 
-This command decodes and prints the recrods in the a cluster metadata snapshot:
+This command decodes and prints the records in a cluster metadata snapshot:
     
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000100-0000000001.checkpoint

--- a/content/en/34/operations/kraft.md
+++ b/content/en/34/operations/kraft.md
@@ -92,7 +92,7 @@ The `kafka-dump-log` tool can be used to debug the log segments and snapshots fo
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000000.log
 
-This command decodes and prints the recrods in the a cluster metadata snapshot:
+This command decodes and prints the records in a cluster metadata snapshot:
     
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000100-0000000001.checkpoint

--- a/content/en/35/operations/kraft.md
+++ b/content/en/35/operations/kraft.md
@@ -92,7 +92,7 @@ The `kafka-dump-log` tool can be used to debug the log segments and snapshots fo
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000000.log
 
-This command decodes and prints the recrods in the a cluster metadata snapshot:
+This command decodes and prints the records in a cluster metadata snapshot:
     
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000100-0000000001.checkpoint

--- a/content/en/36/operations/kraft.md
+++ b/content/en/36/operations/kraft.md
@@ -92,7 +92,7 @@ The `kafka-dump-log` tool can be used to debug the log segments and snapshots fo
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000000.log
 
-This command decodes and prints the records in the a cluster metadata snapshot:
+This command decodes and prints the records in a cluster metadata snapshot:
     
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000100-0000000001.checkpoint

--- a/content/en/37/operations/kraft.md
+++ b/content/en/37/operations/kraft.md
@@ -92,7 +92,7 @@ The `kafka-dump-log` tool can be used to debug the log segments and snapshots fo
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000000.log
 
-This command decodes and prints the records in the a cluster metadata snapshot:
+This command decodes and prints the records in a cluster metadata snapshot:
     
     
       > bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000100-0000000001.checkpoint

--- a/content/en/38/operations/kraft.md
+++ b/content/en/38/operations/kraft.md
@@ -92,7 +92,7 @@ The `kafka-dump-log` tool can be used to debug the log segments and snapshots fo
     
     $ bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000000.log
 
-This command decodes and prints the records in the a cluster metadata snapshot:
+This command decodes and prints the records in a cluster metadata snapshot:
     
     
     $ bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000100-0000000001.checkpoint

--- a/content/en/39/operations/kraft.md
+++ b/content/en/39/operations/kraft.md
@@ -201,7 +201,7 @@ The `kafka-dump-log` tool can be used to debug the log segments and snapshots fo
     
     $ bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000000.log
 
-This command decodes and prints the records in the a cluster metadata snapshot:
+This command decodes and prints the records in a cluster metadata snapshot:
     
     
     $ bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000100-0000000001.checkpoint

--- a/content/en/40/operations/kraft.md
+++ b/content/en/40/operations/kraft.md
@@ -200,7 +200,7 @@ The kafka-dump-log.sh tool can be used to debug the log segments and snapshots f
     
     $ bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000000.log
 
-This command decodes and prints the records in the a cluster metadata snapshot:
+This command decodes and prints the records in a cluster metadata snapshot:
     
     
     $ bin/kafka-dump-log.sh --cluster-metadata-decoder --files metadata_log_dir/__cluster_metadata-0/00000000000000000100-0000000001.checkpoint


### PR DESCRIPTION
### Description
While reading the 3.8 documentation I noticed a typo. I also found similar typos in other versions so I updated those as well.