### PR TITLE
KAFKA-20073: Address invalid encoding for security mailto links

### DIFF
--- a/content/en/community/project_security.md
+++ b/content/en/community/project_security.md
@@ -26,7 +26,7 @@ aliases:
 
 # Kafka security
 
-The Apache Software Foundation takes security issues very seriously. Apache Kafka® specifically offers security features and is responsive to issues around its features. If you have any concern around Kafka Security or believe you have uncovered a vulnerability, we suggest that you get in touch via the e-mail address [security@kafka.apache.org](mailto:security@kafka.apache.org?Subject=\[SECURITY\] My security issue). In the message, try to provide a description of the issue and ideally a way of reproducing it. The security team will get back to you after assessing the description. 
+The Apache Software Foundation takes security issues very seriously. Apache Kafka® specifically offers security features and is responsive to issues around its features. If you have any concern around Kafka Security or believe you have uncovered a vulnerability, we suggest that you get in touch via the e-mail address [security@kafka.apache.org](mailto:security@kafka.apache.org?subject=%5BSECURITY%5D%20My%20security%20issue). In the message, try to provide a description of the issue and ideally a way of reproducing it. The security team will get back to you after assessing the description. 
 
 Note that this security address should be used only for undisclosed vulnerabilities. Dealing with fixed issues or general questions on how to use the security features should be handled regularly via the user and the dev lists. **Please report any security problems to the project security address before disclosing it publicly.**
 
@@ -36,13 +36,13 @@ For a list of security issues fixed in released versions of Apache Kafka, see [C
 
 ## Advisories for dependencies
 
-Many organizations use 'security scanning' tools to detect components for which advisories exist. While we generally encourage using such tools, since they are an important way users are notified of risks, our experience is that they produce a lot of false positives: when a dependency of Kafka contains a vulnerability, it is likely Kafka is using it in a way that is not affected. As such, we do not consider the fact that an advisory has been published for a Kafka dependency sensitive. Only when additional analysis suggests Kafka may be affected by the problem, we ask you to report this finding privately through [security@kafka.apache.org](mailto:security@kafka.apache.org?Subject=\[SECURITY\] My security issue). 
+Many organizations use 'security scanning' tools to detect components for which advisories exist. While we generally encourage using such tools, since they are an important way users are notified of risks, our experience is that they produce a lot of false positives: when a dependency of Kafka contains a vulnerability, it is likely Kafka is using it in a way that is not affected. As such, we do not consider the fact that an advisory has been published for a Kafka dependency sensitive. Only when additional analysis suggests Kafka may be affected by the problem, we ask you to report this finding privately through [security@kafka.apache.org](mailto:security@kafka.apache.org?subject=%5BSECURITY%5D%20My%20security%20issue). 
 
 When handling such warnings, you can: 
 
   * Check if our [DependencyCheck suppressions](https://github.com/apache/kafka/blob/trunk/gradle/resources/dependencycheck-suppressions.xml) contain any information on this advisory. 
   * See if there is any discussion on this advisory in the [issue tracker](https://issues.apache.org/jira/browse/KAFKA)
   * Do your own analysis on whether this advisory affects Kafka. 
-    * If it seems it might, report this finding privately through [security@kafka.apache.org](mailto:security@kafka.apache.org?Subject=\[SECURITY\] My security issue). 
+    * If it seems it might, report this finding privately through [security@kafka.apache.org](mailto:security@kafka.apache.org?subject=%5BSECURITY%5D%20My%20security%20issue). 
     * If it seems not to, [contribute](/contributing.html) a section to our [DependencyCheck suppressions](https://github.com/apache/kafka/blob/trunk/gradle/resources/dependencycheck-suppressions.xml) explaining why it is not affected.  
 


### PR DESCRIPTION
## Description

This pull request addresses [KAFKA-20073](https://issues.apache.org/jira/browse/KAFKA-20073) which details several links within the Project Security section of the site that fail to render properly. This is because the supplied square brackets within the links need to be explicitly encoded to render properly (e.g., `Subject=\[SECURITY\] ` -> `subject=%5BSECURITY%5D`).

## Example(s) of Applied Fix

#### Example of Rendered Project Security Section (Post-fix)
<img width="1120" height="873" alt="Project-Security-Postfix" src="https://github.com/user-attachments/assets/cab01a23-7273-4675-b669-2fa046510427" />

#### Example of Functional Mailto Link
<img width="868" height="809" alt="Mail Link Results" src="https://github.com/user-attachments/assets/bc7875f0-1817-4fd9-8869-9fb71ece8e4f" />
