### PR TITLE
MINOR: add redirect to 4.2 blog

### DIFF
--- a/content/en/blog/releases/ak-4.2.0.md
+++ b/content/en/blog/releases/ak-4.2.0.md
@@ -3,6 +3,8 @@ date: 2026-02-17
 title: Apache Kafka 4.2.0 Release Announcement
 linkTitle: AK 4.2.0
 author: Christo Lolov
+aliases:
+  - /blog/2026/01/14/apache-kafka-4.2.0-release-announcement/
 ---
 
 <!--


### PR DESCRIPTION
Alias so that the initial url for the blog post (included wrong date) automatically redirects the the 4.2 blog.

Tried it locally, the old broken link is fixed:
https://kafka.apache.org/blog/2026/01/14/apache-kafka-4.2.0-release-announcement/ -> now redirects to the 4.2 blog https://kafka.apache.org/blog/2026/02/17/apache-kafka-4.2.0-release-announcement/