### PR TITLE
KAFKA-20200: fix broken link on project security page to cve list

### DIFF
--- a/content/en/community/project_security.md
+++ b/content/en/community/project_security.md
@@ -32,7 +32,7 @@ Note that this security address should be used only for undisclosed vulnerabilit
 
 The ASF Security team maintains a page with a description of how vulnerabilities are handled, check their [Web page](http://www.apache.org/security/) for more information. 
 
-For a list of security issues fixed in released versions of Apache Kafka, see [CVE list](cve-list). 
+For a list of security issues fixed in released versions of Apache Kafka, see [CVE list](/cve-list.html). 
 
 ## Advisories for dependencies
 


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/KAFKA-20200

Summary: fix the broken link on project security page (the link to CVE list page)

Validation: run the patch locally.

Reviewers: Ken Huang <s7133700@gmail.com>, Chia-Ping Tsai <chia7712@gmail.com>