### PR TITLE
MINOR: fix: the broken link of version 0.8.0

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -362,7 +362,7 @@ params:
       url: /081/
       archived_version: true
     - version: "0.8.0"
-      url: /080/
+      url: /08/
       archived_version: true
     - version: "0.7"
       url: /07/


### PR DESCRIPTION
fix the broken link of version 0.8.0 in release
as-is:
<img width="672" height="240" alt="image" src="https://github.com/user-attachments/assets/5cf10337-3437-4b63-a4f4-307562bd4d92" />
to-be:

https://github.com/user-attachments/assets/5624d747-9533-4749-a4ef-4613acdb7d5d

Reviewers: Matthias J. Sax <matthias@confluent.io>, Chia-Ping Tsai <chia7712@gmail.com>

