### PR TITLE
KAFKA-20049: Publish Hugo base image under Apache namespace

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -11,6 +11,7 @@ env:
   # GitHub Container Registry
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  HUGO_BASE_IMAGE: ghcr.io/${{ github.repository }}/hugo:v0.123.7-ext-multiplatform
 
 jobs:
   build-and-push:
@@ -46,10 +47,14 @@ jobs:
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
     
+    - name: Ensure Hugo base image
+      run: |
+        docker pull ${{ env.HUGO_BASE_IMAGE }} || docker build -t ${{ env.HUGO_BASE_IMAGE }} -f Dockerfile.multiplatform .
+
     - name: Build Hugo site
       run: |
-        # Build the site using the multi-platform Hugo image
-        docker run --rm -v $(pwd):/src hvishwanath/hugo:v0.123.7-ext-multiplatform \
+        # Build the site using the Apache-owned multi-platform Hugo image
+        docker run --rm -v $(pwd):/src ${{ env.HUGO_BASE_IMAGE }} \
           --minify \
           --destination output
     

--- a/.github/workflows/build-hugo-base-image.yml
+++ b/.github/workflows/build-hugo-base-image.yml
@@ -1,0 +1,61 @@
+name: Build and Publish Hugo Base Image
+
+on:
+  push:
+    branches: [ markdown ]
+    paths:
+      - Dockerfile.multiplatform
+      - scripts/entrypoint.sh
+      - .github/workflows/build-hugo-base-image.yml
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    branches: [ markdown ]
+    paths:
+      - Dockerfile.multiplatform
+      - scripts/entrypoint.sh
+      - .github/workflows/build-hugo-base-image.yml
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/hugo
+  HUGO_VERSION: 0.123.7
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build and optionally push Hugo base image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./Dockerfile.multiplatform
+        platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ env.HUGO_VERSION }}-ext-multiplatform
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Create build summary
+      run: |
+        echo "## Hugo Base Image" >> $GITHUB_STEP_SUMMARY
+        echo "- **Image**: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ env.HUGO_VERSION }}-ext-multiplatform" >> $GITHUB_STEP_SUMMARY
+        echo "- **Push Enabled**: ${{ github.event_name != 'pull_request' }}" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,8 @@ OUTPUT_DIR := output
 HUGO_VERSION := 0.123.7
 HUGO_BASE_IMAGE := ghcr.io/apache/kafka-site/hugo:v$(HUGO_VERSION)-ext-multiplatform
 DOCKER_IMAGE := $(HUGO_BASE_IMAGE)
-#PROD_IMAGE := hvishwanath/kafka-site-md:1.2.0
-PROD_IMAGE := us-west1-docker.pkg.dev/play-394201/kafka-site-md/kafka-site-md:1.6.0
 
-.PHONY: build serve clean docker-image ensure-hugo-image hugo-base-multi-platform prod-image prod-run buildx-setup ghcr-prod-image
+.PHONY: build serve clean docker-image ensure-hugo-image hugo-base-multi-platform buildx-setup ghcr-prod-image
 
 # Setup buildx for multi-arch builds
 buildx-setup:
@@ -49,20 +47,6 @@ serve: ensure-hugo-image
 		--buildDrafts \
 		--buildFuture
 
-# Build production Nginx image for multiple architectures
-prod-image: build buildx-setup
-	docker buildx build \
-		--platform linux/amd64,linux/arm64 \
-		--tag $(PROD_IMAGE) \
-		--file Dockerfile.prod \
-		--push \
-		.
-
-# Run production image locally
-prod-run: prod-image
-	docker pull $(PROD_IMAGE)
-	docker run --rm -p 8080:80 $(PROD_IMAGE)
-
 # Build and push production image to GHCR
 ghcr-prod-image: build buildx-setup
 	docker buildx build \
@@ -77,5 +61,5 @@ ghcr-prod-image: build buildx-setup
 # Clean the output directory and remove Docker images
 clean:
 	rm -rf $(OUTPUT_DIR)
-	docker rmi $(DOCKER_IMAGE) $(HUGO_BASE_IMAGE) $(PROD_IMAGE)
+	docker rmi $(DOCKER_IMAGE) $(HUGO_BASE_IMAGE)
 	docker buildx rm multiarch || true

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 # Hugo configuration
 OUTPUT_DIR := output
-HUGO_BASE_IMAGE := hvishwanath/hugo:v0.123.7-ext-multiplatform
+HUGO_VERSION := 0.123.7
+HUGO_BASE_IMAGE := ghcr.io/apache/kafka-site/hugo:v$(HUGO_VERSION)-ext-multiplatform
 DOCKER_IMAGE := $(HUGO_BASE_IMAGE)
 #PROD_IMAGE := hvishwanath/kafka-site-md:1.2.0
 PROD_IMAGE := us-west1-docker.pkg.dev/play-394201/kafka-site-md/kafka-site-md:1.6.0
 
-.PHONY: build serve clean docker-image hugo-base-multi-platform prod-image prod-run buildx-setup ghcr-prod-image
+.PHONY: build serve clean docker-image ensure-hugo-image hugo-base-multi-platform prod-image prod-run buildx-setup ghcr-prod-image
 
 # Setup buildx for multi-arch builds
 buildx-setup:
@@ -26,16 +27,19 @@ hugo-base-multi-platform: buildx-setup
 		--push \
 		.
 
+# Pull the published Apache-owned Hugo image, or build it locally if it is not
+# available yet (useful for first-time bootstrapping and PR validation).
+ensure-hugo-image:
+	docker pull $(DOCKER_IMAGE) || docker build -t $(DOCKER_IMAGE) -f Dockerfile.multiplatform .
+
 # Build the static site using Docker
-build: 
-	docker pull $(DOCKER_IMAGE)
+build: ensure-hugo-image
 	docker run --rm -v $(PWD):/src $(DOCKER_IMAGE) \
 		--minify \
 		--destination $(OUTPUT_DIR)
 
 # Serve the site locally using Docker (development)
-serve: 
-	docker pull $(DOCKER_IMAGE)
+serve: ensure-hugo-image
 	docker run --rm -it -v $(PWD):/src -p 1313:1313 $(DOCKER_IMAGE) \
 		server \
 		--bind 0.0.0.0 \

--- a/README.md
+++ b/README.md
@@ -309,7 +309,8 @@ author: "Author Name (@github_handle)"
    make serve
    ```
    This will:
-   - Build the Hugo Docker image
+   - Pull the published Apache-owned Hugo build image if available
+   - Or build the Hugo build image locally from `Dockerfile.multiplatform`
    - Start a development server on http://localhost:1313
    - Watch for changes and automatically rebuild
    - Enable drafts and future posts


### PR DESCRIPTION
This PR removes the short-term dependency on the personal `hvishwanath/hugo` image namespace and moves the repo toward an Apache-owned GHCR image.

Changes:
  - update the Hugo base image reference in `Makefile` to `ghcr.io/apache/kafka-site/hugo:v0.123.7-ext-multiplatform`
  - add a new GitHub Actions workflow to build and publish that Hugo base image from `Dockerfile.multiplatform`
  - update the Docker image workflow to use the Apache-owned image, with a local build fallback if the image is not published yet
  - update the README to reflect the new build flow

 This is intended as the short-term fix only: preserve the current custom Hugo image behavior, but stop relying on a personal image. 

Longer term, we should evaluate replacing this custom Kafka-owned Hugo image with the official Hugo image from the Hugo project, moving any repo-specific bootstrap steps into CI as needed.