### PR TITLE
KAFKA-20463: Auto-deploy to asf-site on PR merge

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -51,7 +51,7 @@ jobs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
     - name: Configure
       id: configure
-      run: echo "ref=${{ (github.event_name == 'push' || inputs.deploy-to-asf-site) && 'asf-site' || 'asf-staging' }}" >> "$GITHUB_OUTPUT"
+      run: echo "ref=${{ inputs.deploy-to-asf-site && 'asf-site' || 'asf-staging' }}" >> "$GITHUB_OUTPUT"
     - name: Checkout
       uses: actions/checkout@v5
       with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -44,6 +44,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build-html
+    permissions:
+      pull-requests: write
     steps:
     - name: Env
       run: printenv
@@ -85,6 +87,21 @@ jobs:
         git diff --quiet && git diff --staged --quiet || git commit -m "$COMMIT_MSG"
         git push
     
+    - name: Comment on merged PR
+      if: ${{ steps.configure.outputs.ref == 'asf-staging' && github.event_name == 'push' }}
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        REPO: ${{ github.repository }}
+        SHA: ${{ github.sha }}
+      run: |
+        PR_NUMBER=$(gh api "repos/$REPO/commits/$SHA/pulls" --jq '.[0].number' 2>/dev/null)
+        if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "Your changes are live on the [staging site](https://kafka.staged.apache.org/) ([GHA run]($RUN_URL)).
+
+        They will be automatically promoted to the production site (https://kafka.apache.org/) on the next scheduled run (every Monday & Thursday at 02:00 UTC). Please review staging and open a follow-up PR if you spot any issues."
+        fi
+
     - name: Create deployment summary
       run: |
         echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -51,7 +51,7 @@ jobs:
         GITHUB_CONTEXT: ${{ toJson(github) }}
     - name: Configure
       id: configure
-      run: echo "ref=${{ inputs.deploy-to-asf-site && 'asf-site' || 'asf-staging' }}" >> "$GITHUB_OUTPUT"
+      run: echo "ref=${{ (github.event_name == 'push' || inputs.deploy-to-asf-site) && 'asf-site' || 'asf-staging' }}" >> "$GITHUB_OUTPUT"
     - name: Checkout
       uses: actions/checkout@v5
       with:

--- a/.github/workflows/promote-staging-to-production.yml
+++ b/.github/workflows/promote-staging-to-production.yml
@@ -1,0 +1,52 @@
+name: Promote Staging to Production
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'  # Monday 02:00 UTC
+    - cron: '0 2 * * 4'  # Thursday 02:00 UTC
+  workflow_dispatch:
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout asf-site
+      uses: actions/checkout@v4
+      with:
+        ref: asf-site
+        fetch-depth: 0
+        persist-credentials: true
+
+    - name: Copy asf-staging content into asf-site
+      run: |
+        # Download asf-staging refs without switching branches
+        git fetch origin asf-staging
+        # Stage deletions for every tracked file
+        git rm -rf . --quiet
+        # Overwrite working tree and index with all files from asf-staging
+        git checkout origin/asf-staging -- .
+        # Restore asf-site-specific files: .asf.yaml differs (staging vs production whoami), .gitignore only exists in asf-site
+        git checkout HEAD -- .htaccess .asf.yaml .gitignore
+
+    - name: Commit and push
+      env:
+        COMMIT_MSG: |
+          Promote asf-staging to asf-site (run ${{ github.run_id }})
+
+          GitHub Run: https://github.com/apache/kafka-site/actions/runs/${{ github.run_id }}
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        # Stage any remaining unstaged changes (e.g. restored config files)
+        git add .
+        # Skip the commit entirely if staging content is identical to what's already in asf-site
+        git diff --quiet && git diff --staged --quiet || git commit -m "$COMMIT_MSG"
+        git push
+
+    - name: Create promotion summary
+      run: |
+        echo "## Promotion Summary" >> $GITHUB_STEP_SUMMARY
+        echo "- **Source**: asf-staging" >> $GITHUB_STEP_SUMMARY
+        echo "- **Target**: asf-site" >> $GITHUB_STEP_SUMMARY
+        echo "- **Time**: $(date)" >> $GITHUB_STEP_SUMMARY
+        echo "- **Run**: ${{ github.run_id }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Previously, merging a PR only deployed to asf-staging because `inputs.deploy-to-asf-site` is null for push events. The live site required a manual workflow_dispatch with the checkbox enabled.                                                                                                                                                           
                                                                                                                                                                                                                           
Now push events deploy directly to asf-site. Manual runs without the checkbox still target asf-staging for testing.