### PR TITLE
KAFKA-20100 : Fix broken links in Developer Guide

### DIFF
--- a/content/en/community/developer.md
+++ b/content/en/community/developer.md
@@ -35,16 +35,16 @@ Our code is kept in Apache GitHub repo. You can check it out like this:
     
     git clone https://github.com/apache/kafka.git kafka
 
-Information on contributing patches can be found [here](contributing.html). 
+Information on contributing patches can be found [here](#how-to-contribute). 
 
-Official releases are available [here](downloads.html). 
+Official releases are available [here](/downloads.html). 
 
 The source code for the web site and documentation can be checked out from Apache GitHub repo: 
     
     
     git clone -b asf-site https://github.com/apache/kafka-site.git
 
-We are happy to received patches for the website and documentation. We think documentation is a core part of the project and welcome any improvements, suggestions, or clarifications. The procedure of contributing to the documentation can also be found [here](contributing.html). 
+We are happy to received patches for the website and documentation. We think documentation is a core part of the project and welcome any improvements, suggestions, or clarifications. The procedure of contributing to the documentation can also be found [here](#contributing-a-change-to-the-website). 
 
 To setup IDEs for development, following [this guide](https://cwiki.apache.org/confluence/display/KAFKA/Developer+Setup) on the wiki. 
 


### PR DESCRIPTION
## Purpose of the change
*   [x] Bug fix
*   [ ] New feature
*   [ ] Enhancement
*   [ ] Documentation
*   [ ] Dependency upgrade

**Link to Jira Issue:**
* [KAFKA-20100](https://issues.apache.org/jira/browse/KAFKA-20100)

**Description of the change:**

This PR fixes several broken and inefficient links in the `developer.md` file.

Specifically:

- **Internal Anchors:** Changed links pointing to `contributing.html` (which was resulting in a 404 page load) to point directly to internal section anchors: `#how-to-contribute` and `#contributing-a-change-to-the-website`.
- **Path Correction:** Updated the link for official releases to use a root-relative path (`/downloads.html`) to ensure it works correctly across different subdirectories.

## Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation accordingly.
- [x] I have read the [contribution guidelines](https://apache.org).

## Additional Information
