### PR TITLE
KAFKA-20529: Remove aggressive hover animation from the ASF Feather logo on the Kafka website footer

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -1255,7 +1255,7 @@ p {
   }
 }
 
-// ASF Feather Logo styling - Smaller with very rapid continuous spin effect
+// ASF Feather Logo styling
 .asf-feather-logo {
   max-width: 50px;
   width: 50px;
@@ -1265,7 +1265,6 @@ p {
 
   &:hover {
     opacity: 1;
-    animation: spin-continuous 0.2s linear infinite;
   }
 }
 


### PR DESCRIPTION
## Purpose of the change
*   [x] Bug fix
*   [ ] New feature
*   [ ] Enhancement
*   [ ] Documentation
*   [ ] Dependency upgrade

**Link to Jira Issue:**
* [KAFKA-20529](https://issues.apache.org/jira/browse/KAFKA-20529)

**Description of the change:**

This PR removes the aggressive hover animation from the ASF feather logo. The current 0.2s continuous spin is distracting and inconsistent with a professional UI/UX.

Changes :
Removed `animation: spin-continuous` from the `.asf-feather-logo:hover` selector.
Maintained the opacity transition for subtle visual feedback.

## Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the documentation accordingly.
- [x] I have read the [contribution guidelines](https://apache.org).

## Additional Information
