### PR TITLE
MINOR: Remove outdated note for streams group protocol in 4.2 docs

### DIFF
--- a/content/en/42/streams/developer-guide/config-streams.md
+++ b/content/en/42/streams/developer-guide/config-streams.md
@@ -1348,7 +1348,7 @@ Serde for the inner class of a windowed record. Must implement the `Serde` inter
 
 ### group.protocol
 
-> The group protocol used by the Kafka Streams client used for coordination. It determines how the client will communicate with the Kafka brokers and other clients in the same group. The default value is `"classic"`, which is the classic consumer group protocol. Can be set to `"streams"` (requires broker-side enablement) to enable the new Kafka Streams group protocol. Note that the "streams" rebalance protocol is an Early Access feature and should not be used in production. 
+> The group protocol used by the Kafka Streams client used for coordination. It determines how the client will communicate with the Kafka brokers and other clients in the same group. The default value is `"classic"`, which is the classic consumer group protocol. Can be set to `"streams"` (requires broker-side enablement) to enable the new Kafka Streams group protocol.
 
 ### rack.aware.assignment.non_overlap_cost
 


### PR DESCRIPTION
Mirrors #866 for the 4.2 docs. KIP-1071 reached GA in 4.2, so the `group.protocol` config description should not still describe `"streams"` as Early Access. The rest of the 4.2 streams docs (developer guide, upgrade guide, getting-started upgrade) already present the protocol as GA, so this lone sentence in `config-streams.md` was the only stale mention left.

The historical "Streams API changes in 4.1.0" sections in the upgrade guides are intentionally left alone — they describe the state at 4.1.0. The KAFKA-20254 offline migration warning is also retained.