### PR TITLE
MINOR: Fix and add CVE-2026-41115 info

### DIFF
--- a/content/en/38/security/authorization-and-acls.md
+++ b/content/en/38/security/authorization-and-acls.md
@@ -2257,7 +2257,7 @@ CONSUMER_GROUP_DESCRIBE (69)
 </td>  
 <td>
 
-Read
+Describe
 </td>  
 <td>
 

--- a/content/en/39/security/authorization-and-acls.md
+++ b/content/en/39/security/authorization-and-acls.md
@@ -2257,7 +2257,7 @@ CONSUMER_GROUP_DESCRIBE (69)
 </td>  
 <td>
 
-Read
+Describe
 </td>  
 <td>
 

--- a/content/en/40/security/authorization-and-acls.md
+++ b/content/en/40/security/authorization-and-acls.md
@@ -2210,7 +2210,7 @@ CONSUMER_GROUP_DESCRIBE (69)
 </td>  
 <td>
 
-Read
+Describe
 </td>  
 <td>
 

--- a/content/en/41/security/authorization-and-acls.md
+++ b/content/en/41/security/authorization-and-acls.md
@@ -2218,7 +2218,7 @@ CONSUMER_GROUP_DESCRIBE (69)
 </td>  
 <td>
 
-Read
+Describe
 </td>  
 <td>
 

--- a/content/en/42/security/authorization-and-acls.md
+++ b/content/en/42/security/authorization-and-acls.md
@@ -2218,7 +2218,7 @@ CONSUMER_GROUP_DESCRIBE (69)
 </td>  
 <td>
 
-Read
+Describe
 </td>  
 <td>
 

--- a/content/en/43/security/authorization-and-acls.md
+++ b/content/en/43/security/authorization-and-acls.md
@@ -2218,7 +2218,7 @@ CONSUMER_GROUP_DESCRIBE (69)
 </td>  
 <td>
 
-Read
+Describe
 </td>  
 <td>
 

--- a/content/en/community/cve-list.md
+++ b/content/en/community/cve-list.md
@@ -32,12 +32,12 @@ This page does **not** list security advisories for dependencies of Kafka. If yo
 
 ## [CVE-2026-41115](https://nvd.nist.gov/vuln/detail/CVE-2026-41115) Apache Kafka: Improper Authorization in CONSUMER_GROUP_DESCRIBE API {#CVE-2026-41115}
 
-The implementation of the CONSUMER_GROUP_DESCRIBE (69) API validates the DESCRIBE operation on the GROUP resource instead of the READ operation that documented in the official kafka documentation and the KIP-848.
+The implementation of the CONSUMER_GROUP_DESCRIBE (69) API validates the DESCRIBE operation on the GROUP resource instead of the READ operation as documented in the official Kafka documentation and KIP-848.
 This discrepancy can result in misconfigured Access Control Lists (ACLs) and unintended security postures,
 like granting READ permission to users who should not be able to join/sync groups, or allowing users without READ permission (but with DESCRIBE permission) to access sensitive group metadata.
 
 The correct permission for CONSUMER_GROUP_DESCRIBE API is DESCRIBE GROUP so the current implementation is correct.
-However, the kafka documentation as well as the KIP-848 will be updated to reflect the correct permission.
+However, the Kafka documentation as well as KIP-848 have been updated to reflect the correct permission.
 We advise the Kafka users to review existing group ACLs to ensure the principle of least privilege.
 
 <table>

--- a/content/en/community/cve-list.md
+++ b/content/en/community/cve-list.md
@@ -28,7 +28,66 @@ type: docs
 
 This page lists all security vulnerabilities fixed in released versions of Apache Kafka. 
 
-This page does **not** list security advisories for dependencies of Kafka. If your security scanner warns that there is an advisory for a dependency of Kafka, please see [this documentation](https://security.apache.org/report-dependency/). You can find the current development versions of various dependencies [here](https://github.com/apache/kafka/blob/trunk/gradle/dependencies.gradle). You can find a list of advisories that have been confirmed not to apply to Kafka [here](https://github.com/apache/kafka/blob/trunk/gradle/resources/dependencycheck-suppressions.xml). You are invited to [contribute](https://kafka.apache.org/contributing.html) version updates or (motivated) suppressions. 
+This page does **not** list security advisories for dependencies of Kafka. If your security scanner warns that there is an advisory for a dependency of Kafka, please see [this documentation](https://security.apache.org/report-dependency/). You can find the current development versions of various dependencies [here](https://github.com/apache/kafka/blob/trunk/gradle/dependencies.gradle). You can find a list of advisories that have been confirmed not to apply to Kafka [here](https://github.com/apache/kafka/blob/trunk/gradle/resources/dependencycheck-suppressions.xml). You are invited to [contribute](https://kafka.apache.org/contributing.html) version updates or (motivated) suppressions.
+
+## [CVE-2026-41115](https://nvd.nist.gov/vuln/detail/CVE-2026-41115) Apache Kafka: Improper Authorization in CONSUMER_GROUP_DESCRIBE API {#CVE-2026-41115}
+
+The implementation of the CONSUMER_GROUP_DESCRIBE (69) API validates the DESCRIBE operation on the GROUP resource instead of the READ operation that documented in the official kafka documentation and the KIP-848.
+This discrepancy can result in misconfigured Access Control Lists (ACLs) and unintended security postures,
+like granting READ permission to users who should not be able to join/sync groups, or allowing users without READ permission (but with DESCRIBE permission) to access sensitive group metadata.
+
+The correct permission for CONSUMER_GROUP_DESCRIBE API is DESCRIBE GROUP so the current implementation is correct.
+However, the kafka documentation as well as the KIP-848 will be updated to reflect the correct permission.
+We advise the Kafka users to review existing group ACLs to ensure the principle of least privilege.
+
+<table>
+<tr>
+<td>
+
+Versions affected
+</td>
+<td>
+
+4.0.0 - 4.3.0
+</td> </tr>
+<tr>
+<td>
+
+Fixed versions
+</td>
+<td>
+
+4.0.0 - 4.3.0
+</td> </tr>
+<tr>
+<td>
+
+Impact
+</td>
+<td>
+
+This improper authorization can result in misconfigured ACLs and unintended security postures,
+like granting READ permission to users who should not be able to join/sync groups,
+or allowing users without READ permission (but with DESCRIBE permission) to access sensitive group metadata.
+</td> </tr>
+<tr>
+<td>
+
+Advice
+</td>
+<td>
+
+Kafka users using 4.0.0 - 4.3.0 are advised to review existing group ACLs to ensure the principle of least privilege.
+</td> </tr>
+<tr>
+<td>
+
+Issue announced
+</td>
+<td>
+
+2 Jun 2026
+</td> </tr> </table>
 
 ## [CVE-2026-33558](https://nvd.nist.gov/vuln/detail/CVE-2026-33558) Apache Kafka, Apache Kafka Clients: Information Exposure Through Network Client Log Output {#CVE-2026-33558}
 


### PR DESCRIPTION
1. add CVE-2026-41115 info
2. Fix documentation for CVE-2026-41115, to use `DESCRIBE` permission on `GROUP` resource for `CONSUMER_GROUP_DESCRIBE (69)` API.