### PR TITLE
MINOR: Add a build image based on the official Hugo release binary

### DIFF
--- a/Dockerfile.hugo-builder
+++ b/Dockerfile.hugo-builder
@@ -1,0 +1,32 @@
+ARG HUGO_VERSION=0.123.7
+
+FROM alpine:3.21
+
+RUN apk add --no-cache \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    go \
+    libc6-compat \
+    nodejs \
+    npm
+
+ARG HUGO_VERSION
+ARG TARGETARCH
+RUN HUGO_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "arm64" || echo "amd64") && \
+    curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-${HUGO_ARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin hugo && \
+    chmod +x /usr/local/bin/hugo && \
+    hugo version
+
+WORKDIR /src
+
+RUN git config --global --add safe.directory /src
+
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 1313
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,15 @@
 OUTPUT_DIR := output
 HUGO_BASE_IMAGE := hvishwanath/hugo:v0.123.7-ext-multiplatform
 DOCKER_IMAGE := $(HUGO_BASE_IMAGE)
+# Experimental image built locally from Dockerfile.hugo-builder using the
+# official Hugo release binary. Not used by CI; produces byte-identical output
+# to $(DOCKER_IMAGE). See the `hugo-image` and `build-official` targets.
+HUGO_VERSION := 0.123.7
+HUGO_IMAGE := apache/kafka-site/hugo:v$(HUGO_VERSION)
 #PROD_IMAGE := hvishwanath/kafka-site-md:1.2.0
 PROD_IMAGE := us-west1-docker.pkg.dev/play-394201/kafka-site-md/kafka-site-md:1.6.0
 
-.PHONY: build serve clean docker-image hugo-base-multi-platform prod-image prod-run buildx-setup ghcr-prod-image
+.PHONY: build serve clean docker-image hugo-base-multi-platform hugo-image build-official prod-image prod-run buildx-setup ghcr-prod-image
 
 # Setup buildx for multi-arch builds
 buildx-setup:
@@ -44,6 +49,20 @@ serve:
 		--appendPort=true \
 		--buildDrafts \
 		--buildFuture
+
+# Build the experimental Hugo image from the official Hugo release binary
+hugo-image:
+	docker build \
+		--build-arg HUGO_VERSION=$(HUGO_VERSION) \
+		--file Dockerfile.hugo-builder \
+		--tag $(HUGO_IMAGE) \
+		.
+
+# Build the static site with the official-Hugo image (parity check; not used by CI)
+build-official: hugo-image
+	docker run --rm -v $(PWD):/src $(HUGO_IMAGE) \
+		--minify \
+		--destination $(OUTPUT_DIR)
 
 # Build production Nginx image for multiple architectures
 prod-image: build buildx-setup

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ author: "Author Name (@github_handle)"
 `Dockerfile.hugo-builder` defines an alternative build image that installs the
 official Hugo extended release binary from the Hugo project (pinned via the
 `HUGO_VERSION` variable in the `Makefile`) together with the Node.js/PostCSS and
-Go toolchains the Docsy theme needs. Unlike the current build image, it does not
+Go toolchains. Unlike the current build image, it does not
 depend on any externally-hosted or personal image.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -320,6 +320,24 @@ author: "Author Name (@github_handle)"
    ```
    The built site will be available in the `output` directory.
 
+### Building with the official Hugo binary (experimental)
+
+`Dockerfile.hugo-builder` defines an alternative build image that installs the
+official Hugo extended release binary from the Hugo project (pinned via the
+`HUGO_VERSION` variable in the `Makefile`) together with the Node.js/PostCSS and
+Go toolchains the Docsy theme needs. Unlike the current build image, it does not
+depend on any externally-hosted or personal image.
+
+```bash
+make build-official
+```
+
+This builds the image locally and renders the site into `output`, producing
+output that is byte-for-byte identical to `make build`. It is **not** used by any
+CI workflow yet; the existing `make build`/`make serve` flow and the deployment
+pipeline are unchanged. The intent is to validate the official-binary image
+before switching the build over to it in a follow-up change.
+
 ### Production Build
 
 1. Build and test the production image locally:


### PR DESCRIPTION
## Summary

Add a local build image `Dockerfile.hugo-builder` that installs the official Hugo extended release binary from the Hugo project, alongside the other required binaries such as the `Node.js`, `PostCSS` and Go toolchains . 

Unlike the current build image, it does not depend on any externally-hosted or personal image (e.g. hvishwanath/hugo).

This is added as a separate, opt-in path, so no CI behaviour or deployment changes in this PR:

- CI: the "Build and Deploy Site" workflow runs `make build`, which is left unchanged and still uses the current image. The published website is not affected.
- Local: `make build-official` builds the new image from the official binary and renders the site with it. Its output is byte-for-byte identical to `make build`

The goal is to validate the official-binary image first; switching the build and CI over to it can follow in a later change.