### PR TITLE
MINOR: Updates for release

### DIFF
--- a/content/en/43/apis/_index.md
+++ b/content/en/43/apis/_index.md
@@ -48,7 +48,7 @@ To use the producer, add the following Maven dependency to your project:
 <dependency>
 	<groupId>org.apache.kafka</groupId>
 	<artifactId>kafka-clients</artifactId>
-	<version>4.3.0</version>
+	<version>4.3.1</version>
 </dependency>
 ```
 
@@ -64,7 +64,7 @@ To use the consumer, add the following Maven dependency to your project:
 <dependency>
 	<groupId>org.apache.kafka</groupId>
 	<artifactId>kafka-clients</artifactId>
-	<version>4.3.0</version>
+	<version>4.3.1</version>
 </dependency>
 ```
 
@@ -80,7 +80,7 @@ To use the share consumer, add the following Maven dependency to your project:
 <dependency>
 	<groupId>org.apache.kafka</groupId>
 	<artifactId>kafka-clients</artifactId>
-	<version>4.3.0</version>
+	<version>4.3.1</version>
 </dependency>
 ```
 
@@ -98,7 +98,7 @@ To use Kafka Streams, add the following Maven dependency to your project:
 <dependency>
 	<groupId>org.apache.kafka</groupId>
 	<artifactId>kafka-streams</artifactId>
-	<version>4.3.0</version>
+	<version>4.3.1</version>
 </dependency>
 ```
 
@@ -114,7 +114,7 @@ To use Kafka Streams DSL for Scala 2.13, add the following Maven dependency to y
 <dependency>
 	<groupId>org.apache.kafka</groupId>
 	<artifactId>kafka-streams-scala_2.13</artifactId>
-	<version>4.3.0</version>
+	<version>4.3.1</version>
 </dependency>
 ```
 
@@ -136,7 +136,7 @@ To use the Admin API, add the following Maven dependency to your project:
 <dependency>
 	<groupId>org.apache.kafka</groupId>
 	<artifactId>kafka-clients</artifactId>
-	<version>4.3.0</version>
+	<version>4.3.1</version>
 </dependency>
 ```
 

--- a/content/en/43/getting-started/upgrade.md
+++ b/content/en/43/getting-started/upgrade.md
@@ -26,6 +26,15 @@ type: docs
 -->
 
 
+## Upgrading to 4.3.1
+
+### Notable changes in 4.3.1
+
+  * Includes a fix for a critical Kafka Streams native memory leak caused by RocksDB column family handles and `ColumnFamilyOptions` not being released, notably for the offsets column family introduced for [KIP-1035](https://cwiki.apache.org/confluence/x/uYvOEg) ([KAFKA-20616](https://issues.apache.org/jira/browse/KAFKA-20616), [KAFKA-20688](https://issues.apache.org/jira/browse/KAFKA-20688)).
+  * Includes a fix for a Kafka Streams stale-offset issue that could cause `OffsetOutOfRangeException` on restart ([KAFKA-20663](https://issues.apache.org/jira/browse/KAFKA-20663)).
+  * Includes a fix for `Admin` partition-leader APIs hanging when a cached leader has left the cluster ([KAFKA-20673](https://issues.apache.org/jira/browse/KAFKA-20673)).
+  * Includes fixes for spurious group coordinator errors logged after a partition leadership change ([KAFKA-20634](https://issues.apache.org/jira/browse/KAFKA-20634), [KAFKA-20635](https://issues.apache.org/jira/browse/KAFKA-20635)).
+
 ## Upgrading to 4.3.0
 
 ### Upgrading Servers to 4.3.0 from any version 3.3.x through 4.2.0

--- a/content/en/community/downloads.md
+++ b/content/en/community/downloads.md
@@ -37,7 +37,7 @@ The project goal is to have 3 releases a year, which means a release every 4 mon
 * Source download: [kafka-4.3.1-src.tgz](https://www.apache.org/dyn/closer.lua/kafka/4.3.1/kafka-4.3.1-src.tgz?action=download) ([asc](https://downloads.apache.org/kafka/4.3.1/kafka-4.3.1-src.tgz.asc), [sha512](https://downloads.apache.org/kafka/4.3.1/kafka-4.3.1-src.tgz.sha512))
 * Binary download: [kafka_2.13-4.3.1.tgz](https://www.apache.org/dyn/closer.lua/kafka/4.3.1/kafka_2.13-4.3.1.tgz?action=download) ([asc](https://downloads.apache.org/kafka/4.3.1/kafka_2.13-4.3.1.tgz.asc), [sha512](https://downloads.apache.org/kafka/4.3.1/kafka_2.13-4.3.1.tgz.sha512))
 
-Kafka 4.3.1 fixes around 15 issues since the 4.3.0 release, most notably a critical Kafka Streams RocksDB native memory leak (KAFKA-20616). For more information, please read the detailed [Upgrade Notes](https://kafka.apache.org/43/getting-started/upgrade/) and the [Release Notes](https://www.apache.org/dyn/closer.lua/kafka/4.3.1/RELEASE_NOTES.html?action=download).
+Kafka 4.3.1 fixes around 15 issues since the 4.3.0 release, most notably a critical Kafka Streams RocksDB native memory leak (KAFKA-20616). For more information, please read the detailed [Upgrade Notes](https://kafka.apache.org/43/getting-started/upgrade/#upgrading-to-431) and the [Release Notes](https://www.apache.org/dyn/closer.lua/kafka/4.3.1/RELEASE_NOTES.html?action=download).
 
 ### 4.2.1
 


### PR DESCRIPTION
Updates the correct version on the APIs page and adds upgrade to section for `4.3.1`