### PR TITLE
MINOR: Restore _tagged_fields in protocol header docs for v42/v43

### DIFF
--- a/content/en/42/generated/protocol_messages.html
+++ b/content/en/42/generated/protocol_messages.html
@@ -17,7 +17,7 @@
 <tr>
 <td>client_id</td><td>The client ID string.</td></tr>
 </tbody></table>
-<pre>Request Header v2 => request_api_key request_api_version correlation_id client_id 
+<pre>Request Header v2 => request_api_key request_api_version correlation_id client_id _tagged_fields 
   request_api_key => INT16
   request_api_version => INT16
   correlation_id => INT32
@@ -35,7 +35,7 @@
 <tr>
 <td>client_id</td><td>The client ID string.</td></tr>
 <tr>
-</td></tr>
+<td>_tagged_fields</td><td>The tagged fields</td></tr>
 </tbody></table>
 <pre>Response Header v0 => correlation_id 
   correlation_id => INT32
@@ -46,7 +46,7 @@
 </tr><tr>
 <td>correlation_id</td><td>The correlation ID of this response.</td></tr>
 </tbody></table>
-<pre>Response Header v1 => correlation_id 
+<pre>Response Header v1 => correlation_id _tagged_fields 
   correlation_id => INT32
 </pre>
 <table class="data-table"><tbody>
@@ -55,7 +55,7 @@
 </tr><tr>
 <td>correlation_id</td><td>The correlation ID of this response.</td></tr>
 <tr>
-</td></tr>
+<td>_tagged_fields</td><td>The tagged fields</td></tr>
 </tbody></table>
 <h5><a name="The_Messages_Produce">Produce API (Key: 0):</a></h5>
 

--- a/content/en/43/generated/protocol_messages.html
+++ b/content/en/43/generated/protocol_messages.html
@@ -17,7 +17,7 @@
 <tr>
 <td>client_id</td><td>The client ID string.</td></tr>
 </tbody></table>
-<pre>Request Header v2 => { request_api_key request_api_version correlation_id client_id }
+<pre>Request Header v2 => { request_api_key request_api_version correlation_id client_id _tagged_fields }
   request_api_key => INT16
   request_api_version => INT16
   correlation_id => INT32
@@ -35,7 +35,7 @@
 <tr>
 <td>client_id</td><td>The client ID string.</td></tr>
 <tr>
-</td></tr>
+<td>_tagged_fields</td><td>The tagged fields</td></tr>
 </tbody></table>
 <pre>Response Header v0 => { correlation_id }
   correlation_id => INT32
@@ -46,7 +46,7 @@
 </tr><tr>
 <td>correlation_id</td><td>The correlation ID of this response.</td></tr>
 </tbody></table>
-<pre>Response Header v1 => { correlation_id }
+<pre>Response Header v1 => { correlation_id _tagged_fields }
   correlation_id => INT32
 </pre>
 <table class="data-table"><tbody>
@@ -55,7 +55,7 @@
 </tr><tr>
 <td>correlation_id</td><td>The correlation ID of this response.</td></tr>
 <tr>
-</td></tr>
+<td>_tagged_fields</td><td>The tagged fields</td></tr>
 </tbody></table>
 <h5><a name="The_Messages_Produce">Produce API (Key: 0):</a></h5>
 


### PR DESCRIPTION
## Summary
- Restore the missing `_tagged_fields` field in **Request Header v2** and **Response Header v1** for Kafka documentation versions 4.2 and 4.3
- Fix malformed HTML table rows in the Headers section that were left behind when tagged fields were dropped from the generated protocol docs

## Test plan
- [ ] Run `make serve` and open the Protocol page for versions 42 and 43
- [ ] Verify the Headers section lists `_tagged_fields` for Request Header v2 and Response Header v1
- [ ] Confirm the field description tables render correctly without empty rows


Made with [Cursor](https://cursor.com)