### PR TITLE
MINOR: Sync doc description fix from apache/kafka#22605 to 4.3.X pages

### DIFF
--- a/content/en/0100/configuration/broker-configs.md
+++ b/content/en/0100/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/configuration/consumer-configs.md
+++ b/content/en/0100/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/configuration/kafka-connect-configs.md
+++ b/content/en/0100/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/configuration/kafka-streams-configs.md
+++ b/content/en/0100/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/configuration/producer-configs.md
+++ b/content/en/0100/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/implementation/api-design.md
+++ b/content/en/0100/implementation/api-design.md
@@ -1,6 +1,6 @@
 ---
 title: API Design
-description: API Design
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/implementation/distribution.md
+++ b/content/en/0100/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/implementation/log.md
+++ b/content/en/0100/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/implementation/message-format.md
+++ b/content/en/0100/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/implementation/messages.md
+++ b/content/en/0100/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/implementation/network-layer.md
+++ b/content/en/0100/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/kafka-connect/connector-development-guide.md
+++ b/content/en/0100/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/kafka-connect/overview.md
+++ b/content/en/0100/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/kafka-connect/user-guide.md
+++ b/content/en/0100/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/operations/basic-kafka-operations.md
+++ b/content/en/0100/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/operations/datacenters.md
+++ b/content/en/0100/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/operations/hardware-and-os.md
+++ b/content/en/0100/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/operations/java-version.md
+++ b/content/en/0100/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/operations/kafka-configuration.md
+++ b/content/en/0100/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/operations/monitoring.md
+++ b/content/en/0100/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/operations/zookeeper.md
+++ b/content/en/0100/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/security/authentication-using-sasl.md
+++ b/content/en/0100/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/security/authorization-and-acls.md
+++ b/content/en/0100/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/0100/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/0100/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/security/security-overview.md
+++ b/content/en/0100/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0100/security/zookeeper-authentication.md
+++ b/content/en/0100/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/configuration/broker-configs.md
+++ b/content/en/0101/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/configuration/consumer-configs.md
+++ b/content/en/0101/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/configuration/kafka-connect-configs.md
+++ b/content/en/0101/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/configuration/kafka-streams-configs.md
+++ b/content/en/0101/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/configuration/producer-configs.md
+++ b/content/en/0101/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/implementation/api-design.md
+++ b/content/en/0101/implementation/api-design.md
@@ -1,6 +1,6 @@
 ---
 title: API Design
-description: API Design
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/implementation/distribution.md
+++ b/content/en/0101/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/implementation/log.md
+++ b/content/en/0101/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/implementation/message-format.md
+++ b/content/en/0101/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/implementation/messages.md
+++ b/content/en/0101/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/implementation/network-layer.md
+++ b/content/en/0101/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/kafka-connect/connector-development-guide.md
+++ b/content/en/0101/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/kafka-connect/overview.md
+++ b/content/en/0101/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/kafka-connect/user-guide.md
+++ b/content/en/0101/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/operations/basic-kafka-operations.md
+++ b/content/en/0101/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/operations/datacenters.md
+++ b/content/en/0101/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/operations/hardware-and-os.md
+++ b/content/en/0101/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/operations/java-version.md
+++ b/content/en/0101/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/operations/kafka-configuration.md
+++ b/content/en/0101/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/operations/monitoring.md
+++ b/content/en/0101/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/operations/zookeeper.md
+++ b/content/en/0101/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/security/authentication-using-sasl.md
+++ b/content/en/0101/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/security/authorization-and-acls.md
+++ b/content/en/0101/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/0101/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/0101/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/security/security-overview.md
+++ b/content/en/0101/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0101/security/zookeeper-authentication.md
+++ b/content/en/0101/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/configuration/broker-configs.md
+++ b/content/en/0102/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/configuration/consumer-configs.md
+++ b/content/en/0102/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/configuration/kafka-connect-configs.md
+++ b/content/en/0102/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/configuration/kafka-streams-configs.md
+++ b/content/en/0102/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/configuration/producer-configs.md
+++ b/content/en/0102/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/implementation/api-design.md
+++ b/content/en/0102/implementation/api-design.md
@@ -1,6 +1,6 @@
 ---
 title: API Design
-description: API Design
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/implementation/distribution.md
+++ b/content/en/0102/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/implementation/log.md
+++ b/content/en/0102/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/implementation/message-format.md
+++ b/content/en/0102/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/implementation/messages.md
+++ b/content/en/0102/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/implementation/network-layer.md
+++ b/content/en/0102/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/kafka-connect/connector-development-guide.md
+++ b/content/en/0102/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/kafka-connect/overview.md
+++ b/content/en/0102/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/kafka-connect/user-guide.md
+++ b/content/en/0102/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/operations/basic-kafka-operations.md
+++ b/content/en/0102/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/operations/datacenters.md
+++ b/content/en/0102/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/operations/hardware-and-os.md
+++ b/content/en/0102/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/operations/java-version.md
+++ b/content/en/0102/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/operations/kafka-configuration.md
+++ b/content/en/0102/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/operations/monitoring.md
+++ b/content/en/0102/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/operations/zookeeper.md
+++ b/content/en/0102/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/security/authentication-using-sasl.md
+++ b/content/en/0102/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/security/authorization-and-acls.md
+++ b/content/en/0102/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/0102/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/0102/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/security/security-overview.md
+++ b/content/en/0102/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0102/security/zookeeper-authentication.md
+++ b/content/en/0102/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/configuration/adminclient-configs.md
+++ b/content/en/0110/configuration/adminclient-configs.md
@@ -1,6 +1,6 @@
 ---
 title: AdminClient Configs
-description: AdminClient Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/configuration/broker-configs.md
+++ b/content/en/0110/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/configuration/consumer-configs.md
+++ b/content/en/0110/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/configuration/kafka-connect-configs.md
+++ b/content/en/0110/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/configuration/kafka-streams-configs.md
+++ b/content/en/0110/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/configuration/producer-configs.md
+++ b/content/en/0110/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/configuration/topic-level-configs.md
+++ b/content/en/0110/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/implementation/distribution.md
+++ b/content/en/0110/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/implementation/log.md
+++ b/content/en/0110/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/implementation/message-format.md
+++ b/content/en/0110/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/implementation/messages.md
+++ b/content/en/0110/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/implementation/network-layer.md
+++ b/content/en/0110/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/kafka-connect/connector-development-guide.md
+++ b/content/en/0110/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/kafka-connect/overview.md
+++ b/content/en/0110/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/kafka-connect/user-guide.md
+++ b/content/en/0110/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/operations/basic-kafka-operations.md
+++ b/content/en/0110/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/operations/datacenters.md
+++ b/content/en/0110/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/operations/hardware-and-os.md
+++ b/content/en/0110/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/operations/java-version.md
+++ b/content/en/0110/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/operations/kafka-configuration.md
+++ b/content/en/0110/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/operations/monitoring.md
+++ b/content/en/0110/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/operations/zookeeper.md
+++ b/content/en/0110/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/security/authentication-using-sasl.md
+++ b/content/en/0110/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/security/authorization-and-acls.md
+++ b/content/en/0110/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/0110/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/0110/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/security/security-overview.md
+++ b/content/en/0110/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/0110/security/zookeeper-authentication.md
+++ b/content/en/0110/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/07/configuration/important-configuration-properties-for-kafka-broker.md
+++ b/content/en/07/configuration/important-configuration-properties-for-kafka-broker.md
@@ -1,6 +1,6 @@
 ---
 title: Important configuration properties for Kafka broker
-description: Important configuration properties for Kafka broker
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/07/configuration/important-configuration-properties-for-the-high-level-consumer.md
+++ b/content/en/07/configuration/important-configuration-properties-for-the-high-level-consumer.md
@@ -1,6 +1,6 @@
 ---
 title: Important configuration properties for the high-level consumer
-description: Important configuration properties for the high-level consumer
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/07/configuration/important-configuration-properties-for-the-producer.md
+++ b/content/en/07/configuration/important-configuration-properties-for-the-producer.md
@@ -1,6 +1,6 @@
 ---
 title: Important configuration properties for the producer
-description: Important configuration properties for the producer
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/configuration/broker-configs.md
+++ b/content/en/08/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/configuration/consumer-configs.md
+++ b/content/en/08/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/configuration/producer-configs.md
+++ b/content/en/08/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/implementation/api-design.md
+++ b/content/en/08/implementation/api-design.md
@@ -1,6 +1,6 @@
 ---
 title: API Design
-description: API Design
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/implementation/distribution.md
+++ b/content/en/08/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/implementation/log.md
+++ b/content/en/08/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/implementation/message-format.md
+++ b/content/en/08/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/implementation/messages.md
+++ b/content/en/08/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/implementation/network-layer.md
+++ b/content/en/08/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/operations/datacenters.md
+++ b/content/en/08/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/operations/hardware-and-os.md
+++ b/content/en/08/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/operations/java-version.md
+++ b/content/en/08/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/operations/kafka-configuration.md
+++ b/content/en/08/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/operations/monitoring.md
+++ b/content/en/08/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/08/operations/zookeeper.md
+++ b/content/en/08/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: Zookeeper
-description: Zookeeper
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/configuration/broker-configs.md
+++ b/content/en/081/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/configuration/consumer-configs.md
+++ b/content/en/081/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/configuration/new-producer-configs.md
+++ b/content/en/081/configuration/new-producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: New Producer Configs
-description: New Producer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/configuration/producer-configs.md
+++ b/content/en/081/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/implementation/api-design.md
+++ b/content/en/081/implementation/api-design.md
@@ -1,6 +1,6 @@
 ---
 title: API Design
-description: API Design
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/implementation/distribution.md
+++ b/content/en/081/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/implementation/log.md
+++ b/content/en/081/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/implementation/message-format.md
+++ b/content/en/081/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/implementation/messages.md
+++ b/content/en/081/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/implementation/network-layer.md
+++ b/content/en/081/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/operations/basic-kafka-operations.md
+++ b/content/en/081/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/operations/datacenters.md
+++ b/content/en/081/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/operations/hardware-and-os.md
+++ b/content/en/081/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/operations/java-version.md
+++ b/content/en/081/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/operations/kafka-configuration.md
+++ b/content/en/081/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/operations/monitoring.md
+++ b/content/en/081/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/081/operations/zookeeper.md
+++ b/content/en/081/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/configuration/broker-configs.md
+++ b/content/en/082/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/configuration/consumer-configs.md
+++ b/content/en/082/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/configuration/new-producer-configs.md
+++ b/content/en/082/configuration/new-producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: New Producer Configs
-description: New Producer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/configuration/producer-configs.md
+++ b/content/en/082/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/implementation/api-design.md
+++ b/content/en/082/implementation/api-design.md
@@ -1,6 +1,6 @@
 ---
 title: API Design
-description: API Design
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/implementation/distribution.md
+++ b/content/en/082/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/implementation/log.md
+++ b/content/en/082/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/implementation/message-format.md
+++ b/content/en/082/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/implementation/messages.md
+++ b/content/en/082/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/implementation/network-layer.md
+++ b/content/en/082/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/operations/basic-kafka-operations.md
+++ b/content/en/082/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/operations/datacenters.md
+++ b/content/en/082/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/operations/hardware-and-os.md
+++ b/content/en/082/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/operations/java-version.md
+++ b/content/en/082/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/operations/kafka-configuration.md
+++ b/content/en/082/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/operations/monitoring.md
+++ b/content/en/082/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/082/operations/zookeeper.md
+++ b/content/en/082/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/configuration/broker-configs.md
+++ b/content/en/090/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/configuration/consumer-configs.md
+++ b/content/en/090/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/configuration/kafka-connect-configs.md
+++ b/content/en/090/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/configuration/producer-configs.md
+++ b/content/en/090/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/implementation/api-design.md
+++ b/content/en/090/implementation/api-design.md
@@ -1,6 +1,6 @@
 ---
 title: API Design
-description: API Design
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/implementation/distribution.md
+++ b/content/en/090/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/implementation/log.md
+++ b/content/en/090/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/implementation/message-format.md
+++ b/content/en/090/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/implementation/messages.md
+++ b/content/en/090/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/implementation/network-layer.md
+++ b/content/en/090/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/kafka-connect/connector-development-guide.md
+++ b/content/en/090/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/kafka-connect/overview.md
+++ b/content/en/090/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/kafka-connect/user-guide.md
+++ b/content/en/090/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/operations/basic-kafka-operations.md
+++ b/content/en/090/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/operations/datacenters.md
+++ b/content/en/090/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/operations/hardware-and-os.md
+++ b/content/en/090/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/operations/java-version.md
+++ b/content/en/090/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/operations/kafka-configuration.md
+++ b/content/en/090/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/operations/monitoring.md
+++ b/content/en/090/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/operations/zookeeper.md
+++ b/content/en/090/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/security/authentication-using-sasl.md
+++ b/content/en/090/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/security/authorization-and-acls.md
+++ b/content/en/090/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/090/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/security/security-overview.md
+++ b/content/en/090/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/090/security/zookeeper-authentication.md
+++ b/content/en/090/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/configuration/adminclient-configs.md
+++ b/content/en/10/configuration/adminclient-configs.md
@@ -1,6 +1,6 @@
 ---
 title: AdminClient Configs
-description: AdminClient Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/configuration/broker-configs.md
+++ b/content/en/10/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/configuration/consumer-configs.md
+++ b/content/en/10/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/configuration/kafka-connect-configs.md
+++ b/content/en/10/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/configuration/kafka-streams-configs.md
+++ b/content/en/10/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/configuration/producer-configs.md
+++ b/content/en/10/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/configuration/topic-level-configs.md
+++ b/content/en/10/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/implementation/distribution.md
+++ b/content/en/10/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/implementation/log.md
+++ b/content/en/10/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/implementation/message-format.md
+++ b/content/en/10/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/implementation/messages.md
+++ b/content/en/10/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/implementation/network-layer.md
+++ b/content/en/10/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/kafka-connect/connector-development-guide.md
+++ b/content/en/10/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/kafka-connect/overview.md
+++ b/content/en/10/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/kafka-connect/user-guide.md
+++ b/content/en/10/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/operations/basic-kafka-operations.md
+++ b/content/en/10/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/operations/datacenters.md
+++ b/content/en/10/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/operations/hardware-and-os.md
+++ b/content/en/10/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/operations/java-version.md
+++ b/content/en/10/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/operations/kafka-configuration.md
+++ b/content/en/10/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/operations/monitoring.md
+++ b/content/en/10/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/operations/zookeeper.md
+++ b/content/en/10/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/security/authentication-using-sasl.md
+++ b/content/en/10/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/security/authorization-and-acls.md
+++ b/content/en/10/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/10/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/10/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/security/security-overview.md
+++ b/content/en/10/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/10/security/zookeeper-authentication.md
+++ b/content/en/10/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/configuration/adminclient-configs.md
+++ b/content/en/11/configuration/adminclient-configs.md
@@ -1,6 +1,6 @@
 ---
 title: AdminClient Configs
-description: AdminClient Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/configuration/broker-configs.md
+++ b/content/en/11/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/configuration/consumer-configs.md
+++ b/content/en/11/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/configuration/kafka-connect-configs.md
+++ b/content/en/11/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/configuration/kafka-streams-configs.md
+++ b/content/en/11/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/configuration/producer-configs.md
+++ b/content/en/11/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/configuration/topic-level-configs.md
+++ b/content/en/11/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/implementation/distribution.md
+++ b/content/en/11/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/implementation/log.md
+++ b/content/en/11/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/implementation/message-format.md
+++ b/content/en/11/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/implementation/messages.md
+++ b/content/en/11/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/implementation/network-layer.md
+++ b/content/en/11/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/kafka-connect/connector-development-guide.md
+++ b/content/en/11/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/kafka-connect/overview.md
+++ b/content/en/11/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/kafka-connect/user-guide.md
+++ b/content/en/11/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/operations/basic-kafka-operations.md
+++ b/content/en/11/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/operations/datacenters.md
+++ b/content/en/11/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/operations/hardware-and-os.md
+++ b/content/en/11/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/operations/java-version.md
+++ b/content/en/11/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/operations/kafka-configuration.md
+++ b/content/en/11/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/operations/monitoring.md
+++ b/content/en/11/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/operations/zookeeper.md
+++ b/content/en/11/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/security/authentication-using-sasl.md
+++ b/content/en/11/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/security/authorization-and-acls.md
+++ b/content/en/11/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/11/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/11/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/security/security-overview.md
+++ b/content/en/11/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/11/security/zookeeper-authentication.md
+++ b/content/en/11/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/configuration/adminclient-configs.md
+++ b/content/en/20/configuration/adminclient-configs.md
@@ -1,6 +1,6 @@
 ---
 title: AdminClient Configs
-description: AdminClient Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/configuration/broker-configs.md
+++ b/content/en/20/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/configuration/consumer-configs.md
+++ b/content/en/20/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/configuration/kafka-connect-configs.md
+++ b/content/en/20/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/configuration/kafka-streams-configs.md
+++ b/content/en/20/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/configuration/producer-configs.md
+++ b/content/en/20/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/configuration/topic-level-configs.md
+++ b/content/en/20/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/implementation/distribution.md
+++ b/content/en/20/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/implementation/log.md
+++ b/content/en/20/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/implementation/message-format.md
+++ b/content/en/20/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/implementation/messages.md
+++ b/content/en/20/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/implementation/network-layer.md
+++ b/content/en/20/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/kafka-connect/connector-development-guide.md
+++ b/content/en/20/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/kafka-connect/overview.md
+++ b/content/en/20/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/kafka-connect/user-guide.md
+++ b/content/en/20/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/operations/basic-kafka-operations.md
+++ b/content/en/20/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/operations/datacenters.md
+++ b/content/en/20/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/operations/hardware-and-os.md
+++ b/content/en/20/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/operations/java-version.md
+++ b/content/en/20/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/operations/kafka-configuration.md
+++ b/content/en/20/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/operations/monitoring.md
+++ b/content/en/20/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/operations/zookeeper.md
+++ b/content/en/20/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/security/authentication-using-sasl.md
+++ b/content/en/20/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/security/authorization-and-acls.md
+++ b/content/en/20/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/20/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/20/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/security/security-overview.md
+++ b/content/en/20/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/20/security/zookeeper-authentication.md
+++ b/content/en/20/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/configuration/adminclient-configs.md
+++ b/content/en/21/configuration/adminclient-configs.md
@@ -1,6 +1,6 @@
 ---
 title: AdminClient Configs
-description: AdminClient Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/configuration/broker-configs.md
+++ b/content/en/21/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/configuration/consumer-configs.md
+++ b/content/en/21/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/configuration/kafka-connect-configs.md
+++ b/content/en/21/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/configuration/kafka-streams-configs.md
+++ b/content/en/21/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/configuration/producer-configs.md
+++ b/content/en/21/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/configuration/topic-level-configs.md
+++ b/content/en/21/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/implementation/distribution.md
+++ b/content/en/21/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/implementation/log.md
+++ b/content/en/21/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/implementation/message-format.md
+++ b/content/en/21/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/implementation/messages.md
+++ b/content/en/21/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/implementation/network-layer.md
+++ b/content/en/21/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/kafka-connect/connector-development-guide.md
+++ b/content/en/21/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/kafka-connect/overview.md
+++ b/content/en/21/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/kafka-connect/user-guide.md
+++ b/content/en/21/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/operations/basic-kafka-operations.md
+++ b/content/en/21/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/operations/datacenters.md
+++ b/content/en/21/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/operations/hardware-and-os.md
+++ b/content/en/21/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/operations/java-version.md
+++ b/content/en/21/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/operations/kafka-configuration.md
+++ b/content/en/21/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/operations/monitoring.md
+++ b/content/en/21/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/operations/zookeeper.md
+++ b/content/en/21/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/security/authentication-using-sasl.md
+++ b/content/en/21/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/security/authorization-and-acls.md
+++ b/content/en/21/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/21/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/21/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/security/security-overview.md
+++ b/content/en/21/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/21/security/zookeeper-authentication.md
+++ b/content/en/21/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/configuration/adminclient-configs.md
+++ b/content/en/22/configuration/adminclient-configs.md
@@ -1,6 +1,6 @@
 ---
 title: AdminClient Configs
-description: AdminClient Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/configuration/broker-configs.md
+++ b/content/en/22/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/configuration/consumer-configs.md
+++ b/content/en/22/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/configuration/kafka-connect-configs.md
+++ b/content/en/22/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/configuration/kafka-streams-configs.md
+++ b/content/en/22/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/configuration/producer-configs.md
+++ b/content/en/22/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/configuration/topic-level-configs.md
+++ b/content/en/22/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/implementation/distribution.md
+++ b/content/en/22/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/implementation/log.md
+++ b/content/en/22/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/implementation/message-format.md
+++ b/content/en/22/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/implementation/messages.md
+++ b/content/en/22/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/implementation/network-layer.md
+++ b/content/en/22/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/kafka-connect/connector-development-guide.md
+++ b/content/en/22/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/kafka-connect/overview.md
+++ b/content/en/22/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/kafka-connect/user-guide.md
+++ b/content/en/22/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/operations/basic-kafka-operations.md
+++ b/content/en/22/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/operations/datacenters.md
+++ b/content/en/22/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/operations/hardware-and-os.md
+++ b/content/en/22/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/operations/java-version.md
+++ b/content/en/22/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/operations/kafka-configuration.md
+++ b/content/en/22/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/operations/monitoring.md
+++ b/content/en/22/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/operations/zookeeper.md
+++ b/content/en/22/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/security/authentication-using-sasl.md
+++ b/content/en/22/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/security/authorization-and-acls.md
+++ b/content/en/22/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/22/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/22/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/security/security-overview.md
+++ b/content/en/22/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/22/security/zookeeper-authentication.md
+++ b/content/en/22/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/configuration/adminclient-configs.md
+++ b/content/en/23/configuration/adminclient-configs.md
@@ -1,6 +1,6 @@
 ---
 title: AdminClient Configs
-description: AdminClient Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/configuration/broker-configs.md
+++ b/content/en/23/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/configuration/consumer-configs.md
+++ b/content/en/23/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/configuration/kafka-connect-configs.md
+++ b/content/en/23/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/configuration/kafka-streams-configs.md
+++ b/content/en/23/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/configuration/producer-configs.md
+++ b/content/en/23/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/configuration/topic-level-configs.md
+++ b/content/en/23/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/implementation/distribution.md
+++ b/content/en/23/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/implementation/log.md
+++ b/content/en/23/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/implementation/message-format.md
+++ b/content/en/23/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/implementation/messages.md
+++ b/content/en/23/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/implementation/network-layer.md
+++ b/content/en/23/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/kafka-connect/connector-development-guide.md
+++ b/content/en/23/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/kafka-connect/overview.md
+++ b/content/en/23/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/kafka-connect/user-guide.md
+++ b/content/en/23/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/operations/basic-kafka-operations.md
+++ b/content/en/23/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/operations/datacenters.md
+++ b/content/en/23/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/operations/hardware-and-os.md
+++ b/content/en/23/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/operations/java-version.md
+++ b/content/en/23/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/operations/kafka-configuration.md
+++ b/content/en/23/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/operations/monitoring.md
+++ b/content/en/23/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/operations/zookeeper.md
+++ b/content/en/23/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/security/authentication-using-sasl.md
+++ b/content/en/23/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/security/authorization-and-acls.md
+++ b/content/en/23/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/23/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/23/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/security/security-overview.md
+++ b/content/en/23/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/23/security/zookeeper-authentication.md
+++ b/content/en/23/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/configuration/admin-configs.md
+++ b/content/en/24/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/configuration/broker-configs.md
+++ b/content/en/24/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/configuration/consumer-configs.md
+++ b/content/en/24/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/configuration/kafka-connect-configs.md
+++ b/content/en/24/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/configuration/kafka-streams-configs.md
+++ b/content/en/24/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/configuration/producer-configs.md
+++ b/content/en/24/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/configuration/topic-level-configs.md
+++ b/content/en/24/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/implementation/distribution.md
+++ b/content/en/24/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/implementation/log.md
+++ b/content/en/24/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/implementation/message-format.md
+++ b/content/en/24/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/implementation/messages.md
+++ b/content/en/24/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/implementation/network-layer.md
+++ b/content/en/24/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/kafka-connect/connector-development-guide.md
+++ b/content/en/24/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/kafka-connect/overview.md
+++ b/content/en/24/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/kafka-connect/user-guide.md
+++ b/content/en/24/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/operations/basic-kafka-operations.md
+++ b/content/en/24/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/operations/datacenters.md
+++ b/content/en/24/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/operations/hardware-and-os.md
+++ b/content/en/24/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/operations/java-version.md
+++ b/content/en/24/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/operations/kafka-configuration.md
+++ b/content/en/24/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/operations/monitoring.md
+++ b/content/en/24/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/operations/zookeeper.md
+++ b/content/en/24/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/security/authentication-using-sasl.md
+++ b/content/en/24/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/security/authorization-and-acls.md
+++ b/content/en/24/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/24/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/24/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/security/security-overview.md
+++ b/content/en/24/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/24/security/zookeeper-authentication.md
+++ b/content/en/24/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/configuration/admin-configs.md
+++ b/content/en/25/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/configuration/broker-configs.md
+++ b/content/en/25/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/configuration/consumer-configs.md
+++ b/content/en/25/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/configuration/kafka-connect-configs.md
+++ b/content/en/25/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/configuration/kafka-streams-configs.md
+++ b/content/en/25/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/configuration/producer-configs.md
+++ b/content/en/25/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/configuration/topic-level-configs.md
+++ b/content/en/25/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/implementation/distribution.md
+++ b/content/en/25/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/implementation/log.md
+++ b/content/en/25/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/implementation/message-format.md
+++ b/content/en/25/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/implementation/messages.md
+++ b/content/en/25/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/implementation/network-layer.md
+++ b/content/en/25/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/kafka-connect/connector-development-guide.md
+++ b/content/en/25/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/kafka-connect/overview.md
+++ b/content/en/25/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/kafka-connect/user-guide.md
+++ b/content/en/25/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/operations/basic-kafka-operations.md
+++ b/content/en/25/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/operations/datacenters.md
+++ b/content/en/25/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/operations/hardware-and-os.md
+++ b/content/en/25/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/operations/java-version.md
+++ b/content/en/25/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/operations/kafka-configuration.md
+++ b/content/en/25/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/operations/monitoring.md
+++ b/content/en/25/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/operations/zookeeper.md
+++ b/content/en/25/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/security/authentication-using-sasl.md
+++ b/content/en/25/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/security/authorization-and-acls.md
+++ b/content/en/25/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/25/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/25/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/security/security-overview.md
+++ b/content/en/25/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/security/zookeeper-authentication.md
+++ b/content/en/25/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/25/security/zookeeper-encryption.md
+++ b/content/en/25/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/configuration/admin-configs.md
+++ b/content/en/26/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/configuration/broker-configs.md
+++ b/content/en/26/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/configuration/consumer-configs.md
+++ b/content/en/26/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/configuration/kafka-connect-configs.md
+++ b/content/en/26/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/configuration/kafka-streams-configs.md
+++ b/content/en/26/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/configuration/producer-configs.md
+++ b/content/en/26/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/configuration/topic-level-configs.md
+++ b/content/en/26/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/implementation/distribution.md
+++ b/content/en/26/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/implementation/log.md
+++ b/content/en/26/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/implementation/message-format.md
+++ b/content/en/26/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/implementation/messages.md
+++ b/content/en/26/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/implementation/network-layer.md
+++ b/content/en/26/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/kafka-connect/connector-development-guide.md
+++ b/content/en/26/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/kafka-connect/overview.md
+++ b/content/en/26/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/kafka-connect/user-guide.md
+++ b/content/en/26/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/operations/basic-kafka-operations.md
+++ b/content/en/26/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/operations/datacenters.md
+++ b/content/en/26/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/26/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/operations/hardware-and-os.md
+++ b/content/en/26/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/operations/java-version.md
+++ b/content/en/26/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/operations/kafka-configuration.md
+++ b/content/en/26/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/operations/monitoring.md
+++ b/content/en/26/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/operations/zookeeper.md
+++ b/content/en/26/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/security/authentication-using-sasl.md
+++ b/content/en/26/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/security/authorization-and-acls.md
+++ b/content/en/26/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/26/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/26/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/security/security-overview.md
+++ b/content/en/26/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/security/zookeeper-authentication.md
+++ b/content/en/26/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/26/security/zookeeper-encryption.md
+++ b/content/en/26/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/configuration/admin-configs.md
+++ b/content/en/27/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/configuration/broker-configs.md
+++ b/content/en/27/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/configuration/consumer-configs.md
+++ b/content/en/27/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/configuration/kafka-connect-configs.md
+++ b/content/en/27/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/configuration/kafka-streams-configs.md
+++ b/content/en/27/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/configuration/producer-configs.md
+++ b/content/en/27/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/configuration/topic-level-configs.md
+++ b/content/en/27/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/implementation/distribution.md
+++ b/content/en/27/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/implementation/log.md
+++ b/content/en/27/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/implementation/message-format.md
+++ b/content/en/27/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/implementation/messages.md
+++ b/content/en/27/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/implementation/network-layer.md
+++ b/content/en/27/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/kafka-connect/connector-development-guide.md
+++ b/content/en/27/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/kafka-connect/overview.md
+++ b/content/en/27/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/kafka-connect/user-guide.md
+++ b/content/en/27/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/operations/basic-kafka-operations.md
+++ b/content/en/27/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/operations/datacenters.md
+++ b/content/en/27/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/27/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/operations/hardware-and-os.md
+++ b/content/en/27/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/operations/java-version.md
+++ b/content/en/27/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/operations/kafka-configuration.md
+++ b/content/en/27/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/operations/monitoring.md
+++ b/content/en/27/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/operations/multi-tenancy.md
+++ b/content/en/27/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/operations/zookeeper.md
+++ b/content/en/27/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/security/authentication-using-sasl.md
+++ b/content/en/27/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/security/authorization-and-acls.md
+++ b/content/en/27/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/27/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/27/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/security/security-overview.md
+++ b/content/en/27/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/security/zookeeper-authentication.md
+++ b/content/en/27/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/27/security/zookeeper-encryption.md
+++ b/content/en/27/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/configuration/admin-configs.md
+++ b/content/en/28/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/configuration/broker-configs.md
+++ b/content/en/28/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/configuration/consumer-configs.md
+++ b/content/en/28/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/configuration/kafka-connect-configs.md
+++ b/content/en/28/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/configuration/kafka-streams-configs.md
+++ b/content/en/28/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/configuration/producer-configs.md
+++ b/content/en/28/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/configuration/topic-level-configs.md
+++ b/content/en/28/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/implementation/distribution.md
+++ b/content/en/28/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/implementation/log.md
+++ b/content/en/28/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/implementation/message-format.md
+++ b/content/en/28/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/implementation/messages.md
+++ b/content/en/28/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/implementation/network-layer.md
+++ b/content/en/28/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/kafka-connect/connector-development-guide.md
+++ b/content/en/28/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/kafka-connect/overview.md
+++ b/content/en/28/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/kafka-connect/user-guide.md
+++ b/content/en/28/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/operations/basic-kafka-operations.md
+++ b/content/en/28/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/operations/datacenters.md
+++ b/content/en/28/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/28/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/operations/hardware-and-os.md
+++ b/content/en/28/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/operations/java-version.md
+++ b/content/en/28/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/operations/kafka-configuration.md
+++ b/content/en/28/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/operations/monitoring.md
+++ b/content/en/28/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/operations/multi-tenancy.md
+++ b/content/en/28/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/operations/zookeeper.md
+++ b/content/en/28/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/security/authentication-using-sasl.md
+++ b/content/en/28/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/security/authorization-and-acls.md
+++ b/content/en/28/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/28/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/28/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/security/security-overview.md
+++ b/content/en/28/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/security/zookeeper-authentication.md
+++ b/content/en/28/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/28/security/zookeeper-encryption.md
+++ b/content/en/28/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/configuration/admin-configs.md
+++ b/content/en/30/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/configuration/broker-configs.md
+++ b/content/en/30/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/configuration/consumer-configs.md
+++ b/content/en/30/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/configuration/kafka-connect-configs.md
+++ b/content/en/30/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/configuration/kafka-streams-configs.md
+++ b/content/en/30/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/configuration/producer-configs.md
+++ b/content/en/30/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/configuration/topic-level-configs.md
+++ b/content/en/30/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/implementation/distribution.md
+++ b/content/en/30/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/implementation/log.md
+++ b/content/en/30/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/implementation/message-format.md
+++ b/content/en/30/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/implementation/messages.md
+++ b/content/en/30/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/implementation/network-layer.md
+++ b/content/en/30/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/kafka-connect/connector-development-guide.md
+++ b/content/en/30/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/kafka-connect/overview.md
+++ b/content/en/30/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/kafka-connect/user-guide.md
+++ b/content/en/30/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/operations/basic-kafka-operations.md
+++ b/content/en/30/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/operations/datacenters.md
+++ b/content/en/30/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/30/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/operations/hardware-and-os.md
+++ b/content/en/30/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/operations/java-version.md
+++ b/content/en/30/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/operations/kafka-configuration.md
+++ b/content/en/30/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/operations/monitoring.md
+++ b/content/en/30/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/operations/multi-tenancy.md
+++ b/content/en/30/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/operations/zookeeper.md
+++ b/content/en/30/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/security/authentication-using-sasl.md
+++ b/content/en/30/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/security/authorization-and-acls.md
+++ b/content/en/30/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/30/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/30/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/security/security-overview.md
+++ b/content/en/30/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/security/zookeeper-authentication.md
+++ b/content/en/30/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/30/security/zookeeper-encryption.md
+++ b/content/en/30/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/configuration/admin-configs.md
+++ b/content/en/31/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/configuration/broker-configs.md
+++ b/content/en/31/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/configuration/consumer-configs.md
+++ b/content/en/31/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/configuration/kafka-connect-configs.md
+++ b/content/en/31/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/configuration/kafka-streams-configs.md
+++ b/content/en/31/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/configuration/producer-configs.md
+++ b/content/en/31/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/configuration/topic-level-configs.md
+++ b/content/en/31/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/implementation/distribution.md
+++ b/content/en/31/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/implementation/log.md
+++ b/content/en/31/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/implementation/message-format.md
+++ b/content/en/31/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/implementation/messages.md
+++ b/content/en/31/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/implementation/network-layer.md
+++ b/content/en/31/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/kafka-connect/connector-development-guide.md
+++ b/content/en/31/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/kafka-connect/overview.md
+++ b/content/en/31/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/kafka-connect/user-guide.md
+++ b/content/en/31/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/operations/basic-kafka-operations.md
+++ b/content/en/31/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/operations/datacenters.md
+++ b/content/en/31/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/31/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/operations/hardware-and-os.md
+++ b/content/en/31/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/operations/java-version.md
+++ b/content/en/31/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/operations/kafka-configuration.md
+++ b/content/en/31/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/operations/monitoring.md
+++ b/content/en/31/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/operations/multi-tenancy.md
+++ b/content/en/31/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/operations/zookeeper.md
+++ b/content/en/31/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/security/authentication-using-sasl.md
+++ b/content/en/31/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/security/authorization-and-acls.md
+++ b/content/en/31/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/31/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/31/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/security/security-overview.md
+++ b/content/en/31/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/security/zookeeper-authentication.md
+++ b/content/en/31/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/31/security/zookeeper-encryption.md
+++ b/content/en/31/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/configuration/admin-configs.md
+++ b/content/en/32/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/configuration/broker-configs.md
+++ b/content/en/32/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/configuration/consumer-configs.md
+++ b/content/en/32/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/configuration/kafka-connect-configs.md
+++ b/content/en/32/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/configuration/kafka-streams-configs.md
+++ b/content/en/32/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/configuration/producer-configs.md
+++ b/content/en/32/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/configuration/topic-level-configs.md
+++ b/content/en/32/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/implementation/distribution.md
+++ b/content/en/32/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/implementation/log.md
+++ b/content/en/32/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/implementation/message-format.md
+++ b/content/en/32/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/implementation/messages.md
+++ b/content/en/32/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/implementation/network-layer.md
+++ b/content/en/32/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/kafka-connect/connector-development-guide.md
+++ b/content/en/32/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/kafka-connect/overview.md
+++ b/content/en/32/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/kafka-connect/user-guide.md
+++ b/content/en/32/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/operations/basic-kafka-operations.md
+++ b/content/en/32/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/operations/datacenters.md
+++ b/content/en/32/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/32/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/operations/hardware-and-os.md
+++ b/content/en/32/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/operations/java-version.md
+++ b/content/en/32/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/operations/kafka-configuration.md
+++ b/content/en/32/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/operations/monitoring.md
+++ b/content/en/32/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/operations/multi-tenancy.md
+++ b/content/en/32/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/operations/zookeeper.md
+++ b/content/en/32/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/security/authentication-using-sasl.md
+++ b/content/en/32/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/security/authorization-and-acls.md
+++ b/content/en/32/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/32/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/32/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/security/security-overview.md
+++ b/content/en/32/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/security/zookeeper-authentication.md
+++ b/content/en/32/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/32/security/zookeeper-encryption.md
+++ b/content/en/32/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/configuration/admin-configs.md
+++ b/content/en/33/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/configuration/broker-configs.md
+++ b/content/en/33/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/configuration/consumer-configs.md
+++ b/content/en/33/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/configuration/kafka-connect-configs.md
+++ b/content/en/33/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/configuration/kafka-streams-configs.md
+++ b/content/en/33/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/configuration/producer-configs.md
+++ b/content/en/33/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/configuration/topic-level-configs.md
+++ b/content/en/33/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/implementation/distribution.md
+++ b/content/en/33/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/implementation/log.md
+++ b/content/en/33/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/implementation/message-format.md
+++ b/content/en/33/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/implementation/messages.md
+++ b/content/en/33/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/implementation/network-layer.md
+++ b/content/en/33/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/kafka-connect/connector-development-guide.md
+++ b/content/en/33/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/kafka-connect/overview.md
+++ b/content/en/33/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/kafka-connect/user-guide.md
+++ b/content/en/33/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/basic-kafka-operations.md
+++ b/content/en/33/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/datacenters.md
+++ b/content/en/33/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/33/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/hardware-and-os.md
+++ b/content/en/33/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/java-version.md
+++ b/content/en/33/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/kafka-configuration.md
+++ b/content/en/33/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/kraft.md
+++ b/content/en/33/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/monitoring.md
+++ b/content/en/33/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/multi-tenancy.md
+++ b/content/en/33/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/operations/zookeeper.md
+++ b/content/en/33/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/security/authentication-using-sasl.md
+++ b/content/en/33/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/security/authorization-and-acls.md
+++ b/content/en/33/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/33/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/33/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/security/listener-configuration.md
+++ b/content/en/33/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/security/security-overview.md
+++ b/content/en/33/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/security/zookeeper-authentication.md
+++ b/content/en/33/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/33/security/zookeeper-encryption.md
+++ b/content/en/33/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/configuration/admin-configs.md
+++ b/content/en/34/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/configuration/broker-configs.md
+++ b/content/en/34/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/configuration/consumer-configs.md
+++ b/content/en/34/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/configuration/kafka-connect-configs.md
+++ b/content/en/34/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/configuration/kafka-streams-configs.md
+++ b/content/en/34/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/configuration/producer-configs.md
+++ b/content/en/34/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/configuration/system-properties.md
+++ b/content/en/34/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/configuration/topic-level-configs.md
+++ b/content/en/34/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/implementation/distribution.md
+++ b/content/en/34/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/implementation/log.md
+++ b/content/en/34/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/implementation/message-format.md
+++ b/content/en/34/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/implementation/messages.md
+++ b/content/en/34/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/implementation/network-layer.md
+++ b/content/en/34/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/kafka-connect/connector-development-guide.md
+++ b/content/en/34/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/kafka-connect/overview.md
+++ b/content/en/34/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/kafka-connect/user-guide.md
+++ b/content/en/34/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/basic-kafka-operations.md
+++ b/content/en/34/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/datacenters.md
+++ b/content/en/34/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/34/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/hardware-and-os.md
+++ b/content/en/34/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/java-version.md
+++ b/content/en/34/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/kafka-configuration.md
+++ b/content/en/34/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/kraft.md
+++ b/content/en/34/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/monitoring.md
+++ b/content/en/34/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/multi-tenancy.md
+++ b/content/en/34/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/operations/zookeeper.md
+++ b/content/en/34/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/security/authentication-using-sasl.md
+++ b/content/en/34/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/security/authorization-and-acls.md
+++ b/content/en/34/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/34/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/34/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/security/listener-configuration.md
+++ b/content/en/34/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/security/security-overview.md
+++ b/content/en/34/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/security/zookeeper-authentication.md
+++ b/content/en/34/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/34/security/zookeeper-encryption.md
+++ b/content/en/34/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/configuration/admin-configs.md
+++ b/content/en/35/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/configuration/broker-configs.md
+++ b/content/en/35/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/configuration/consumer-configs.md
+++ b/content/en/35/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/configuration/kafka-connect-configs.md
+++ b/content/en/35/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/configuration/kafka-streams-configs.md
+++ b/content/en/35/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/configuration/producer-configs.md
+++ b/content/en/35/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/configuration/system-properties.md
+++ b/content/en/35/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/configuration/topic-level-configs.md
+++ b/content/en/35/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/implementation/distribution.md
+++ b/content/en/35/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/implementation/log.md
+++ b/content/en/35/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/implementation/message-format.md
+++ b/content/en/35/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/implementation/messages.md
+++ b/content/en/35/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/implementation/network-layer.md
+++ b/content/en/35/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/kafka-connect/administration.md
+++ b/content/en/35/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/kafka-connect/connector-development-guide.md
+++ b/content/en/35/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/kafka-connect/overview.md
+++ b/content/en/35/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/kafka-connect/user-guide.md
+++ b/content/en/35/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/basic-kafka-operations.md
+++ b/content/en/35/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/datacenters.md
+++ b/content/en/35/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/35/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/hardware-and-os.md
+++ b/content/en/35/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/java-version.md
+++ b/content/en/35/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/kafka-configuration.md
+++ b/content/en/35/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/kraft.md
+++ b/content/en/35/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/monitoring.md
+++ b/content/en/35/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/multi-tenancy.md
+++ b/content/en/35/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/operations/zookeeper.md
+++ b/content/en/35/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/security/authentication-using-sasl.md
+++ b/content/en/35/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/security/authorization-and-acls.md
+++ b/content/en/35/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/35/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/35/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/security/listener-configuration.md
+++ b/content/en/35/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/security/security-overview.md
+++ b/content/en/35/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/security/zookeeper-authentication.md
+++ b/content/en/35/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/35/security/zookeeper-encryption.md
+++ b/content/en/35/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/admin-configs.md
+++ b/content/en/36/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/broker-configs.md
+++ b/content/en/36/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/consumer-configs.md
+++ b/content/en/36/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/kafka-connect-configs.md
+++ b/content/en/36/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/kafka-streams-configs.md
+++ b/content/en/36/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/mirrormaker-configs.md
+++ b/content/en/36/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/producer-configs.md
+++ b/content/en/36/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/system-properties.md
+++ b/content/en/36/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/tiered-storage-configs.md
+++ b/content/en/36/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/configuration/topic-level-configs.md
+++ b/content/en/36/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/implementation/distribution.md
+++ b/content/en/36/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/implementation/log.md
+++ b/content/en/36/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/implementation/message-format.md
+++ b/content/en/36/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/implementation/messages.md
+++ b/content/en/36/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/implementation/network-layer.md
+++ b/content/en/36/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/kafka-connect/administration.md
+++ b/content/en/36/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/kafka-connect/connector-development-guide.md
+++ b/content/en/36/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/kafka-connect/overview.md
+++ b/content/en/36/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/kafka-connect/user-guide.md
+++ b/content/en/36/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/basic-kafka-operations.md
+++ b/content/en/36/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/datacenters.md
+++ b/content/en/36/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/36/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/hardware-and-os.md
+++ b/content/en/36/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/java-version.md
+++ b/content/en/36/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/kafka-configuration.md
+++ b/content/en/36/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/kraft.md
+++ b/content/en/36/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/monitoring.md
+++ b/content/en/36/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/multi-tenancy.md
+++ b/content/en/36/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/tiered-storage.md
+++ b/content/en/36/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/operations/zookeeper.md
+++ b/content/en/36/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/security/authentication-using-sasl.md
+++ b/content/en/36/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/security/authorization-and-acls.md
+++ b/content/en/36/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/36/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/36/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/security/listener-configuration.md
+++ b/content/en/36/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/security/security-overview.md
+++ b/content/en/36/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/security/zookeeper-authentication.md
+++ b/content/en/36/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/36/security/zookeeper-encryption.md
+++ b/content/en/36/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/admin-configs.md
+++ b/content/en/37/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/broker-configs.md
+++ b/content/en/37/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/consumer-configs.md
+++ b/content/en/37/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/kafka-connect-configs.md
+++ b/content/en/37/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/kafka-streams-configs.md
+++ b/content/en/37/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/mirrormaker-configs.md
+++ b/content/en/37/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/producer-configs.md
+++ b/content/en/37/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/system-properties.md
+++ b/content/en/37/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/tiered-storage-configs.md
+++ b/content/en/37/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/configuration/topic-level-configs.md
+++ b/content/en/37/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/implementation/distribution.md
+++ b/content/en/37/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/implementation/log.md
+++ b/content/en/37/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/implementation/message-format.md
+++ b/content/en/37/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/implementation/messages.md
+++ b/content/en/37/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/implementation/network-layer.md
+++ b/content/en/37/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/kafka-connect/administration.md
+++ b/content/en/37/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/kafka-connect/connector-development-guide.md
+++ b/content/en/37/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/kafka-connect/overview.md
+++ b/content/en/37/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/kafka-connect/user-guide.md
+++ b/content/en/37/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/basic-kafka-operations.md
+++ b/content/en/37/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/datacenters.md
+++ b/content/en/37/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/37/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/hardware-and-os.md
+++ b/content/en/37/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/java-version.md
+++ b/content/en/37/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/kafka-configuration.md
+++ b/content/en/37/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/kraft.md
+++ b/content/en/37/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/monitoring.md
+++ b/content/en/37/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/multi-tenancy.md
+++ b/content/en/37/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/tiered-storage.md
+++ b/content/en/37/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/operations/zookeeper.md
+++ b/content/en/37/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/security/authentication-using-sasl.md
+++ b/content/en/37/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/security/authorization-and-acls.md
+++ b/content/en/37/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/37/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/37/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/security/listener-configuration.md
+++ b/content/en/37/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/security/security-overview.md
+++ b/content/en/37/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/security/zookeeper-authentication.md
+++ b/content/en/37/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/37/security/zookeeper-encryption.md
+++ b/content/en/37/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/admin-configs.md
+++ b/content/en/38/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/broker-configs.md
+++ b/content/en/38/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/consumer-configs.md
+++ b/content/en/38/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/kafka-connect-configs.md
+++ b/content/en/38/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/kafka-streams-configs.md
+++ b/content/en/38/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/mirrormaker-configs.md
+++ b/content/en/38/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/producer-configs.md
+++ b/content/en/38/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/system-properties.md
+++ b/content/en/38/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/tiered-storage-configs.md
+++ b/content/en/38/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/configuration/topic-level-configs.md
+++ b/content/en/38/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/implementation/distribution.md
+++ b/content/en/38/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/implementation/log.md
+++ b/content/en/38/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/implementation/message-format.md
+++ b/content/en/38/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/implementation/messages.md
+++ b/content/en/38/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/implementation/network-layer.md
+++ b/content/en/38/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/kafka-connect/administration.md
+++ b/content/en/38/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/kafka-connect/connector-development-guide.md
+++ b/content/en/38/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/kafka-connect/overview.md
+++ b/content/en/38/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/kafka-connect/user-guide.md
+++ b/content/en/38/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/basic-kafka-operations.md
+++ b/content/en/38/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/datacenters.md
+++ b/content/en/38/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/38/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/hardware-and-os.md
+++ b/content/en/38/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/java-version.md
+++ b/content/en/38/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/kafka-configuration.md
+++ b/content/en/38/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/kraft.md
+++ b/content/en/38/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/monitoring.md
+++ b/content/en/38/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/multi-tenancy.md
+++ b/content/en/38/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/tiered-storage.md
+++ b/content/en/38/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/operations/zookeeper.md
+++ b/content/en/38/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/security/authentication-using-sasl.md
+++ b/content/en/38/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/security/authorization-and-acls.md
+++ b/content/en/38/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/38/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/38/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/security/listener-configuration.md
+++ b/content/en/38/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/security/security-overview.md
+++ b/content/en/38/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/security/zookeeper-authentication.md
+++ b/content/en/38/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/38/security/zookeeper-encryption.md
+++ b/content/en/38/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/admin-configs.md
+++ b/content/en/39/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/broker-configs.md
+++ b/content/en/39/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/configuration-providers.md
+++ b/content/en/39/configuration/configuration-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Providers
-description: Configuration Providers
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/consumer-configs.md
+++ b/content/en/39/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/kafka-connect-configs.md
+++ b/content/en/39/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/kafka-streams-configs.md
+++ b/content/en/39/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/mirrormaker-configs.md
+++ b/content/en/39/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/producer-configs.md
+++ b/content/en/39/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/system-properties.md
+++ b/content/en/39/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/tiered-storage-configs.md
+++ b/content/en/39/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/configuration/topic-level-configs.md
+++ b/content/en/39/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/implementation/distribution.md
+++ b/content/en/39/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/implementation/log.md
+++ b/content/en/39/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/implementation/message-format.md
+++ b/content/en/39/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/implementation/messages.md
+++ b/content/en/39/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/implementation/network-layer.md
+++ b/content/en/39/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/kafka-connect/administration.md
+++ b/content/en/39/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/kafka-connect/connector-development-guide.md
+++ b/content/en/39/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/kafka-connect/overview.md
+++ b/content/en/39/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/kafka-connect/user-guide.md
+++ b/content/en/39/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/basic-kafka-operations.md
+++ b/content/en/39/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/datacenters.md
+++ b/content/en/39/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/39/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/hardware-and-os.md
+++ b/content/en/39/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/java-version.md
+++ b/content/en/39/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/kafka-configuration.md
+++ b/content/en/39/operations/kafka-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Configuration
-description: Kafka Configuration
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/kraft.md
+++ b/content/en/39/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/monitoring.md
+++ b/content/en/39/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/multi-tenancy.md
+++ b/content/en/39/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/tiered-storage.md
+++ b/content/en/39/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/operations/zookeeper.md
+++ b/content/en/39/operations/zookeeper.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper
-description: ZooKeeper
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/security/authentication-using-sasl.md
+++ b/content/en/39/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/security/authorization-and-acls.md
+++ b/content/en/39/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/39/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/39/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/security/listener-configuration.md
+++ b/content/en/39/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/security/security-overview.md
+++ b/content/en/39/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/security/zookeeper-authentication.md
+++ b/content/en/39/security/zookeeper-authentication.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Authentication
-description: ZooKeeper Authentication
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/39/security/zookeeper-encryption.md
+++ b/content/en/39/security/zookeeper-encryption.md
@@ -1,6 +1,6 @@
 ---
 title: ZooKeeper Encryption
-description: ZooKeeper Encryption
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/admin-configs.md
+++ b/content/en/40/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/broker-configs.md
+++ b/content/en/40/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/configuration-providers.md
+++ b/content/en/40/configuration/configuration-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Providers
-description: Configuration Providers
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/consumer-configs.md
+++ b/content/en/40/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/kafka-connect-configs.md
+++ b/content/en/40/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/kafka-streams-configs.md
+++ b/content/en/40/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/mirrormaker-configs.md
+++ b/content/en/40/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/producer-configs.md
+++ b/content/en/40/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/system-properties.md
+++ b/content/en/40/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/tiered-storage-configs.md
+++ b/content/en/40/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/configuration/topic-level-configs.md
+++ b/content/en/40/configuration/topic-level-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic-Level Configs
-description: Topic-Level Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/implementation/distribution.md
+++ b/content/en/40/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/implementation/log.md
+++ b/content/en/40/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/implementation/message-format.md
+++ b/content/en/40/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/implementation/messages.md
+++ b/content/en/40/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/implementation/network-layer.md
+++ b/content/en/40/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/kafka-connect/administration.md
+++ b/content/en/40/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/kafka-connect/connector-development-guide.md
+++ b/content/en/40/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/kafka-connect/overview.md
+++ b/content/en/40/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/kafka-connect/user-guide.md
+++ b/content/en/40/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/basic-kafka-operations.md
+++ b/content/en/40/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/consumer-rebalance-protocol.md
+++ b/content/en/40/operations/consumer-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Rebalance Protocol
-description: Consumer Rebalance Protocol
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/datacenters.md
+++ b/content/en/40/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/eligible-leader-replicas.md
+++ b/content/en/40/operations/eligible-leader-replicas.md
@@ -1,6 +1,6 @@
 ---
 title: Eligible Leader Replicas
-description: Eligible Leader Replicas
+description: 
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/40/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/hardware-and-os.md
+++ b/content/en/40/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/java-version.md
+++ b/content/en/40/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/kraft.md
+++ b/content/en/40/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/monitoring.md
+++ b/content/en/40/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/multi-tenancy.md
+++ b/content/en/40/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/tiered-storage.md
+++ b/content/en/40/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/operations/transaction-protocol.md
+++ b/content/en/40/operations/transaction-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Transaction Protocol
-description: Transaction Protocol
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/security/authentication-using-sasl.md
+++ b/content/en/40/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/security/authorization-and-acls.md
+++ b/content/en/40/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/40/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/40/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/security/listener-configuration.md
+++ b/content/en/40/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/40/security/security-overview.md
+++ b/content/en/40/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/admin-configs.md
+++ b/content/en/41/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/broker-configs.md
+++ b/content/en/41/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/configuration-providers.md
+++ b/content/en/41/configuration/configuration-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Providers
-description: Configuration Providers
+description: 
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/consumer-configs.md
+++ b/content/en/41/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/group-configs.md
+++ b/content/en/41/configuration/group-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Group Configs
-description: Group Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/kafka-connect-configs.md
+++ b/content/en/41/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/kafka-streams-configs.md
+++ b/content/en/41/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/mirrormaker-configs.md
+++ b/content/en/41/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/producer-configs.md
+++ b/content/en/41/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/system-properties.md
+++ b/content/en/41/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/tiered-storage-configs.md
+++ b/content/en/41/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/topic-configs.md
+++ b/content/en/41/configuration/topic-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic Configs
-description: Topic Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/distribution.md
+++ b/content/en/41/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/log.md
+++ b/content/en/41/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/message-format.md
+++ b/content/en/41/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/messages.md
+++ b/content/en/41/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/network-layer.md
+++ b/content/en/41/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/kafka-connect/administration.md
+++ b/content/en/41/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/kafka-connect/connector-development-guide.md
+++ b/content/en/41/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/kafka-connect/overview.md
+++ b/content/en/41/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/kafka-connect/user-guide.md
+++ b/content/en/41/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/basic-kafka-operations.md
+++ b/content/en/41/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/consumer-rebalance-protocol.md
+++ b/content/en/41/operations/consumer-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Rebalance Protocol
-description: Consumer Rebalance Protocol
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/datacenters.md
+++ b/content/en/41/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/eligible-leader-replicas.md
+++ b/content/en/41/operations/eligible-leader-replicas.md
@@ -1,6 +1,6 @@
 ---
 title: Eligible Leader Replicas
-description: Eligible Leader Replicas
+description: 
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/41/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/hardware-and-os.md
+++ b/content/en/41/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/java-version.md
+++ b/content/en/41/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/kraft.md
+++ b/content/en/41/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/monitoring.md
+++ b/content/en/41/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/multi-tenancy.md
+++ b/content/en/41/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/tiered-storage.md
+++ b/content/en/41/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/transaction-protocol.md
+++ b/content/en/41/operations/transaction-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Transaction Protocol
-description: Transaction Protocol
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/authentication-using-sasl.md
+++ b/content/en/41/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/authorization-and-acls.md
+++ b/content/en/41/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/41/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/41/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/listener-configuration.md
+++ b/content/en/41/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/security-overview.md
+++ b/content/en/41/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/admin-configs.md
+++ b/content/en/42/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/broker-configs.md
+++ b/content/en/42/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/configuration-providers.md
+++ b/content/en/42/configuration/configuration-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Providers
-description: Configuration Providers
+description: 
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/consumer-configs.md
+++ b/content/en/42/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/group-configs.md
+++ b/content/en/42/configuration/group-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Group Configs
-description: Group Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/kafka-connect-configs.md
+++ b/content/en/42/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/kafka-streams-configs.md
+++ b/content/en/42/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/mirrormaker-configs.md
+++ b/content/en/42/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/producer-configs.md
+++ b/content/en/42/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/system-properties.md
+++ b/content/en/42/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/tiered-storage-configs.md
+++ b/content/en/42/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/topic-configs.md
+++ b/content/en/42/configuration/topic-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic Configs
-description: Topic Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/distribution.md
+++ b/content/en/42/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/log.md
+++ b/content/en/42/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/message-format.md
+++ b/content/en/42/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/messages.md
+++ b/content/en/42/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/network-layer.md
+++ b/content/en/42/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/kafka-connect/administration.md
+++ b/content/en/42/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/kafka-connect/connector-development-guide.md
+++ b/content/en/42/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/kafka-connect/overview.md
+++ b/content/en/42/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/kafka-connect/user-guide.md
+++ b/content/en/42/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/basic-kafka-operations.md
+++ b/content/en/42/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/consumer-rebalance-protocol.md
+++ b/content/en/42/operations/consumer-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Rebalance Protocol
-description: Consumer Rebalance Protocol
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/datacenters.md
+++ b/content/en/42/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/eligible-leader-replicas.md
+++ b/content/en/42/operations/eligible-leader-replicas.md
@@ -1,6 +1,6 @@
 ---
 title: Eligible Leader Replicas
-description: Eligible Leader Replicas
+description: 
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/42/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/hardware-and-os.md
+++ b/content/en/42/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/java-version.md
+++ b/content/en/42/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/kraft.md
+++ b/content/en/42/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/monitoring.md
+++ b/content/en/42/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/multi-tenancy.md
+++ b/content/en/42/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/tiered-storage.md
+++ b/content/en/42/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/transaction-protocol.md
+++ b/content/en/42/operations/transaction-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Transaction Protocol
-description: Transaction Protocol
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/authentication-using-sasl.md
+++ b/content/en/42/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/authorization-and-acls.md
+++ b/content/en/42/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/42/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/42/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/listener-configuration.md
+++ b/content/en/42/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/security-overview.md
+++ b/content/en/42/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/admin-configs.md
+++ b/content/en/43/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/broker-configs.md
+++ b/content/en/43/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/configuration-providers.md
+++ b/content/en/43/configuration/configuration-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Providers
-description: Configuration Providers
+description: 
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/consumer-configs.md
+++ b/content/en/43/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer and Share Consumer Configs
-description: Consumer and Share Consumer Configs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/group-configs.md
+++ b/content/en/43/configuration/group-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Group Configs
-description: Group Configs
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/kafka-connect-configs.md
+++ b/content/en/43/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/kafka-streams-configs.md
+++ b/content/en/43/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/mirrormaker-configs.md
+++ b/content/en/43/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/producer-configs.md
+++ b/content/en/43/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/system-properties.md
+++ b/content/en/43/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/tiered-storage-configs.md
+++ b/content/en/43/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/topic-configs.md
+++ b/content/en/43/configuration/topic-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic Configs
-description: Topic Configs
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/distribution.md
+++ b/content/en/43/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/log.md
+++ b/content/en/43/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/message-format.md
+++ b/content/en/43/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/messages.md
+++ b/content/en/43/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/network-layer.md
+++ b/content/en/43/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/kafka-connect/administration.md
+++ b/content/en/43/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/kafka-connect/connector-development-guide.md
+++ b/content/en/43/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/kafka-connect/overview.md
+++ b/content/en/43/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/kafka-connect/user-guide.md
+++ b/content/en/43/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/basic-kafka-operations.md
+++ b/content/en/43/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/consumer-rebalance-protocol.md
+++ b/content/en/43/operations/consumer-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Rebalance Protocol
-description: Consumer Rebalance Protocol
+description: 
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/datacenters.md
+++ b/content/en/43/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/eligible-leader-replicas.md
+++ b/content/en/43/operations/eligible-leader-replicas.md
@@ -1,6 +1,6 @@
 ---
 title: Eligible Leader Replicas
-description: Eligible Leader Replicas
+description: 
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/43/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/hardware-and-os.md
+++ b/content/en/43/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/java-version.md
+++ b/content/en/43/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/kraft.md
+++ b/content/en/43/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: 
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/monitoring.md
+++ b/content/en/43/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: 
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/multi-tenancy.md
+++ b/content/en/43/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/tiered-storage.md
+++ b/content/en/43/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: 
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/transaction-protocol.md
+++ b/content/en/43/operations/transaction-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Transaction Protocol
-description: Transaction Protocol
+description: 
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/authentication-using-sasl.md
+++ b/content/en/43/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: 
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/authorization-and-acls.md
+++ b/content/en/43/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: 
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/43/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: 
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/43/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: 
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/listener-configuration.md
+++ b/content/en/43/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: 
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/security-overview.md
+++ b/content/en/43/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: 
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 


### PR DESCRIPTION
apache/kafka#22605 fixed duplicate/blank section descriptions in the
docs/ source, but kafka-site doesn't auto-sync from kafka trunk — the
already-published 4.3.X pages here were untouched. This backports the
same description text to the 82 matching files under content/en/43/, so
the live site gets the fix now instead of waiting for the next release.

Before:


After: