### PR TITLE
KAFKA-20009: Sync doc description fix from kafka trunk to active pages

### DIFF
--- a/content/en/41/_index.md
+++ b/content/en/41/_index.md
@@ -1,6 +1,6 @@
 ---
 title: AK 4.1.X
-description: Documentation for AK 4.1.X
+description: Apache Kafka documentation for version 4.1.x.
 weight: 
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/apis/_index.md
+++ b/content/en/41/apis/_index.md
@@ -1,6 +1,6 @@
 ---
 title: API
-description: 
+description: An overview of the core Kafka APIs for client applications, stream processing, Connect integrations, and cluster administration.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/_index.md
+++ b/content/en/41/configuration/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: 
+description: Kafka configuration reference for clusters, clients, and supporting components.
 weight: 3
 tags: ['kafka', 'docs', 'configuration']
 aliases: 

--- a/content/en/41/configuration/admin-configs.md
+++ b/content/en/41/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: Kafka Admin client configuration reference.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/broker-configs.md
+++ b/content/en/41/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: Kafka broker configuration reference.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/configuration-providers.md
+++ b/content/en/41/configuration/configuration-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Providers
-description: Configuration Providers
+description: Kafka configuration providers for loading configuration values from external sources.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/consumer-configs.md
+++ b/content/en/41/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: Kafka consumer configuration reference.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/group-configs.md
+++ b/content/en/41/configuration/group-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Group Configs
-description: Group Configs
+description: Kafka group configuration reference for consumer, share, and streams groups.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/kafka-connect-configs.md
+++ b/content/en/41/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: Kafka Connect configuration reference.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/kafka-streams-configs.md
+++ b/content/en/41/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: Kafka Streams configuration reference.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/mirrormaker-configs.md
+++ b/content/en/41/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: Kafka MirrorMaker configuration reference.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/producer-configs.md
+++ b/content/en/41/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: Kafka producer configuration reference.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/system-properties.md
+++ b/content/en/41/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: Java system properties used to configure Kafka components.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/tiered-storage-configs.md
+++ b/content/en/41/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: Kafka tiered storage configuration reference.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/configuration/topic-configs.md
+++ b/content/en/41/configuration/topic-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic Configs
-description: Topic Configs
+description: Kafka topic configuration reference.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/design/_index.md
+++ b/content/en/41/design/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Design
-description: 
+description: Kafka architecture, design principles, and wire protocol.
 weight: 4
 tags: ['kafka', 'docs', 'design']
 aliases: 

--- a/content/en/41/design/design.md
+++ b/content/en/41/design/design.md
@@ -1,6 +1,6 @@
 ---
 title: Design
-description: 
+description: Kafka architecture design and the principles behind its core features.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/design/protocol.md
+++ b/content/en/41/design/protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Protocol
-description: 
+description: Kafka communication protocol, request formats, API versions, and client implementation details.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/getting-started/_index.md
+++ b/content/en/41/getting-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: This section provides an overview of what Kafka is, why it is useful, and how to get started using it.
+description: Start here to learn Kafka fundamentals and common use cases, try a local setup, and find Docker, upgrade, and compatibility guidance.
 weight: 1
 tags: ['kafka', 'docs', 'getting-started']
 aliases: 

--- a/content/en/41/getting-started/compatibility.md
+++ b/content/en/41/getting-started/compatibility.md
@@ -1,6 +1,6 @@
 ---
 title: Compatibility
-description: 
+description: Check Java, server, and client/broker compatibility matrices for planning Kafka upgrades.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/getting-started/docker.md
+++ b/content/en/41/getting-started/docker.md
@@ -1,6 +1,6 @@
 ---
 title: Docker
-description: 
+description: Learn how to pull and run the Kafka JVM Docker image and the experimental native Docker image.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/getting-started/ecosystem.md
+++ b/content/en/41/getting-started/ecosystem.md
@@ -1,6 +1,6 @@
 ---
 title: Ecosystem
-description: 
+description: Discover tools and integrations that extend Kafka beyond the main distribution.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/getting-started/introduction.md
+++ b/content/en/41/getting-started/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: 
+description: Learn what event streaming is, how Kafka works, and the core Kafka concepts and APIs.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/getting-started/quickstart.md
+++ b/content/en/41/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: 
+description: Run Kafka locally, create a topic, produce and consume events, and explore Kafka Connect and Kafka Streams.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/getting-started/upgrade.md
+++ b/content/en/41/getting-started/upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading
-description: 
+description: Find upgrade steps for Kafka clusters and clients, along with compatibility requirements and notable changes across releases.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/getting-started/uses.md
+++ b/content/en/41/getting-started/uses.md
@@ -1,6 +1,6 @@
 ---
 title: Use Cases
-description: 
+description: Explore common Kafka use cases for messaging, activity tracking, stream processing, and storing event data.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/getting-started/zk2kraft.md
+++ b/content/en/41/getting-started/zk2kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft vs ZooKeeper
-description: 
+description: Understand how KRaft mode differs from ZooKeeper mode, including removed features, metric changes, and behavioral changes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/_index.md
+++ b/content/en/41/implementation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Implementation
-description: 
+description: Kafka implementation internals for data storage, records, networking, and offset tracking.
 weight: 5
 tags: ['kafka', 'docs', 'implementation']
 aliases: 

--- a/content/en/41/implementation/distribution.md
+++ b/content/en/41/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: Kafka consumer offset tracking via the group coordinator.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/log.md
+++ b/content/en/41/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: Kafka log storage format and segment management.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/message-format.md
+++ b/content/en/41/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: The on-disk binary formats for Kafka record batches and records.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/messages.md
+++ b/content/en/41/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: Kafka message structure, including headers and opaque key/value payloads.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/implementation/network-layer.md
+++ b/content/en/41/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: Kafka NIO-based network layer implementation.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/kafka-connect/_index.md
+++ b/content/en/41/kafka-connect/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect
-description: 
+description: Kafka Connect documentation for integrating Kafka with external systems.
 weight: 8
 tags: ['kafka', 'docs', 'connect']
 aliases: 

--- a/content/en/41/kafka-connect/administration.md
+++ b/content/en/41/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: Kafka Connect administration with REST APIs, connector and task states, and rebalancing.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/kafka-connect/connector-development-guide.md
+++ b/content/en/41/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: Guide to building Kafka Connect source and sink connectors.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/kafka-connect/overview.md
+++ b/content/en/41/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: Scalable, reliable data integration between Kafka and external systems.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/kafka-connect/user-guide.md
+++ b/content/en/41/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: Guide to running, configuring, and managing Kafka Connect workers and connectors.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/_index.md
+++ b/content/en/41/operations/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Operations
-description: 
+description: Operational guidance for running, monitoring, and managing Kafka clusters.
 weight: 6
 tags: ['kafka', 'docs', 'ops']
 aliases: 

--- a/content/en/41/operations/basic-kafka-operations.md
+++ b/content/en/41/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: Common Kafka cluster administration tasks and command-line tools.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/consumer-rebalance-protocol.md
+++ b/content/en/41/operations/consumer-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Rebalance Protocol
-description: Consumer Rebalance Protocol
+description: Kafka consumer rebalance protocol behavior, migration paths, and limitations.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/datacenters.md
+++ b/content/en/41/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: Kafka deployment patterns for multiple datacenters.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/eligible-leader-replicas.md
+++ b/content/en/41/operations/eligible-leader-replicas.md
@@ -1,6 +1,6 @@
 ---
 title: Eligible Leader Replicas
-description: Eligible Leader Replicas
+description: Kafka Eligible Leader Replicas behavior, upgrades, and tooling.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/41/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: Kafka geo-replication and cross-cluster data mirroring with MirrorMaker.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/hardware-and-os.md
+++ b/content/en/41/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: Kafka hardware, operating system, disk, and filesystem recommendations.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/java-version.md
+++ b/content/en/41/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: Java version support and runtime recommendations for Kafka.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/kraft.md
+++ b/content/en/41/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: Kafka KRaft configuration, upgrades, provisioning, and quorum management.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/monitoring.md
+++ b/content/en/41/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: Kafka metrics and JMX monitoring for brokers, clients, and components.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/multi-tenancy.md
+++ b/content/en/41/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: Kafka multi-tenant cluster planning and operational practices.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/tiered-storage.md
+++ b/content/en/41/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: Kafka tiered storage configuration, quick start, and operational limits.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/operations/transaction-protocol.md
+++ b/content/en/41/operations/transaction-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Transaction Protocol
-description: Transaction Protocol
+description: Kafka transaction protocol overview, version upgrades and downgrades, and performance characteristics.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/_index.md
+++ b/content/en/41/security/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-description: 
+description: Kafka security configuration for authentication, encryption, and authorization.
 weight: 7
 tags: ['kafka', 'docs', 'security']
 aliases: 

--- a/content/en/41/security/authentication-using-sasl.md
+++ b/content/en/41/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: Kafka SASL authentication configuration for brokers and clients.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/authorization-and-acls.md
+++ b/content/en/41/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: Kafka authorization model and ACL management.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/41/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: Kafka SSL setup for broker and client encryption and authentication.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/41/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: Phased rollout of security features in a running Kafka cluster.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/listener-configuration.md
+++ b/content/en/41/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: Kafka listener configuration for client, inter-broker, and controller communication.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/security/security-overview.md
+++ b/content/en/41/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: Supported security protocols and features available in Kafka.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/_index.md
+++ b/content/en/41/streams/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams
-description: 
+description: Kafka Streams documentation for building and operating stream processing applications.
 weight: 9
 tags: ['kafka', 'docs', 'streams']
 aliases: 

--- a/content/en/41/streams/architecture.md
+++ b/content/en/41/streams/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: 
+description: Kafka Streams architecture for tasks, threading, state, and fault tolerance.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/core-concepts.md
+++ b/content/en/41/streams/core-concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Core Concepts
-description: 
+description: Core Kafka Streams concepts, including topologies, time, state, windowing, and processing guarantees.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/_index.md
+++ b/content/en/41/streams/developer-guide/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Developer Guide
-description: 
+description: Developer guide for building, configuring, testing, and running Kafka Streams applications.
 weight: 10
 tags: ['kafka', 'docs', 'streams', 'developer-guide']
 aliases: 

--- a/content/en/41/streams/developer-guide/app-reset-tool.md
+++ b/content/en/41/streams/developer-guide/app-reset-tool.md
@@ -1,6 +1,6 @@
 ---
 title: Application Reset Tool
-description: 
+description: Kafka Streams application reset tool usage and limitations.
 weight: 13
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/config-streams.md
+++ b/content/en/41/streams/developer-guide/config-streams.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring a Streams Application
-description: 
+description: Kafka Streams application configuration options and runtime settings.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/datatypes.md
+++ b/content/en/41/streams/developer-guide/datatypes.md
@@ -1,6 +1,6 @@
 ---
 title: Data Types and Serialization
-description: 
+description: Kafka Streams data types, serialization, and SerDes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/dsl-api.md
+++ b/content/en/41/streams/developer-guide/dsl-api.md
@@ -1,6 +1,6 @@
 ---
 title: Streams DSL
-description: 
+description: Kafka Streams DSL API for defining stream processing logic.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/dsl-topology-naming.md
+++ b/content/en/41/streams/developer-guide/dsl-topology-naming.md
@@ -1,6 +1,6 @@
 ---
 title: Naming Operators in a Streams DSL application
-description: 
+description: Kafka Streams DSL operator naming for stable topology upgrades.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/interactive-queries.md
+++ b/content/en/41/streams/developer-guide/interactive-queries.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive Queries
-description: 
+description: Kafka Streams interactive queries for local and remote state stores.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/manage-topics.md
+++ b/content/en/41/streams/developer-guide/manage-topics.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Streams Application Topics
-description: 
+description: Kafka Streams user and internal topic management and configuration.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/memory-mgmt.md
+++ b/content/en/41/streams/developer-guide/memory-mgmt.md
@@ -1,6 +1,6 @@
 ---
 title: Memory Management
-description: 
+description: Kafka Streams memory management for caches, state stores, and record buffers.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/processor-api.md
+++ b/content/en/41/streams/developer-guide/processor-api.md
@@ -1,6 +1,6 @@
 ---
 title: Processor API
-description: 
+description: Kafka Streams Processor API for low-level stream processing.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/running-app.md
+++ b/content/en/41/streams/developer-guide/running-app.md
@@ -1,6 +1,6 @@
 ---
 title: Running Streams Applications
-description: 
+description: Guide to running and scaling Kafka Streams applications.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/security.md
+++ b/content/en/41/streams/developer-guide/security.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Security
-description: 
+description: Security configuration and required ACLs for Kafka Streams applications.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/testing.md
+++ b/content/en/41/streams/developer-guide/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing a Streams Application
-description: 
+description: Guide to testing Kafka Streams applications.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/developer-guide/write-streams-app.md
+++ b/content/en/41/streams/developer-guide/write-streams-app.md
@@ -1,6 +1,6 @@
 ---
 title: Writing a Streams Application
-description: 
+description: Guide to writing Kafka Streams applications with the DSL and Processor API.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/introduction.md
+++ b/content/en/41/streams/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: 
+description: Learn what Kafka Streams is and how to build stream processing applications with it.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/quickstart.md
+++ b/content/en/41/streams/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: 
+description: Quick start for running the Kafka Streams demo application.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/tutorial.md
+++ b/content/en/41/streams/tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: Write a streams app
-description: 
+description: Build your first Kafka Streams application step by step.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/41/streams/upgrade-guide.md
+++ b/content/en/41/streams/upgrade-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade Guide
-description: 
+description: Kafka Streams upgrade guidance and compatibility notes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/_index.md
+++ b/content/en/42/_index.md
@@ -1,6 +1,6 @@
 ---
 title: AK 4.2.X
-description: Documentation for AK 4.2.X
+description: Apache Kafka documentation for version 4.2.x.
 weight: 
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/apis/_index.md
+++ b/content/en/42/apis/_index.md
@@ -1,6 +1,6 @@
 ---
 title: API
-description: 
+description: An overview of the core Kafka APIs for client applications, stream processing, Connect integrations, and cluster administration.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/_index.md
+++ b/content/en/42/configuration/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: 
+description: Kafka configuration reference for clusters, clients, and supporting components.
 weight: 3
 tags: ['kafka', 'docs', 'configuration']
 aliases: 

--- a/content/en/42/configuration/admin-configs.md
+++ b/content/en/42/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: Kafka Admin client configuration reference.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/broker-configs.md
+++ b/content/en/42/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: Kafka broker configuration reference.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/configuration-providers.md
+++ b/content/en/42/configuration/configuration-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Providers
-description: Configuration Providers
+description: Kafka configuration providers for loading configuration values from external sources.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/consumer-configs.md
+++ b/content/en/42/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Configs
-description: Consumer Configs
+description: Kafka consumer configuration reference.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/group-configs.md
+++ b/content/en/42/configuration/group-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Group Configs
-description: Group Configs
+description: Kafka group configuration reference for consumer, share, and streams groups.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/kafka-connect-configs.md
+++ b/content/en/42/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: Kafka Connect configuration reference.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/kafka-streams-configs.md
+++ b/content/en/42/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: Kafka Streams configuration reference.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/mirrormaker-configs.md
+++ b/content/en/42/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: Kafka MirrorMaker configuration reference.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/producer-configs.md
+++ b/content/en/42/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: Kafka producer configuration reference.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/system-properties.md
+++ b/content/en/42/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: Java system properties used to configure Kafka components.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/tiered-storage-configs.md
+++ b/content/en/42/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: Kafka tiered storage configuration reference.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/configuration/topic-configs.md
+++ b/content/en/42/configuration/topic-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic Configs
-description: Topic Configs
+description: Kafka topic configuration reference.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/design/_index.md
+++ b/content/en/42/design/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Design
-description: 
+description: Kafka architecture, design principles, and wire protocol.
 weight: 4
 tags: ['kafka', 'docs', 'design']
 aliases: 

--- a/content/en/42/design/design.md
+++ b/content/en/42/design/design.md
@@ -1,6 +1,6 @@
 ---
 title: Design
-description: 
+description: Kafka architecture design and the principles behind its core features.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/design/protocol.md
+++ b/content/en/42/design/protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Protocol
-description: 
+description: Kafka communication protocol, request formats, API versions, and client implementation details.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/getting-started/_index.md
+++ b/content/en/42/getting-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: This section provides an overview of what Kafka is, why it is useful, and how to get started using it.
+description: Start here to learn Kafka fundamentals and common use cases, try a local setup, and find Docker, upgrade, and compatibility guidance.
 weight: 1
 tags: ['kafka', 'docs', 'getting-started']
 aliases: 

--- a/content/en/42/getting-started/compatibility.md
+++ b/content/en/42/getting-started/compatibility.md
@@ -1,6 +1,6 @@
 ---
 title: Compatibility
-description: 
+description: Check Java, server, and client/broker compatibility matrices for planning Kafka upgrades.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/getting-started/docker.md
+++ b/content/en/42/getting-started/docker.md
@@ -1,6 +1,6 @@
 ---
 title: Docker
-description: 
+description: Learn how to pull and run the Kafka JVM Docker image and the experimental native Docker image.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/getting-started/ecosystem.md
+++ b/content/en/42/getting-started/ecosystem.md
@@ -1,6 +1,6 @@
 ---
 title: Ecosystem
-description: 
+description: Discover tools and integrations that extend Kafka beyond the main distribution.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/getting-started/introduction.md
+++ b/content/en/42/getting-started/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: 
+description: Learn what event streaming is, how Kafka works, and the core Kafka concepts and APIs.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/getting-started/quickstart.md
+++ b/content/en/42/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: 
+description: Run Kafka locally, create a topic, produce and consume events, and explore Kafka Connect and Kafka Streams.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/getting-started/upgrade.md
+++ b/content/en/42/getting-started/upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading
-description: 
+description: Find upgrade steps for Kafka clusters and clients, along with compatibility requirements and notable changes across releases.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/getting-started/uses.md
+++ b/content/en/42/getting-started/uses.md
@@ -1,6 +1,6 @@
 ---
 title: Use Cases
-description: 
+description: Explore common Kafka use cases for messaging, activity tracking, stream processing, and storing event data.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/getting-started/zk2kraft.md
+++ b/content/en/42/getting-started/zk2kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft vs ZooKeeper
-description: 
+description: Understand how KRaft mode differs from ZooKeeper mode, including removed features, metric changes, and behavioral changes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/_index.md
+++ b/content/en/42/implementation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Implementation
-description: 
+description: Kafka implementation internals for data storage, records, networking, and offset tracking.
 weight: 5
 tags: ['kafka', 'docs', 'implementation']
 aliases: 

--- a/content/en/42/implementation/distribution.md
+++ b/content/en/42/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: Kafka consumer offset tracking via the group coordinator.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/log.md
+++ b/content/en/42/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: Kafka log storage format and segment management.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/message-format.md
+++ b/content/en/42/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: The on-disk binary formats for Kafka record batches and records.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/messages.md
+++ b/content/en/42/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: Kafka message structure, including headers and opaque key/value payloads.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/implementation/network-layer.md
+++ b/content/en/42/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: Kafka NIO-based network layer implementation.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/kafka-connect/_index.md
+++ b/content/en/42/kafka-connect/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect
-description: 
+description: Kafka Connect documentation for integrating Kafka with external systems.
 weight: 8
 tags: ['kafka', 'docs', 'connect']
 aliases: 

--- a/content/en/42/kafka-connect/administration.md
+++ b/content/en/42/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: Kafka Connect administration with REST APIs, connector and task states, and rebalancing.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/kafka-connect/connector-development-guide.md
+++ b/content/en/42/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: Guide to building Kafka Connect source and sink connectors.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/kafka-connect/overview.md
+++ b/content/en/42/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: Scalable, reliable data integration between Kafka and external systems.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/kafka-connect/user-guide.md
+++ b/content/en/42/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: Guide to running, configuring, and managing Kafka Connect workers and connectors.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/_index.md
+++ b/content/en/42/operations/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Operations
-description: 
+description: Operational guidance for running, monitoring, and managing Kafka clusters.
 weight: 6
 tags: ['kafka', 'docs', 'ops']
 aliases: 

--- a/content/en/42/operations/basic-kafka-operations.md
+++ b/content/en/42/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: Common Kafka cluster administration tasks and command-line tools.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/consumer-rebalance-protocol.md
+++ b/content/en/42/operations/consumer-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Rebalance Protocol
-description: Consumer Rebalance Protocol
+description: Kafka consumer rebalance protocol behavior, migration paths, and limitations.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/datacenters.md
+++ b/content/en/42/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: Kafka deployment patterns for multiple datacenters.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/eligible-leader-replicas.md
+++ b/content/en/42/operations/eligible-leader-replicas.md
@@ -1,6 +1,6 @@
 ---
 title: Eligible Leader Replicas
-description: Eligible Leader Replicas
+description: Kafka Eligible Leader Replicas behavior, upgrades, and tooling.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/42/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: Kafka geo-replication and cross-cluster data mirroring with MirrorMaker.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/hardware-and-os.md
+++ b/content/en/42/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: Kafka hardware, operating system, disk, and filesystem recommendations.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/java-version.md
+++ b/content/en/42/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: Java version support and runtime recommendations for Kafka.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/kraft.md
+++ b/content/en/42/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: Kafka KRaft configuration, upgrades, provisioning, and quorum management.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/monitoring.md
+++ b/content/en/42/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: Kafka metrics and JMX monitoring for brokers, clients, and components.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/multi-tenancy.md
+++ b/content/en/42/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: Kafka multi-tenant cluster planning and operational practices.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/tiered-storage.md
+++ b/content/en/42/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: Kafka tiered storage configuration, quick start, and operational limits.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/operations/transaction-protocol.md
+++ b/content/en/42/operations/transaction-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Transaction Protocol
-description: Transaction Protocol
+description: Kafka transaction protocol overview, version upgrades and downgrades, and performance characteristics.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/_index.md
+++ b/content/en/42/security/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-description: 
+description: Kafka security configuration for authentication, encryption, and authorization.
 weight: 7
 tags: ['kafka', 'docs', 'security']
 aliases: 

--- a/content/en/42/security/authentication-using-sasl.md
+++ b/content/en/42/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: Kafka SASL authentication configuration for brokers and clients.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/authorization-and-acls.md
+++ b/content/en/42/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: Kafka authorization model and ACL management.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/42/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: Kafka SSL setup for broker and client encryption and authentication.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/42/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: Phased rollout of security features in a running Kafka cluster.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/listener-configuration.md
+++ b/content/en/42/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: Kafka listener configuration for client, inter-broker, and controller communication.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/security/security-overview.md
+++ b/content/en/42/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: Supported security protocols and features available in Kafka.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/_index.md
+++ b/content/en/42/streams/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams
-description: 
+description: Kafka Streams documentation for building and operating stream processing applications.
 weight: 9
 tags: ['kafka', 'docs', 'streams']
 aliases: 

--- a/content/en/42/streams/architecture.md
+++ b/content/en/42/streams/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: 
+description: Kafka Streams architecture for tasks, threading, state, and fault tolerance.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/core-concepts.md
+++ b/content/en/42/streams/core-concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Core Concepts
-description: 
+description: Core Kafka Streams concepts, including topologies, time, state, windowing, and processing guarantees.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/_index.md
+++ b/content/en/42/streams/developer-guide/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Developer Guide
-description: 
+description: Developer guide for building, configuring, testing, and running Kafka Streams applications.
 weight: 10
 tags: ['kafka', 'docs', 'streams', 'developer-guide']
 aliases: 

--- a/content/en/42/streams/developer-guide/app-reset-tool.md
+++ b/content/en/42/streams/developer-guide/app-reset-tool.md
@@ -1,6 +1,6 @@
 ---
 title: Application Reset Tool
-description: 
+description: Kafka Streams application reset tool usage and limitations.
 weight: 13
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/config-streams.md
+++ b/content/en/42/streams/developer-guide/config-streams.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring a Streams Application
-description: 
+description: Kafka Streams application configuration options and runtime settings.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/datatypes.md
+++ b/content/en/42/streams/developer-guide/datatypes.md
@@ -1,6 +1,6 @@
 ---
 title: Data Types and Serialization
-description: 
+description: Kafka Streams data types, serialization, and SerDes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/dsl-api.md
+++ b/content/en/42/streams/developer-guide/dsl-api.md
@@ -1,6 +1,6 @@
 ---
 title: Streams DSL
-description: 
+description: Kafka Streams DSL API for defining stream processing logic.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/dsl-topology-naming.md
+++ b/content/en/42/streams/developer-guide/dsl-topology-naming.md
@@ -1,6 +1,6 @@
 ---
 title: Naming Operators in a Streams DSL application
-description: 
+description: Kafka Streams DSL operator naming for stable topology upgrades.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/interactive-queries.md
+++ b/content/en/42/streams/developer-guide/interactive-queries.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive Queries
-description: 
+description: Kafka Streams interactive queries for local and remote state stores.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/kafka-streams-group-sh.md
+++ b/content/en/42/streams/developer-guide/kafka-streams-group-sh.md
@@ -1,7 +1,7 @@
 ---
 title: Kafka Streams Groups Tool
 type: docs
-description: 
+description: Kafka Streams groups tool for inspecting and managing streams groups.
 weight: 15
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/manage-topics.md
+++ b/content/en/42/streams/developer-guide/manage-topics.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Streams Application Topics
-description: 
+description: Kafka Streams user and internal topic management and configuration.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/memory-mgmt.md
+++ b/content/en/42/streams/developer-guide/memory-mgmt.md
@@ -1,6 +1,6 @@
 ---
 title: Memory Management
-description: 
+description: Kafka Streams memory management for caches, state stores, and record buffers.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/processor-api.md
+++ b/content/en/42/streams/developer-guide/processor-api.md
@@ -1,6 +1,6 @@
 ---
 title: Processor API
-description: 
+description: Kafka Streams Processor API for low-level stream processing.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/running-app.md
+++ b/content/en/42/streams/developer-guide/running-app.md
@@ -1,6 +1,6 @@
 ---
 title: Running Streams Applications
-description: 
+description: Guide to running and scaling Kafka Streams applications.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/security.md
+++ b/content/en/42/streams/developer-guide/security.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Security
-description: 
+description: Security configuration and required ACLs for Kafka Streams applications.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/streams-rebalance-protocol.md
+++ b/content/en/42/streams/developer-guide/streams-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Rebalance Protocol
-description:
+description: Kafka Streams rebalance protocol behavior, migration paths, and limitations.
 weight: 14
 tags: ['kafka', 'docs']
 aliases:

--- a/content/en/42/streams/developer-guide/testing.md
+++ b/content/en/42/streams/developer-guide/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing a Streams Application
-description: 
+description: Guide to testing Kafka Streams applications.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/developer-guide/write-streams-app.md
+++ b/content/en/42/streams/developer-guide/write-streams-app.md
@@ -1,6 +1,6 @@
 ---
 title: Writing a Streams Application
-description: 
+description: Guide to writing Kafka Streams applications with the DSL and Processor API.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/introduction.md
+++ b/content/en/42/streams/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: 
+description: Learn what Kafka Streams is and how to build stream processing applications with it.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/quickstart.md
+++ b/content/en/42/streams/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: 
+description: Quick start for running the Kafka Streams demo application.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/tutorial.md
+++ b/content/en/42/streams/tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: Write a streams app
-description: 
+description: Build your first Kafka Streams application step by step.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/42/streams/upgrade-guide.md
+++ b/content/en/42/streams/upgrade-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade Guide
-description: 
+description: Kafka Streams upgrade guidance and compatibility notes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/_index.md
+++ b/content/en/43/_index.md
@@ -1,6 +1,6 @@
 ---
 title: AK 4.3.X
-description: Documentation for AK 4.3.X
+description: Apache Kafka documentation for version 4.3.x.
 weight: 
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/apis/_index.md
+++ b/content/en/43/apis/_index.md
@@ -1,6 +1,6 @@
 ---
 title: API
-description: 
+description: An overview of the core Kafka APIs for client applications, stream processing, Connect integrations, and cluster administration.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/_index.md
+++ b/content/en/43/configuration/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: 
+description: Kafka configuration reference for clusters, clients, and supporting components.
 weight: 3
 tags: ['kafka', 'docs', 'configuration']
 aliases: 

--- a/content/en/43/configuration/admin-configs.md
+++ b/content/en/43/configuration/admin-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Admin Configs
-description: Admin Configs
+description: Kafka Admin client configuration reference.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/broker-configs.md
+++ b/content/en/43/configuration/broker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Broker Configs
-description: Broker Configs
+description: Kafka broker configuration reference.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/configuration-providers.md
+++ b/content/en/43/configuration/configuration-providers.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration Providers
-description: Configuration Providers
+description: Kafka configuration providers for loading configuration values from external sources.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/consumer-configs.md
+++ b/content/en/43/configuration/consumer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer and Share Consumer Configs
-description: Consumer and Share Consumer Configs
+description: Kafka consumer and share consumer configuration reference.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/group-configs.md
+++ b/content/en/43/configuration/group-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Group Configs
-description: Group Configs
+description: Kafka group configuration reference for consumer, share, and streams groups.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/kafka-connect-configs.md
+++ b/content/en/43/configuration/kafka-connect-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect Configs
-description: Kafka Connect Configs
+description: Kafka Connect configuration reference.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/kafka-streams-configs.md
+++ b/content/en/43/configuration/kafka-streams-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams Configs
-description: Kafka Streams Configs
+description: Kafka Streams configuration reference.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/mirrormaker-configs.md
+++ b/content/en/43/configuration/mirrormaker-configs.md
@@ -1,6 +1,6 @@
 ---
 title: MirrorMaker Configs
-description: MirrorMaker Configs
+description: Kafka MirrorMaker configuration reference.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/producer-configs.md
+++ b/content/en/43/configuration/producer-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Producer Configs
-description: Producer Configs
+description: Kafka producer configuration reference.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/system-properties.md
+++ b/content/en/43/configuration/system-properties.md
@@ -1,6 +1,6 @@
 ---
 title: System Properties
-description: System Properties
+description: Java system properties used to configure Kafka components.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/tiered-storage-configs.md
+++ b/content/en/43/configuration/tiered-storage-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage Configs
-description: Tiered Storage Configs
+description: Kafka tiered storage configuration reference.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/configuration/topic-configs.md
+++ b/content/en/43/configuration/topic-configs.md
@@ -1,6 +1,6 @@
 ---
 title: Topic Configs
-description: Topic Configs
+description: Kafka topic configuration reference.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/design/_index.md
+++ b/content/en/43/design/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Design
-description: 
+description: Kafka architecture, design principles, and wire protocol.
 weight: 4
 tags: ['kafka', 'docs', 'design']
 aliases: 

--- a/content/en/43/design/design.md
+++ b/content/en/43/design/design.md
@@ -1,6 +1,6 @@
 ---
 title: Design
-description: 
+description: Kafka architecture design and the principles behind its core features.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/design/protocol.md
+++ b/content/en/43/design/protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Protocol
-description: 
+description: Kafka communication protocol, request formats, API versions, and client implementation details.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/getting-started/_index.md
+++ b/content/en/43/getting-started/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: This section provides an overview of what Kafka is, why it is useful, and how to get started using it.
+description: Start here to learn Kafka fundamentals and common use cases, try a local setup, and find Docker, upgrade, and compatibility guidance.
 weight: 1
 tags: ['kafka', 'docs', 'getting-started']
 aliases: 

--- a/content/en/43/getting-started/compatibility.md
+++ b/content/en/43/getting-started/compatibility.md
@@ -1,6 +1,6 @@
 ---
 title: Compatibility
-description: 
+description: Check Java, server, and client/broker compatibility matrices for planning Kafka upgrades.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/getting-started/docker.md
+++ b/content/en/43/getting-started/docker.md
@@ -1,6 +1,6 @@
 ---
 title: Docker
-description: 
+description: Learn how to pull and run the Kafka JVM Docker image and the experimental native Docker image.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/getting-started/ecosystem.md
+++ b/content/en/43/getting-started/ecosystem.md
@@ -1,6 +1,6 @@
 ---
 title: Ecosystem
-description: 
+description: Discover tools and integrations that extend Kafka beyond the main distribution.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/getting-started/introduction.md
+++ b/content/en/43/getting-started/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: 
+description: Learn what event streaming is, how Kafka works, and the core Kafka concepts and APIs.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/getting-started/quickstart.md
+++ b/content/en/43/getting-started/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: 
+description: Run Kafka locally, create a topic, produce and consume events, and explore Kafka Connect and Kafka Streams.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/getting-started/upgrade.md
+++ b/content/en/43/getting-started/upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrading
-description: 
+description: Find upgrade steps for Kafka clusters and clients, along with compatibility requirements and notable changes across releases.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/getting-started/uses.md
+++ b/content/en/43/getting-started/uses.md
@@ -1,6 +1,6 @@
 ---
 title: Use Cases
-description: 
+description: Explore common Kafka use cases for messaging, activity tracking, stream processing, and storing event data.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/getting-started/zk2kraft.md
+++ b/content/en/43/getting-started/zk2kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft vs ZooKeeper
-description: 
+description: Understand how KRaft mode differs from ZooKeeper mode, including removed features, metric changes, and behavioral changes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/_index.md
+++ b/content/en/43/implementation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Implementation
-description: 
+description: Kafka implementation internals for data storage, records, networking, and offset tracking.
 weight: 5
 tags: ['kafka', 'docs', 'implementation']
 aliases: 

--- a/content/en/43/implementation/distribution.md
+++ b/content/en/43/implementation/distribution.md
@@ -1,6 +1,6 @@
 ---
 title: Distribution
-description: Distribution
+description: Kafka consumer offset tracking via the group coordinator.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/log.md
+++ b/content/en/43/implementation/log.md
@@ -1,6 +1,6 @@
 ---
 title: Log
-description: Log
+description: Kafka log storage format and segment management.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/message-format.md
+++ b/content/en/43/implementation/message-format.md
@@ -1,6 +1,6 @@
 ---
 title: Message Format
-description: Message Format
+description: The on-disk binary formats for Kafka record batches and records.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/messages.md
+++ b/content/en/43/implementation/messages.md
@@ -1,6 +1,6 @@
 ---
 title: Messages
-description: Messages
+description: Kafka message structure, including headers and opaque key/value payloads.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/implementation/network-layer.md
+++ b/content/en/43/implementation/network-layer.md
@@ -1,6 +1,6 @@
 ---
 title: Network Layer
-description: Network Layer
+description: Kafka NIO-based network layer implementation.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/kafka-connect/_index.md
+++ b/content/en/43/kafka-connect/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Connect
-description: 
+description: Kafka Connect documentation for integrating Kafka with external systems.
 weight: 8
 tags: ['kafka', 'docs', 'connect']
 aliases: 

--- a/content/en/43/kafka-connect/administration.md
+++ b/content/en/43/kafka-connect/administration.md
@@ -1,6 +1,6 @@
 ---
 title: Administration
-description: Administration
+description: Kafka Connect administration with REST APIs, connector and task states, and rebalancing.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/kafka-connect/connector-development-guide.md
+++ b/content/en/43/kafka-connect/connector-development-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Connector Development Guide
-description: Connector Development Guide
+description: Guide to building Kafka Connect source and sink connectors.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/kafka-connect/overview.md
+++ b/content/en/43/kafka-connect/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Overview
+description: Scalable, reliable data integration between Kafka and external systems.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/kafka-connect/user-guide.md
+++ b/content/en/43/kafka-connect/user-guide.md
@@ -1,6 +1,6 @@
 ---
 title: User Guide
-description: User Guide
+description: Guide to running, configuring, and managing Kafka Connect workers and connectors.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/_index.md
+++ b/content/en/43/operations/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Operations
-description: 
+description: Operational guidance for running, monitoring, and managing Kafka clusters.
 weight: 6
 tags: ['kafka', 'docs', 'ops']
 aliases: 

--- a/content/en/43/operations/basic-kafka-operations.md
+++ b/content/en/43/operations/basic-kafka-operations.md
@@ -1,6 +1,6 @@
 ---
 title: Basic Kafka Operations
-description: Basic Kafka Operations
+description: Common Kafka cluster administration tasks and command-line tools.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/consumer-rebalance-protocol.md
+++ b/content/en/43/operations/consumer-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Consumer Rebalance Protocol
-description: Consumer Rebalance Protocol
+description: Kafka consumer rebalance protocol behavior, migration paths, and limitations.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/datacenters.md
+++ b/content/en/43/operations/datacenters.md
@@ -1,6 +1,6 @@
 ---
 title: Datacenters
-description: Datacenters
+description: Kafka deployment patterns for multiple datacenters.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/eligible-leader-replicas.md
+++ b/content/en/43/operations/eligible-leader-replicas.md
@@ -1,6 +1,6 @@
 ---
 title: Eligible Leader Replicas
-description: Eligible Leader Replicas
+description: Kafka Eligible Leader Replicas behavior, upgrades, and tooling.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/geo-replication-(cross-cluster-data-mirroring).md
+++ b/content/en/43/operations/geo-replication-(cross-cluster-data-mirroring).md
@@ -1,6 +1,6 @@
 ---
 title: Geo-Replication (Cross-Cluster Data Mirroring)
-description: Geo-Replication (Cross-Cluster Data Mirroring)
+description: Kafka geo-replication and cross-cluster data mirroring with MirrorMaker.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/hardware-and-os.md
+++ b/content/en/43/operations/hardware-and-os.md
@@ -1,6 +1,6 @@
 ---
 title: Hardware and OS
-description: Hardware and OS
+description: Kafka hardware, operating system, disk, and filesystem recommendations.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/java-version.md
+++ b/content/en/43/operations/java-version.md
@@ -1,6 +1,6 @@
 ---
 title: Java Version
-description: Java Version
+description: Java version support and runtime recommendations for Kafka.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/kraft.md
+++ b/content/en/43/operations/kraft.md
@@ -1,6 +1,6 @@
 ---
 title: KRaft
-description: KRaft
+description: Kafka KRaft configuration, upgrades, provisioning, and quorum management.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/monitoring.md
+++ b/content/en/43/operations/monitoring.md
@@ -1,6 +1,6 @@
 ---
 title: Monitoring
-description: Monitoring
+description: Kafka metrics and JMX monitoring for brokers, clients, and components.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/multi-tenancy.md
+++ b/content/en/43/operations/multi-tenancy.md
@@ -1,6 +1,6 @@
 ---
 title: Multi-Tenancy
-description: Multi-Tenancy
+description: Kafka multi-tenant cluster planning and operational practices.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/tiered-storage.md
+++ b/content/en/43/operations/tiered-storage.md
@@ -1,6 +1,6 @@
 ---
 title: Tiered Storage
-description: Tiered Storage
+description: Kafka tiered storage configuration, quick start, and operational limits.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/operations/transaction-protocol.md
+++ b/content/en/43/operations/transaction-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Transaction Protocol
-description: Transaction Protocol
+description: Kafka transaction protocol overview, version upgrades and downgrades, and performance characteristics.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/_index.md
+++ b/content/en/43/security/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Security
-description: 
+description: Kafka security configuration for authentication, encryption, and authorization.
 weight: 7
 tags: ['kafka', 'docs', 'security']
 aliases: 

--- a/content/en/43/security/authentication-using-sasl.md
+++ b/content/en/43/security/authentication-using-sasl.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication using SASL
-description: Authentication using SASL
+description: Kafka SASL authentication configuration for brokers and clients.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/authorization-and-acls.md
+++ b/content/en/43/security/authorization-and-acls.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization and ACLs
-description: Authorization and ACLs
+description: Kafka authorization model and ACL management.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/encryption-and-authentication-using-ssl.md
+++ b/content/en/43/security/encryption-and-authentication-using-ssl.md
@@ -1,6 +1,6 @@
 ---
 title: Encryption and Authentication using SSL
-description: Encryption and Authentication using SSL
+description: Kafka SSL setup for broker and client encryption and authentication.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/incorporating-security-features-in-a-running-cluster.md
+++ b/content/en/43/security/incorporating-security-features-in-a-running-cluster.md
@@ -1,6 +1,6 @@
 ---
 title: Incorporating Security Features in a Running Cluster
-description: Incorporating Security Features in a Running Cluster
+description: Phased rollout of security features in a running Kafka cluster.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/listener-configuration.md
+++ b/content/en/43/security/listener-configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Listener Configuration
-description: Listener Configuration
+description: Kafka listener configuration for client, inter-broker, and controller communication.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/security/security-overview.md
+++ b/content/en/43/security/security-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Security Overview
-description: Security Overview
+description: Supported security protocols and features available in Kafka.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/_index.md
+++ b/content/en/43/streams/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Kafka Streams
-description: 
+description: Kafka Streams documentation for building and operating stream processing applications.
 weight: 9
 tags: ['kafka', 'docs', 'streams']
 aliases: 

--- a/content/en/43/streams/architecture.md
+++ b/content/en/43/streams/architecture.md
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-description: 
+description: Kafka Streams architecture for tasks, threading, state, and fault tolerance.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/core-concepts.md
+++ b/content/en/43/streams/core-concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Core Concepts
-description: 
+description: Core Kafka Streams concepts, including topologies, time, state, windowing, and processing guarantees.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/_index.md
+++ b/content/en/43/streams/developer-guide/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Developer Guide
-description: 
+description: Developer guide for building, configuring, testing, and running Kafka Streams applications.
 weight: 10
 tags: ['kafka', 'docs', 'streams', 'developer-guide']
 aliases: 

--- a/content/en/43/streams/developer-guide/app-reset-tool.md
+++ b/content/en/43/streams/developer-guide/app-reset-tool.md
@@ -1,6 +1,6 @@
 ---
 title: Application Reset Tool
-description: 
+description: Kafka Streams application reset tool usage and limitations.
 weight: 13
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/config-streams.md
+++ b/content/en/43/streams/developer-guide/config-streams.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring a Streams Application
-description: 
+description: Kafka Streams application configuration options and runtime settings.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/datatypes.md
+++ b/content/en/43/streams/developer-guide/datatypes.md
@@ -1,6 +1,6 @@
 ---
 title: Data Types and Serialization
-description: 
+description: Kafka Streams data types, serialization, and SerDes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/dsl-api.md
+++ b/content/en/43/streams/developer-guide/dsl-api.md
@@ -1,6 +1,6 @@
 ---
 title: Streams DSL
-description: 
+description: Kafka Streams DSL API for defining stream processing logic.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/dsl-topology-naming.md
+++ b/content/en/43/streams/developer-guide/dsl-topology-naming.md
@@ -1,6 +1,6 @@
 ---
 title: Naming Operators in a Streams DSL application
-description: 
+description: Kafka Streams DSL operator naming for stable topology upgrades.
 weight: 5
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/interactive-queries.md
+++ b/content/en/43/streams/developer-guide/interactive-queries.md
@@ -1,6 +1,6 @@
 ---
 title: Interactive Queries
-description: 
+description: Kafka Streams interactive queries for local and remote state stores.
 weight: 8
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/kafka-streams-group-sh.md
+++ b/content/en/43/streams/developer-guide/kafka-streams-group-sh.md
@@ -1,7 +1,7 @@
 ---
 title: Kafka Streams Groups Tool
 type: docs
-description: 
+description: Kafka Streams groups tool for inspecting and managing streams groups.
 weight: 15
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/manage-topics.md
+++ b/content/en/43/streams/developer-guide/manage-topics.md
@@ -1,6 +1,6 @@
 ---
 title: Managing Streams Application Topics
-description: 
+description: Kafka Streams user and internal topic management and configuration.
 weight: 11
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/memory-mgmt.md
+++ b/content/en/43/streams/developer-guide/memory-mgmt.md
@@ -1,6 +1,6 @@
 ---
 title: Memory Management
-description: 
+description: Kafka Streams memory management for caches, state stores, and record buffers.
 weight: 9
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/processor-api.md
+++ b/content/en/43/streams/developer-guide/processor-api.md
@@ -1,6 +1,6 @@
 ---
 title: Processor API
-description: 
+description: Kafka Streams Processor API for low-level stream processing.
 weight: 4
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/running-app.md
+++ b/content/en/43/streams/developer-guide/running-app.md
@@ -1,6 +1,6 @@
 ---
 title: Running Streams Applications
-description: 
+description: Guide to running and scaling Kafka Streams applications.
 weight: 10
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/scala-migration.md
+++ b/content/en/43/streams/developer-guide/scala-migration.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating from Streams Scala to Java API
-description:
+description: Migration guidance from the Kafka Streams Scala API to the Java API.
 weight: 16
 tags: ['kafka', 'docs']
 aliases:

--- a/content/en/43/streams/developer-guide/security.md
+++ b/content/en/43/streams/developer-guide/security.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Security
-description: 
+description: Security configuration and required ACLs for Kafka Streams applications.
 weight: 12
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/streams-rebalance-protocol.md
+++ b/content/en/43/streams/developer-guide/streams-rebalance-protocol.md
@@ -1,6 +1,6 @@
 ---
 title: Streams Rebalance Protocol
-description:
+description: Kafka Streams rebalance protocol behavior, migration paths, and limitations.
 weight: 14
 tags: ['kafka', 'docs']
 aliases:

--- a/content/en/43/streams/developer-guide/testing.md
+++ b/content/en/43/streams/developer-guide/testing.md
@@ -1,6 +1,6 @@
 ---
 title: Testing a Streams Application
-description: 
+description: Guide to testing Kafka Streams applications.
 weight: 7
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/developer-guide/write-streams-app.md
+++ b/content/en/43/streams/developer-guide/write-streams-app.md
@@ -1,6 +1,6 @@
 ---
 title: Writing a Streams Application
-description: 
+description: Guide to writing Kafka Streams applications with the DSL and Processor API.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/introduction.md
+++ b/content/en/43/streams/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: 
+description: Learn what Kafka Streams is and how to build stream processing applications with it.
 weight: 1
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/quickstart.md
+++ b/content/en/43/streams/quickstart.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-description: 
+description: Quick start for running the Kafka Streams demo application.
 weight: 2
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/tutorial.md
+++ b/content/en/43/streams/tutorial.md
@@ -1,6 +1,6 @@
 ---
 title: Write a streams app
-description: 
+description: Build your first Kafka Streams application step by step.
 weight: 3
 tags: ['kafka', 'docs']
 aliases: 

--- a/content/en/43/streams/upgrade-guide.md
+++ b/content/en/43/streams/upgrade-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade Guide
-description: 
+description: Kafka Streams upgrade guidance and compatibility notes.
 weight: 6
 tags: ['kafka', 'docs']
 aliases: 


### PR DESCRIPTION
apache/kafka#22605 fixed duplicate/blank section descriptions in the
docs/ source, but kafka-site doesn't auto-sync from trunk, so the
already-published pages were untouched. Backports the same description
text to the three currently supported release lines (4.1.X, 4.2.X,
4.3.X); archived lines are left as is.