### PR TITLE
KAFKA-20737: Add CI guard for archived release links

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -19,6 +19,9 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0  # Full history needed for branch operations
+
+    - name: Check archived release links
+      run: make check-archived-release-links
     
     - name: Run make build
       run: |

--- a/.github/workflows/check-archived-release-links.yml
+++ b/.github/workflows/check-archived-release-links.yml
@@ -1,0 +1,22 @@
+name: Check Archived Release Links
+
+on:
+  pull_request:
+    branches: [ markdown ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-archived-release-links:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Test archived release link checker
+      run: make check-archived-release-links-test
+
+    - name: Check archived release links
+      run: make check-archived-release-links

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_IMAGE := $(HUGO_BASE_IMAGE)
 #PROD_IMAGE := hvishwanath/kafka-site-md:1.2.0
 PROD_IMAGE := us-west1-docker.pkg.dev/play-394201/kafka-site-md/kafka-site-md:1.6.0
 
-.PHONY: build serve clean docker-image hugo-base-multi-platform prod-image prod-run buildx-setup ghcr-prod-image
+.PHONY: build serve clean docker-image hugo-base-multi-platform prod-image prod-run buildx-setup ghcr-prod-image check-archived-release-links check-archived-release-links-test
 
 # Setup buildx for multi-arch builds
 buildx-setup:
@@ -32,6 +32,12 @@ build:
 	docker run --rm -v $(PWD):/src $(DOCKER_IMAGE) \
 		--minify \
 		--destination $(OUTPUT_DIR)
+
+check-archived-release-links:
+	python3 scripts/check_archived_release_links.py
+
+check-archived-release-links-test:
+	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.tests.test_check_archived_release_links
 
 # Serve the site locally using Docker (development)
 serve: 

--- a/scripts/check_archived_release_links.py
+++ b/scripts/check_archived_release_links.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+ARCHIVED_RELEASES_HEADER = re.compile(
+    r"^[ \t]{0,3}##[ \t]+Archived Releases(?:[ \t]+\{#[^}]+\})?[ \t]*$",
+    re.IGNORECASE,
+)
+NEXT_H2_HEADER = re.compile(r"^[ \t]{0,3}##[ \t]+")
+RELEASE_HEADER = re.compile(r"^[ \t]{0,3}###[ \t]+(.+?)[ \t]*$")
+FENCE_START = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
+URL = re.compile(r"(?:https?:)?//[^)\s>]+", re.IGNORECASE)
+ACTIVE_DOWNLOAD_HOSTS = {"dlcdn.apache.org", "downloads.apache.org"}
+ACTIVE_REDIRECT_PATH = re.compile(r"^/dyn/closer\.lua/kafka/")
+
+
+def archived_release_lines(lines):
+    in_archived_releases = False
+    fence_character = None
+    fence_length = 0
+
+    for line_number, line in enumerate(lines, start=1):
+        if fence_character:
+            closing_fence = re.fullmatch(
+                rf"[ \t]{{0,3}}{re.escape(fence_character)}{{{fence_length},}}[ \t]*",
+                line,
+            )
+            if closing_fence:
+                fence_character = None
+                fence_length = 0
+            continue
+
+        fence_match = FENCE_START.match(line)
+        if fence_match:
+            marker = fence_match.group(1)
+            fence_character = marker[0]
+            fence_length = len(marker)
+            continue
+
+        if ARCHIVED_RELEASES_HEADER.match(line):
+            in_archived_releases = True
+            continue
+
+        if in_archived_releases and NEXT_H2_HEADER.match(line):
+            break
+
+        if in_archived_releases:
+            yield line_number, line
+
+    if not in_archived_releases:
+        raise ValueError("missing required '## Archived Releases' section")
+
+
+def is_active_download_url(url):
+    parsed = urlparse(url)
+    hostname = (parsed.hostname or "").lower()
+    if hostname in ACTIVE_DOWNLOAD_HOSTS and parsed.path.startswith("/kafka/"):
+        return parsed.path != "/kafka/KEYS"
+    return hostname == "www.apache.org" and ACTIVE_REDIRECT_PATH.match(parsed.path) is not None
+
+
+def find_bad_links(path):
+    lines = path.read_text(encoding="utf-8").splitlines()
+    bad_links = []
+    current_release = None
+
+    for line_number, line in archived_release_lines(lines):
+        release_match = RELEASE_HEADER.match(line)
+        if release_match:
+            current_release = release_match.group(1)
+
+        for url in URL.findall(line):
+            if is_active_download_url(url):
+                bad_links.append((line_number, current_release, url))
+
+    return bad_links
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Check that archived Kafka release links use archive.apache.org."
+    )
+    parser.add_argument(
+        "downloads_file",
+        nargs="?",
+        default="content/en/community/downloads.md",
+        help="Path to the downloads markdown file.",
+    )
+    args = parser.parse_args(argv)
+
+    downloads_file = Path(args.downloads_file)
+    try:
+        bad_links = find_bad_links(downloads_file)
+    except OSError as error:
+        reason = error.strerror or str(error)
+        print(f"{downloads_file}: unable to read file: {reason}", file=sys.stderr)
+        return 2
+    except ValueError as error:
+        print(f"{downloads_file}: {error}", file=sys.stderr)
+        return 2
+
+    if not bad_links:
+        print(f"{downloads_file}: archived release links use archive.apache.org")
+        return 0
+
+    print(
+        "Archived release links must use https://archive.apache.org/dist/kafka/ "
+        "instead of active download URLs.",
+        file=sys.stderr,
+    )
+    for line_number, release, url in bad_links:
+        release_label = release or "unknown release"
+        print(f"{downloads_file}:{line_number}: {release_label}: {url}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_archived_release_links.py
+++ b/scripts/tests/test_check_archived_release_links.py
@@ -1,0 +1,254 @@
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.check_archived_release_links import find_bad_links, main
+
+
+class CheckArchivedReleaseLinksTest(unittest.TestCase):
+    def check(self, content):
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as test_file:
+            test_file.write(content)
+            path = Path(test_file.name)
+
+        try:
+            return find_bad_links(path)
+        finally:
+            path.unlink()
+
+    def test_allows_archive_apache_links_in_archived_releases(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+* [Release Notes](https://archive.apache.org/dist/kafka/4.2.0/RELEASE_NOTES.html)
+* Source download: [kafka-4.2.0-src.tgz](https://archive.apache.org/dist/kafka/4.2.0/kafka-4.2.0-src.tgz)
+"""
+        )
+
+        self.assertEqual([], bad_links)
+
+    def test_rejects_closer_lua_links_in_archived_releases(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+* Source download: [kafka-4.2.0-src.tgz](https://www.apache.org/dyn/closer.lua/kafka/4.2.0/kafka-4.2.0-src.tgz?action=download)
+"""
+        )
+
+        self.assertEqual(
+            [
+                (
+                    5,
+                    "4.2.0",
+                    "https://www.apache.org/dyn/closer.lua/kafka/4.2.0/kafka-4.2.0-src.tgz?action=download",
+                )
+            ],
+            bad_links,
+        )
+
+    def test_rejects_scheme_relative_active_download_link(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+* Source: [src](//downloads.apache.org/kafka/4.2.0/src.tgz)
+"""
+        )
+
+        self.assertEqual(
+            [(5, "4.2.0", "//downloads.apache.org/kafka/4.2.0/src.tgz")],
+            bad_links,
+        )
+
+    def test_rejects_downloads_apache_links_in_archived_releases(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+* Source signature: [asc](https://downloads.apache.org/kafka/4.2.0/kafka-4.2.0-src.tgz.asc)
+"""
+        )
+
+        self.assertEqual(
+            [(5, "4.2.0", "https://downloads.apache.org/kafka/4.2.0/kafka-4.2.0-src.tgz.asc")],
+            bad_links,
+        )
+
+    def test_rejects_dlcdn_apache_links_in_archived_releases(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+* Source download: [src](https://dlcdn.apache.org/kafka/4.2.0/kafka-4.2.0-src.tgz)
+"""
+        )
+
+        self.assertEqual(
+            [(5, "4.2.0", "https://dlcdn.apache.org/kafka/4.2.0/kafka-4.2.0-src.tgz")],
+            bad_links,
+        )
+
+    def test_allows_apache_keys_link_in_archived_releases(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+* Verify with [KEYS](https://downloads.apache.org/kafka/KEYS).
+"""
+        )
+
+        self.assertEqual([], bad_links)
+
+    def test_rejects_case_insensitive_host_with_explicit_port(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+* Source signature: [asc](HTTPS://DOWNLOADS.APACHE.ORG:443/kafka/4.2.0/kafka-4.2.0-src.tgz.asc)
+"""
+        )
+
+        self.assertEqual(
+            [
+                (
+                    5,
+                    "4.2.0",
+                    "HTTPS://DOWNLOADS.APACHE.ORG:443/kafka/4.2.0/kafka-4.2.0-src.tgz.asc",
+                )
+            ],
+            bad_links,
+        )
+
+    def test_allows_non_release_download_links_in_archived_releases(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+* Docker image: [apache/kafka:4.2.0](https://hub.docker.com/layers/apache/kafka/4.2.0).
+* Blog post: [announcement](https://kafka.apache.org/blog/2026/02/17/apache-kafka-4.2.0-release-announcement/)
+* Upgrade Notes: [upgrade](https://kafka.apache.org/42/getting-started/upgrade/)
+"""
+        )
+
+        self.assertEqual([], bad_links)
+
+    def test_allows_active_download_links_in_supported_releases(self):
+        bad_links = self.check(
+            """\
+## Supported releases
+
+### 4.3.0
+
+* Source download: [kafka-4.3.0-src.tgz](https://www.apache.org/dyn/closer.lua/kafka/4.3.0/kafka-4.3.0-src.tgz?action=download)
+* Source signature: [asc](https://downloads.apache.org/kafka/4.3.0/kafka-4.3.0-src.tgz.asc)
+
+## Archived Releases
+
+### 4.2.0
+
+* Source download: [kafka-4.2.0-src.tgz](https://archive.apache.org/dist/kafka/4.2.0/kafka-4.2.0-src.tgz)
+"""
+        )
+
+        self.assertEqual([], bad_links)
+
+    def test_stops_at_next_h2_after_archived_releases(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+* Source download: [kafka-4.2.0-src.tgz](https://archive.apache.org/dist/kafka/4.2.0/kafka-4.2.0-src.tgz)
+
+## Other Links
+
+* Active download example: [src](https://downloads.apache.org/kafka/4.3.0/kafka-4.3.0-src.tgz.asc)
+"""
+        )
+
+        self.assertEqual([], bad_links)
+
+    def test_ignores_active_download_links_in_fenced_code_blocks(self):
+        bad_links = self.check(
+            """\
+## Archived Releases
+
+### 4.2.0
+
+```text
+https://downloads.apache.org/kafka/4.2.0/src.tgz
+```
+* Source: [src](https://archive.apache.org/dist/kafka/4.2.0/src.tgz)
+"""
+        )
+
+        self.assertEqual([], bad_links)
+
+    def test_accepts_indented_archived_header_with_hugo_id(self):
+        bad_links = self.check(
+            """\
+   ## Archived Releases {#archived-releases}
+
+   ### 4.2.0
+
+* Source: [src](https://archive.apache.org/dist/kafka/4.2.0/src.tgz)
+"""
+        )
+
+        self.assertEqual([], bad_links)
+
+    def test_rejects_missing_archived_releases_section(self):
+        with self.assertRaisesRegex(ValueError, "missing required"):
+            self.check("## Supported releases\n")
+
+    def test_main_reports_missing_section_without_traceback(self):
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as test_file:
+            test_file.write("## Supported releases\n")
+            path = Path(test_file.name)
+
+        stderr = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(stderr):
+                exit_code = main([str(path)])
+        finally:
+            path.unlink()
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("missing required '## Archived Releases' section", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+    def test_main_reports_missing_file_without_traceback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "missing-kafka-downloads.md"
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                exit_code = main([str(path)])
+
+        self.assertEqual(2, exit_code)
+        self.assertIn("unable to read file", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

When a release moves from `Supported releases` to `Archived Releases`, its Apache release artifact links must move from the active download infrastructure to `https://archive.apache.org/dist/kafka/...`. This is currently a manual step and is easy to miss.

## Approach

The new standard-library Python checker:

1. Reads only the `## Archived Releases` section of `content/en/community/downloads.md`.
2. Extracts URLs outside Markdown code fences.
3. Fails when a Kafka distribution link still points to an active Apache endpoint:
   - `downloads.apache.org/kafka/...`
   - `dlcdn.apache.org/kafka/...`
   - Apache `closer.lua` redirector
4. Leaves unrelated links alone, including Docker Hub, Kafka blog/documentation, `archive.apache.org`, and the ASF `KEYS` link.

The check is static and makes no network requests, avoiding flaky external-link validation.

## CI integration

- Pull requests into `markdown`: run the checker unit tests, then check the real downloads page.
- Deployment workflow: check only the real downloads page before building, so a direct push cannot deploy invalid archived links.
- Make targets provide the same commands locally.

Apache Jira: https://issues.apache.org/jira/browse/KAFKA-20737

## Validation

- `make check-archived-release-links-test` (15 tests)
- `make check-archived-release-links`
- `git diff --check origin/markdown...HEAD`
