### PR TITLE
MINOR: Fix broken "Create documentation issue" link

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -392,7 +392,7 @@ params:
   # images: [images/project-illustration.png]
 
   # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
-  github_repo: https://github.com/apache/kafka-site/
+  github_repo: https://github.com/apache/kafka-site
 
   # An optional link to a related project repo. For example, the sibling repository where your product code lives.
   # github_project_repo: https://github.com/google/docsy
@@ -443,9 +443,9 @@ params:
       enable: false
       # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
       'yes': >-
-        Glad to hear it! Please <a href="https://github.com/apache/kafka-site/issues/new">tell us how we can improve</a>.
+        Glad to hear it! Please <a href="https://issues.apache.org/jira/projects/KAFKA">tell us how we can improve</a>.
       'no': >-
-        Sorry to hear that. Please <a href="https://github.com/apache/kafka-site/issues/new">tell us how we can improve</a>.
+        Sorry to hear that. Please <a href="https://issues.apache.org/jira/projects/KAFKA">tell us how we can improve</a>.
 
     # Adds a reading time to the top of each doc.
     # If you want this feature, but occasionally need to remove the Reading time from a single page,

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -1,0 +1,64 @@
+{{/* cSpell:ignore querify subdir */ -}}
+{{/* Class names ending with `--KIND` are deprecated in favor of `__KIND`, but we're keeping them for a few releases after 0.9.0 */ -}}
+
+{{/*
+  Local override of the Docsy v0.11.0 partial of the same name. Identical to
+  upstream except for $issuesURL below.
+
+  Docsy builds "Create documentation issue" as {github_repo}/issues/new, but
+  GitHub Issues are disabled on apache/kafka-site, so that link 404s on every
+  page. Kafka tracks bugs in JIRA, so the link points there instead.
+
+  When upgrading Docsy, re-copy this partial from the new release and re-apply
+  the $issuesURL change.
+*/ -}}
+
+{{ if .File -}}
+{{ $path := strings.TrimPrefix (add hugo.WorkingDir "/") $.File.Filename -}}
+{{ $gh_repo := $.Param "github_repo" -}}
+{{ $gh_url := $.Param "github_url" -}}
+{{ $gh_subdir := $.Param "github_subdir" | default "" -}}
+{{ $gh_project_repo := $.Param "github_project_repo" -}}
+{{ $gh_branch := $.Param "github_branch" | default "main" -}}
+<div class="td-page-meta ms-2 pb-1 pt-2 mb-0">
+{{ if $gh_url -}}
+  {{ warnf "Warning: use of `github_url` is deprecated. For details, see https://www.docsy.dev/docs/adding-content/repository-links/#github_url-optional" -}}
+  <a href="{{ $gh_url }}" target="_blank"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
+{{ else if $gh_repo -}}
+
+  {{/* Adjust $path based on path_base_for_github_subdir */ -}}
+  {{ $ghs_base := $.Param "path_base_for_github_subdir" -}}
+  {{ $ghs_rename := "" -}}
+  {{ if reflect.IsMap $ghs_base -}}
+    {{ $ghs_rename = $ghs_base.to -}}
+    {{ $ghs_base = $ghs_base.from -}}
+  {{ end -}}
+  {{ with $ghs_base -}}
+    {{ $path = replaceRE . $ghs_rename $path -}}
+  {{ end -}}
+
+  {{ $gh_repo_path := printf "%s/%s/%s" $gh_branch $gh_subdir $path -}}
+  {{ $gh_repo_path = replaceRE "//+" "/" $gh_repo_path -}}
+
+  {{ $viewURL := printf "%s/tree/%s" $gh_repo $gh_repo_path -}}
+  {{ $editURL := printf "%s/edit/%s" $gh_repo $gh_repo_path -}}
+  {{ $issuesURL := "https://issues.apache.org/jira/projects/KAFKA" -}}
+  {{ $newPageStub := resources.Get "stubs/new-page-template.md" -}}
+  {{ $newPageQS := querify "value" $newPageStub.Content "filename" "change-me.md" | safeURL -}}
+  {{ $newPageURL := printf "%s/new/%s?%s" $gh_repo (path.Dir $gh_repo_path) $newPageQS -}}
+
+  <a href="{{ $viewURL }}" class="td-page-meta--view td-page-meta__view" target="_blank" rel="noopener"><i class="fa-solid fa-file-lines fa-fw"></i> {{ T "post_view_this" }}</a>
+  <a href="{{ $editURL }}" class="td-page-meta--edit td-page-meta__edit" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_edit_this" }}</a>
+  <a href="{{ $newPageURL }}" class="td-page-meta--child td-page-meta__child" target="_blank" rel="noopener"><i class="fa-solid fa-pen-to-square fa-fw"></i> {{ T "post_create_child_page" }}</a>
+  <a href="{{ $issuesURL }}" class="td-page-meta--issue td-page-meta__issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_issue" }}</a>
+  {{ with $gh_project_repo -}}
+    {{ $project_issueURL := printf "%s/issues/new" . -}}
+    <a href="{{ $project_issueURL }}" class="td-page-meta--project td-page-meta__project-issue" target="_blank" rel="noopener"><i class="fa-solid fa-list-check fa-fw"></i> {{ T "post_create_project_issue" }}</a>
+  {{ end -}}
+
+{{ end -}}
+{{ with .CurrentSection.AlternativeOutputFormats.Get "print" -}}
+  <a id="print" href="{{ .RelPermalink | safeURL }}"><i class="fa-solid fa-print fa-fw"></i> {{ T "print_entire_section" }}</a>
+{{ end }}
+</div>
+{{ end -}}


### PR DESCRIPTION
The **Create documentation issue** link in the page footer is broken on every
docs page. A reader trying to report a docs bug hit this and had no way to file.

## The problem

Docsy builds that link as `{github_repo}/issues/new`, but GitHub Issues are
disabled on `apache/kafka-site`, so the URL 404s:

```
https://github.com/apache/kafka-site//issues/new?title=Introduction   -> 404
https://github.com/apache/kafka-site/issues/new?title=Introduction    -> 404
```

Both spellings 404 — the doubled slash (from a trailing `/` in `github_repo`)
is a separate cosmetic defect, not the cause. The link cannot work while Issues
are disabled, so it has never worked.

## The fix

Kafka tracks bugs in JIRA, so the link now points at the KAFKA project.

Docsy v0.11.0's `page-meta-links.html` offers no configuration option to
override just that one URL, so the partial is vendored into `layouts/partials/`
with a single line changed:

```diff
- {{ $issuesURL := printf "%s/issues/new?title=%s" $gh_repo (safeURL $.Title ) -}}
+ {{ $issuesURL := "https://issues.apache.org/jira/projects/KAFKA" -}}
```

A comment at the top of the file records why the override exists and what to
re-apply on a Docsy upgrade. Apart from that comment and the one line, the file
is byte-identical to upstream Docsy v0.11.0.

Two smaller changes in `hugo.yaml`:

- Drop the trailing slash from `params.github_repo`, which was producing a
  doubled slash in every generated link. GitHub tolerates it on `/tree/` and
  `/edit/`, so those links did work; this just makes the URLs canonical.
- Point the two `ui.feedback` responses at JIRA too — they carried the same dead
  `/issues/new` URL. These sit behind `ui.feedback.enable: false`, so they are
  not currently user-visible.

## Alternatives considered

- **Enable Issues on the repo** via `.asf.yaml`. Smallest change that would make
  the existing button work, but it opens a bug-intake channel the project has
  not opted into, alongside JIRA. Happy to switch to this if maintainers prefer.
- **Delete the button.** Removes the dead link without offering a destination.
  Pointing at JIRA seemed more useful to readers, but this is easy to change.

## Verification

Built locally with the Hugo version CI uses (`v0.123.7-extended`, per
`.github/workflows/build-and-deploy.yml`):

- Build succeeds: 3792 pages, 25649 static files.
- Rendered output: **0** pages containing the old `issues/new` URL, **2157**
  containing the JIRA URL.
- Sample rendered anchor:

  ```html
  <a href="https://issues.apache.org/jira/projects/KAFKA" class="td-page-meta--issue td-page-meta__issue" target="_blank" rel="noopener">
  ```

Note for anyone reproducing: the repo does not build with Hugo 0.164+ (the
version currently pinned in `package.json` as `hugo-extended`). It fails with
`no such template "_default/_markup/td-render-heading.html"` — docsy v0.11.0
against Hugo's newer render-hook rules. That failure is present on an unmodified
checkout of `markdown` too, so it is unrelated to this change, but the
`package.json` pin looks out of step with the CI image.
